### PR TITLE
add ability to select columns

### DIFF
--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -87,7 +87,7 @@ class DecisionEngine(SocketServer.ThreadingMixIn,
         else:
             return self.config_manager.get_channels()[channel]
 
-    def rpc_print_product(self, product, query=None):
+    def rpc_print_product(self, product, columns=None, query=None):
         found = False
         txt = "Product {}: ".format(product)
         for ch, worker in self.task_managers.items():
@@ -107,14 +107,28 @@ class DecisionEngine(SocketServer.ThreadingMixIn,
                 data_block.generation_id -= 1
                 df = data_block[product]
                 df = pd.read_json(df.to_json())
-                if query : 
-                    txt += "{}\n".format(tabulate.tabulate(df.query(query),
-                                                           headers='keys',
-                                                           tablefmt='psql'))
-                else: 
-                    txt += "{}\n".format(tabulate.tabulate(df,
-                                                           headers='keys',
-                                                           tablefmt='psql'))
+                column_names = []
+                if columns:
+                    column_names = columns.split(",")
+                if query:
+                    if column_names:
+                        txt += "{}\n".format(tabulate.tabulate(df.loc[:, column_names].query(query),
+                                                               headers='keys',
+                                                               tablefmt='psql'))
+                    else:
+                        txt += "{}\n".format(tabulate.tabulate(df.query(query),
+                                                               headers='keys',
+                                                               tablefmt='psql'))
+
+                else:
+                    if column_names:
+                        txt += "{}\n".format(tabulate.tabulate(df.loc[:, column_names],
+                                                               headers='keys',
+                                                               tablefmt='psql'))
+                    else:
+                        txt += "{}\n".format(tabulate.tabulate(df,
+                                                               headers='keys',
+                                                               tablefmt='psql'))
             except Exception as e:
                 txt += "\t\t{}\n".format(str(e))
                 pass

--- a/framework/engine/de_client.py
+++ b/framework/engine/de_client.py
@@ -70,11 +70,14 @@ if __name__ == "__main__":
         "--query",
         help="panda query, e.g. \" FigureOfMerit != inf \"")
 
+    parser.add_argument(
+        "--columns",
+        help="comma separated list of columns")
 
     args = parser.parse_args()
 
-    con_string = "http://{}:{}".format(args.host,args.port)
-    s = xmlrpclib.ServerProxy(con_string)
+    con_string = "http://{}:{}".format(args.host, args.port)
+    s = xmlrpclib.ServerProxy(con_string, allow_none=True)
 
     if args.status:
         print s.status()
@@ -102,11 +105,9 @@ if __name__ == "__main__":
         print s.print_products()
 
     if args.print_product:
-        if args.query:
-            print s.print_product(args.print_product,
-                                  args.query)
-        else:
-            print s.print_product(args.print_product)
-            
+        print s.print_product(args.print_product,
+                              args.columns,
+                              args.query)
+
     if args.stop:
         s.stop()


### PR DESCRIPTION
Per Steve's request - add ability to select on column names 

like so:

```
[root@fermicloud371 ~]# de-client --print-product Factory_Entries_LCF  --columns "EntryName,GlideinMonitorTotalStatusWait"Product Factory_Entries_LCF:  Found in channel Nersc
+----+-----------------------------------+---------------------------------+
|    | EntryName                         |   GlideinMonitorTotalStatusWait |
|----+-----------------------------------+---------------------------------|
|  0 | CMSHTPC_T3_US_NERSC_Cori_shared   |                             nan |
|  1 | FIFE_T3_US_NERSC_Cori_shared      |                             nan |
| 10 | CMSHTPC_T3_US_NERSC_Cori          |                               0 |
| 11 | FIFE_T3_US_NERSC_Cori             |                             nan |
| 18 | CMSHTPC_T3_US_NERSC_Edison_shared |                             nan |
| 19 | FIFE_T3_US_NERSC_Edison_shared    |                             nan |
|  2 | FIFE_T3_US_NERSC_Cori_KNL         |                             nan |
|  3 | CMSHTPC_T3_US_NERSC_Cori_KNL      |                               0 |
|  8 | CMSHTPC_T3_US_NERSC_Edison        |                             nan |
|  9 | FIFE_T3_US_NERSC_Edison           |                             nan |
+----+-----------------------------------+---------------------------------+
 Found in channel Gce
+----+-----------------------------------+---------------------------------+
|    | EntryName                         |   GlideinMonitorTotalStatusWait |
|----+-----------------------------------+---------------------------------|
|  0 | CMSHTPC_T3_US_NERSC_Cori_shared   |                             nan |
|  1 | FIFE_T3_US_NERSC_Cori_shared      |                             nan |
| 10 | CMSHTPC_T3_US_NERSC_Cori          |                               0 |
| 11 | FIFE_T3_US_NERSC_Cori             |                             nan |
| 18 | CMSHTPC_T3_US_NERSC_Edison_shared |                             nan |
| 19 | FIFE_T3_US_NERSC_Edison_shared    |                             nan |
|  2 | FIFE_T3_US_NERSC_Cori_KNL         |                             nan |
|  3 | CMSHTPC_T3_US_NERSC_Cori_KNL      |                               0 |
|  8 | CMSHTPC_T3_US_NERSC_Edison        |                             nan |
|  9 | FIFE_T3_US_NERSC_Edison           |                             nan |
+----+-----------------------------------+---------------------------------+
[root@fermicloud371 ~]# 
```