### PR TITLE
TaskManager: rename _STATE_NAMES -> STATE_NAMES

### DIFF
--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -87,12 +87,12 @@ class DecisionEngine(SocketServer.ThreadingMixIn,
         else:
             return self.config_manager.get_channels()[channel]
 
-    def rpc_print_product(self, product): 
+    def rpc_print_product(self, product):
         found = False
         txt = "Product {}: ".format(product)
         for ch, worker in self.task_managers.items():
             channel_config = self.config_manager.get_channels()[ch]
-            produces = self.config_manager.get_produces(channel_config) 
+            produces = self.config_manager.get_produces(channel_config)
             r = filter(lambda x: product in x[1], produces.items())
             if not r:
                 continue
@@ -121,7 +121,7 @@ class DecisionEngine(SocketServer.ThreadingMixIn,
         width = max(map(lambda x: len(x), self.task_managers.keys())) + 1
         txt = ""
         for ch, worker in self.task_managers.items():
-            sname = TaskManager._state_names[worker.task_manager.get_state()]
+            sname = TaskManager.STATE_NAMES[worker.task_manager.get_state()]
             txt += "channel: {:<{width}}, id = {:<{width}}, state = {:<10} \n".format(ch,
                                                                                       worker.task_manager.id,
                                                                                       sname,
@@ -139,7 +139,7 @@ class DecisionEngine(SocketServer.ThreadingMixIn,
                       "logicengines",
                       "publishers"):
                 txt += "\t{}:\n".format(i)
-                modules = channel_config.get(i, {}) 
+                modules = channel_config.get(i, {})
                 for mod_name, mod_config in modules.iteritems():
                     txt += "\t\t{}\n".format(mod_name)
                     products = produces.get(mod_name,[])
@@ -157,7 +157,7 @@ class DecisionEngine(SocketServer.ThreadingMixIn,
         width = max(map(lambda x: len(x), self.task_managers.keys())) + 1
         txt=""
         for ch, worker in self.task_managers.items():
-            sname = TaskManager._state_names[worker.task_manager.get_state()]
+            sname = TaskManager.STATE_NAMES[worker.task_manager.get_state()]
             txt += "channel: {:<{width}}, id = {:<{width}}, state = {:<10} \n".format(ch,
                                                                                       worker.task_manager.id,
                                                                                       sname,
@@ -168,12 +168,12 @@ class DecisionEngine(SocketServer.ThreadingMixIn,
                       "logicengines",
                       "publishers"):
                 txt += "\t{}:\n".format(i)
-                modules = channel_config.get(i, {}) 
+                modules = channel_config.get(i, {})
                 for mod_name, mod_config in modules.iteritems():
                     txt += "\t\t{}\n".format(mod_name)
                     my_module = importlib.import_module(mod_config.get('module'))
-                    produces = None 
-                    consumes = None 
+                    produces = None
+                    consumes = None
                     try:
                         produces = getattr(my_module, 'PRODUCES')
                     except:

--- a/framework/taskmanager/TaskManager.py
+++ b/framework/taskmanager/TaskManager.py
@@ -79,7 +79,7 @@ class Channel(object):
 # states
 
 BOOT, STEADY, OFFLINE, SHUTTINGDOWN, SHUTDOWN = range(5)
-_STATE_NAMES = ['BOOT', 'STEADY', 'OFFLINE', 'SHUTTINGDOWN', 'SHUTDOWN']
+STATE_NAMES = ['BOOT', 'STEADY', 'OFFLINE', 'SHUTTINGDOWN', 'SHUTDOWN']
 
 class TaskManager(object):
     """
@@ -185,7 +185,7 @@ class TaskManager(object):
                 break
 
             time.sleep(1)
-        self.logger.error('Error occured. Task Manager %s exits with state %s'%(self.id, _STATE_NAMES[self.get_state()]))
+        self.logger.error('Error occured. Task Manager %s exits with state %s'%(self.id, STATE_NAMES[self.get_state()]))
 
 
     def set_state(self, state):
@@ -496,7 +496,7 @@ if __name__ == '__main__':
             if len(multiprocessing.active_children()) < 1:
                 break
             for tm_name, tm in task_managers.iteritems():
-                print 'TM %s state %s'%(tm_name, _STATE_NAMES[tm.get_state()])
+                print 'TM %s state %s'%(tm_name, STATE_NAMES[tm.get_state()])
             time.sleep(10)
     except (SystemExit, KeyboardInterrupt):
         pass


### PR DESCRIPTION
pull request :

https://github.com/HEPCloud/decisionengine/pull/14

changed _state_names -> _STATE_NAMES breaking DecisionEngine.py
This patch renames {_state_names, _STATE_NAMES} -> STATE_NAMES
everywhere where it is used .

Addresses Issue:

 https://github.com/HEPCloud/decisionengine/issues/20