### PR TITLE
decisionengine: allow to execute panda data frame queries

### DIFF
--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -12,9 +12,9 @@ import signal
 import sys
 import multiprocessing
 import pandas as pd
-import uuid
 import tabulate
 import time
+import uuid
 
 import SocketServer
 import SimpleXMLRPCServer
@@ -87,7 +87,7 @@ class DecisionEngine(SocketServer.ThreadingMixIn,
         else:
             return self.config_manager.get_channels()[channel]
 
-    def rpc_print_product(self, product):
+    def rpc_print_product(self, product, query=None):
         found = False
         txt = "Product {}: ".format(product)
         for ch, worker in self.task_managers.items():
@@ -107,9 +107,14 @@ class DecisionEngine(SocketServer.ThreadingMixIn,
                 data_block.generation_id -= 1
                 df = data_block[product]
                 df = pd.read_json(df.to_json())
-                txt += "{}\n".format(tabulate.tabulate(df,
-                                                       headers='keys',
-                                                       tablefmt='psql'))
+                if query : 
+                    txt += "{}\n".format(tabulate.tabulate(df.query(query),
+                                                           headers='keys',
+                                                           tablefmt='psql'))
+                else: 
+                    txt += "{}\n".format(tabulate.tabulate(df,
+                                                           headers='keys',
+                                                           tablefmt='psql'))
             except Exception as e:
                 txt += "\t\t{}\n".format(str(e))
                 pass

--- a/framework/engine/de_client.py
+++ b/framework/engine/de_client.py
@@ -66,6 +66,11 @@ if __name__ == "__main__":
         action='store_true',
         help="print products")
 
+    parser.add_argument(
+        "--query",
+        help="panda query, e.g. \" FigureOfMerit != inf \"")
+
+
     args = parser.parse_args()
 
     con_string = "http://{}:{}".format(args.host,args.port)
@@ -97,7 +102,11 @@ if __name__ == "__main__":
         print s.print_products()
 
     if args.print_product:
-        print s.print_product(args.print_product)
-
+        if args.query:
+            print s.print_product(args.print_product,
+                                  args.query)
+        else:
+            print s.print_product(args.print_product)
+            
     if args.stop:
         s.stop()


### PR DESCRIPTION
Addresses issue: 

https://github.com/HEPCloud/decisionengine/issues/12

Adds ability to execute panda query. Like so: 

```
de-client --print-product GCE_Figure_Of_Merit  --query " FigureOfMerit != inf "
Product GCE_Figure_Of_Merit:  Found in channel Gce
+----+----------------------------------------------------+-----------------+
|    | EntryName                                          |   FigureOfMerit |
|----+----------------------------------------------------+-----------------|
|  0 | FNAL_HEPCLOUD_GOOGLE_us-central1-a_n1-standard-1   |    29968.5      |
| 14 | FNAL_HEPCLOUD_GOOGLE_us-central1-a_custom-16-32768 |        0.45004  |
| 16 | FNAL_HEPCLOUD_GOOGLE_us-central1-a_n1-standard-1   |        0.201271 |
| 22 | FNAL_HEPCLOUD_GOOGLE_us-central1-a_custom-16-32768 |        0.362476 |
|  6 | FNAL_HEPCLOUD_GOOGLE_us-central1-a_custom-16-32768 |        0.540048 |
|  8 | FNAL_HEPCLOUD_GOOGLE_us-central1-a_n1-standard-1   |        0.25     |
+----+----------------------------------------------------+-----------------+
```