### PR TITLE
Add safe (for python 2.7) python3 compatible syntax

### DIFF
--- a/framework/configmanager/ConfigManager.py
+++ b/framework/configmanager/ConfigManager.py
@@ -62,7 +62,7 @@ class ConfigManager(object):
         """
         sources = channel.get('sources')
         all_produces = set()
-        for sname, conf in sources.iteritems():
+        for sname, conf in sources.items():
             my_module = importlib.import_module(conf.get('module'))
             try:
                 produces = getattr(my_module, 'PRODUCES')
@@ -79,7 +79,7 @@ class ConfigManager(object):
         transforms = channel.get('transforms')
         transform_map = {}
 
-        for tname, conf in transforms.iteritems():
+        for tname, conf in transforms.items():
             my_module = importlib.import_module(conf.get('module'))
             try:
                 consumes = set(getattr(my_module, 'CONSUMES'))
@@ -105,12 +105,12 @@ class ConfigManager(object):
 
         graph = {}
         for i in range(len(transform_map)):
-            k1 = transform_map.keys()[i]
+            k1 = list(transform_map.keys())[i]
             c1 = set(transform_map[k1].get('consumes', []))
             p1 = set(transform_map[k1].get('produces', []))
             added = False
             for j in range(i + 1, len(transform_map)):
-                k2 = transform_map.keys()[j]
+                k2 = list(transform_map.keys())[j]
                 c2 = set(transform_map[k2].get('consumes', []))
                 p2 = set(transform_map[k2].get('produces', []))
                 if c2 & p1:
@@ -136,7 +136,7 @@ class ConfigManager(object):
         produces = {}
         for i in ('sources', 'transforms'):
             modules = channel_config.get(i, {})
-            for name, conf in modules.iteritems(): 
+            for name, conf in modules.items():
                 my_module = importlib.import_module(conf.get('module'))
                 try:
                     produces.setdefault(name, []).extend(getattr(my_module, 'PRODUCES'))

--- a/framework/dataspace/datablock.py
+++ b/framework/dataspace/datablock.py
@@ -2,7 +2,10 @@
 
 import ast
 import copy
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import threading
 import time
 import uuid
@@ -28,7 +31,7 @@ STATE_EXPIRED = 'EXPIRED'
 
 def zdumps(obj):
     """
-    Pickle and compress     
+    Pickle and compress
     :param obj: a python object
     :return: compressed string
     """
@@ -39,12 +42,12 @@ def zdumps(obj):
 
 def zloads(zstring):
     """
-    Decompress and unpickle 
-    If input string is not a compressed string 
+    Decompress and unpickle
+    If input string is not a compressed string
     attempts to just unpickle the string.
-    
-    :param zstring: compressed string  
-    :return: returns python object  
+
+    :param zstring: compressed string
+    :return: returns python object
     """
     try:
         return pickle.loads(zlib.decompress(zstring))
@@ -54,19 +57,19 @@ def zloads(zstring):
 
 def compress(obj):
     """
-    Compress python object 
-    :param obj: python object 
-    :return: compressed string 
+    Compress python object
+    :param obj: python object
+    :return: compressed string
     """
     return zlib.compress(str(obj), 9)
 
 
 def decompress(zstring):
     """
-    Decompress a compressed string. 
+    Decompress a compressed string.
     Returns the same string if it is not compressed.
-    :param zstring: 
-    :return: uncompressed string 
+    :param zstring:
+    :return: uncompressed string
     """
     try:
         return zlib.decompress(zstring)

--- a/framework/dataspace/datasources/object.py
+++ b/framework/dataspace/datasources/object.py
@@ -95,7 +95,7 @@ class ObjectDB(decisionengine.framework.dataspace.datasource.DataSource):
                 metadata['missed_update_count'])
 
     def get_datablock(self, taskmanager_id, generation_id):
-        return {k: v for (k, v) in ObjectDB._tables['dataproduct'].items() if (k[0]==taskmanager_id and k[1]==generation_id)}
+        return {k: v for (k, v) in list(ObjectDB._tables['dataproduct'].items()) if (k[0]==taskmanager_id and k[1]==generation_id)}
 
     def duplicate_datablock(self, taskmanager_id, generation_id,
                             new_generation_id):

--- a/framework/dataspace/datasources/postgresql.py
+++ b/framework/dataspace/datasources/postgresql.py
@@ -326,11 +326,11 @@ class Postgresql(ds.DataSource):
             colnames = [desc[0] for desc in cursor.description]
             res = cursor.fetchall()
             return colnames, res
-        except psycopg2.Error, msg:
+        except psycopg2.Error as msg:
             raise
         finally:
             try:
-                map(lambda x: x.close if x else None, (cursor, db))
+                list([x.close if x else None for x in (cursor, db)])
             except:
                 pass
 
@@ -344,7 +344,7 @@ class Postgresql(ds.DataSource):
             else:
                 cursor.execute(query_string)
             db.commit()
-        except psycopg2.Error, msg:
+        except psycopg2.Error as msg:
             try:
                 if db:
                     db.rollback()
@@ -356,7 +356,7 @@ class Postgresql(ds.DataSource):
                 db.rollback()
             raise
         finally:
-            map(lambda x: x.close if x else None, (cursor, db))
+            list([x.close if x else None for x in (cursor, db)])
 
     def _update_returning_result(self, query_string, values=None):
         db, cursor = None, None
@@ -371,7 +371,7 @@ class Postgresql(ds.DataSource):
             res = cursor.fetchone()
             db.commit()
             return res
-        except psycopg2.Error, msg:
+        except psycopg2.Error as msg:
             try:
                 if db:
                     db.rollback()
@@ -383,13 +383,13 @@ class Postgresql(ds.DataSource):
                 db.rollback()
             raise
         finally:
-            map(lambda x: x.close if x else None, (cursor, db))
+            list([x.close if x else None for x in (cursor, db)])
 
     def _insert(self, table_name_or_sql_query, record=None):
         if record:
             if isinstance(record, dict):
-                q = generate_insert_query(table_name_or_sql_query, record.keys())
-                return self._update(q, record.values())
+                q = generate_insert_query(table_name_or_sql_query, list(record.keys()))
+                return self._update(q, list(record.values()))
             else:
                 return self._update(table_name_or_sql_query, record)
         else:
@@ -398,8 +398,8 @@ class Postgresql(ds.DataSource):
     def _insert_returning_result(self, table_name_or_sql_query, record=None):
         if record:
             if isinstance(record, dict):
-                q = generate_insert_query(table_name_or_sql_query, record.keys())
-                return self._update_returning_result(q, record.values())
+                q = generate_insert_query(table_name_or_sql_query, list(record.keys()))
+                return self._update_returning_result(q, list(record.values()))
             else:
                 return self._update_returning_result(table_name_or_sql_query, record)
         else:

--- a/framework/dataspace/datasources/sqlite3.py
+++ b/framework/dataspace/datasources/sqlite3.py
@@ -122,7 +122,7 @@ class SQLite3DB(decisionengine.framework.dataspace.datasource.DataSource):
 
 
     def connect(self):
-        print self.db_filename
+        print(self.db_filename)
         self.conn = sqlite3.connect(self.db_filename)
 
 
@@ -134,7 +134,7 @@ class SQLite3DB(decisionengine.framework.dataspace.datasource.DataSource):
         """
 
         try:
-            for table, cols in SQLite3DB.tables.iteritems():
+            for table, cols in SQLite3DB.tables.items():
                 if isinstance(cols, list):
                     cmd = """CREATE TABLE %s (%s)""" % (table, ', '.join(str(c) for c in cols))
                     cursor = self.conn.cursor()
@@ -173,7 +173,7 @@ class SQLite3DB(decisionengine.framework.dataspace.datasource.DataSource):
                 key, value)
             cursor = self.conn.cursor()
             cursor.execute(cmd)
-  
+
             # Insert header in the header table
             cmd = """INSERT INTO %s VALUES ("%s", %i, "%s", %f, %f, %f, "%s", "%s")""" % (
                 SQLite3DB.header_table, taskmanager_id, generation_id,
@@ -311,7 +311,7 @@ class SQLite3DB(decisionengine.framework.dataspace.datasource.DataSource):
     def duplicate_datablock(self, taskmanager_id, generation_id,
                             new_generation_id):
         """
-        For the given taskmanager_id, make a copy of the datablock with given 
+        For the given taskmanager_id, make a copy of the datablock with given
         generation_id, set the generation_id for the datablock copy
 
         :type taskmanager_id: :obj:`string`
@@ -363,7 +363,7 @@ class SQLite3DB(decisionengine.framework.dataspace.datasource.DataSource):
 
         :type taskmanager_id: :obj:`string`
         :arg taskmanager_id: taskmanager_id for generation to be retrieved
-        
+
         :rtype: :obj:`int`
 
         TODO: COALESCE is not safe. Find a better way check with DB experts
@@ -374,7 +374,7 @@ class SQLite3DB(decisionengine.framework.dataspace.datasource.DataSource):
 
             cursor = self.conn.cursor()
             cursor.execute(cmd)
-            value = cursor.fetchall()   
+            value = cursor.fetchall()
         except:
             raise
         return value[0][0]
@@ -388,7 +388,7 @@ class SQLite3DB(decisionengine.framework.dataspace.datasource.DataSource):
             cols = ['*']
         try:
             template = (taskmanager_id, generation_id, key)
-            
+
             #print cmd
             cmd = """SELECT %s FROM %s WHERE ((taskmanager_id=?) AND (generation_id=?) AND (key=?))""" % (', '.join(str(c) for c in cols), table)
             params = (taskmanager_id, generation_id, key)

--- a/framework/engine/de_client.py
+++ b/framework/engine/de_client.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
 import argparse
-import xmlrpclib
+try:
+    import xmlrpclib
+except ImportError:
+    import xmlrpc.client as xmlrpclib
 import pprint
 
 if __name__ == "__main__":
@@ -80,34 +83,34 @@ if __name__ == "__main__":
     s = xmlrpclib.ServerProxy(con_string, allow_none=True)
 
     if args.status:
-        print s.status()
+        print(s.status())
 
     if args.stop_channel:
-        print s.stop_channel(args.stop_channel)
+        print(s.stop_channel(args.stop_channel))
 
     if args.start_channel:
-        print s.start_channel(args.start_channel)
+        print(s.start_channel(args.start_channel))
 
     if args.stop_channels:
-        print s.stop_channels()
+        print(s.stop_channels())
 
     if args.start_channels:
-        print s.start_channels()
+        print(s.start_channels())
 
     if args.show_config:
         conf = s.show_config()
         pprint.pprint(conf)
 
     if args.reload_config:
-        print s.reload_config()
+        print(s.reload_config())
 
     if args.print_products:
-        print s.print_products()
+        print(s.print_products())
 
     if args.print_product:
-        print s.print_product(args.print_product,
+        print(s.print_product(args.print_product,
                               args.columns,
-                              args.query)
+                              args.query))
 
     if args.stop:
         s.stop()

--- a/framework/logicengine/LogicEngine.py
+++ b/framework/logicengine/LogicEngine.py
@@ -15,7 +15,7 @@ class LogicEngine(Module, object):
     def __init__(self, cfg):
         super(LogicEngine, self).__init__(cfg)
         self.logger = logging.getLogger()
-        self.facts = [NamedFact(name, expr) for name, expr in cfg["facts"].iteritems()]
+        self.facts = [NamedFact(name, expr) for name, expr in cfg["facts"].items()]
 
         # Only the names of facts are really needed. We pass in the
         # JSON form of the whole facts dictionary until the C++ is

--- a/framework/logicengine/NamedFact.py
+++ b/framework/logicengine/NamedFact.py
@@ -27,7 +27,7 @@ class LogicError(TypeError):
 
 
 def function_name_from_call(callnode):
-    print "In name_from_call: ", callnode
+    print("In name_from_call: ", callnode)
     if (not isinstance(callnode, ast.Call)):
         raise LogicError("not a call node")
     if (isinstance(callnode.func, ast.Name)):

--- a/framework/logicengine/tests/astpp.py
+++ b/framework/logicengine/tests/astpp.py
@@ -43,7 +43,7 @@ def dump(node, annotate_fields=True, include_attributes=False, indent='  '):
                 lines[-1] += ']'
             return '\n'.join(lines)
         return repr(node)
-    
+
     if not isinstance(node, AST):
         raise TypeError('expected AST, got %r' % node.__class__.__name__)
     return _format(node)
@@ -59,24 +59,24 @@ pdp = parseprint
 def load_ipython_extension(ip):
     from IPython.core.magic import Magics, magics_class, cell_magic
     from IPython.core import magic_arguments
-    
+
     @magics_class
     class AstMagics(Magics):
-        
+
         @magic_arguments.magic_arguments()
         @magic_arguments.argument(
             '-m', '--mode', default='exec',
             help="The mode in which to parse the code. Can be exec (the default), "
                  "eval or single."
-        )    
+        )
         @cell_magic
         def dump_ast(self, line, cell):
             """Parse the code in the cell, and pretty-print the AST."""
             args = magic_arguments.parse_argstring(self.dump_ast, line)
             parseprint(cell, mode=args.mode)
-    
+
     ip.register_magics(AstMagics)
-    
+
 if __name__ == '__main__':
     for filename in sys.argv[1:]:
         print('=' * 50)
@@ -84,6 +84,6 @@ if __name__ == '__main__':
         print('=' * 50)
         with tokenize.open(filename) as f:
             fstr = f.read()
-        
+
         parseprint(fstr, filename=filename, include_attributes=True)
-        print()
+        print('')

--- a/framework/modules/LogicEngine.py
+++ b/framework/modules/LogicEngine.py
@@ -5,5 +5,5 @@ class LogicEngine(Module.Module):
         super(LogicEngine, self).__init__(set_of_parameters)
 
     def evaluate(self, data_block):
-        print "Called LogicEngine.evaluate"
+        print("Called LogicEngine.evaluate")
         return True

--- a/framework/modules/Publisher.py
+++ b/framework/modules/Publisher.py
@@ -6,7 +6,7 @@ class Publisher(Module.Module):
         super(Publisher, self).__init__(set_of_parameters)
 
     def consumes(self, name_list):
-        print "Called Publisher.consumes"
+        print("Called Publisher.consumes")
 
     def publish(self, data_block=None):
-        print "Called Publisher.publish"
+        print("Called Publisher.publish")

--- a/framework/modules/Source.py
+++ b/framework/modules/Source.py
@@ -8,12 +8,12 @@ class Source(Module.Module):
     # name_schema_id_list: a list of dictionaries containing
     # the data product name and a pointer to a schema
     def produces(self, name_schema_id_list):
-        print "Called Source.produces"
+        print("Called Source.produces")
         return None
 
     # acquire: The action function for a source. Will
     # retrieve data from external sources and issue a
     # DataBlock "put" transaction.
     def acquire(self):
-        print "Called Source.acquires"
+        print("Called Source.acquires")
         return None

--- a/framework/modules/SourceProxy.py
+++ b/framework/modules/SourceProxy.py
@@ -138,7 +138,7 @@ class SourceProxy(Source.Source):
                 else:
                     retry_cnt += 1
                     time.sleep(self.retry_to)
-            except Exception, detail:
+            except Exception as detail:
                 self.logger.error('Error getting datablock for %s %s'%(self.source_channel, detail))
 
         if not data_block:
@@ -191,14 +191,14 @@ def module_config_template():
         }
     }
 
-    print "Entry in channel cofiguration"
+    print("Entry in channel cofiguration")
     pprint.pprint(d)
 
 def module_config_info():
     """
     print this module configuration information
     """
-    print "produces: available dynamically based on configuration"
+    print("produces: available dynamically based on configuration")
     module_config_template()
 
 

--- a/framework/modules/Transform.py
+++ b/framework/modules/Transform.py
@@ -9,8 +9,8 @@ class Transform(Module.Module):
     name_list: A list of the data product names that
     the Transform will consume
     """
-    def consumes(self,name_list):
-        print "Called Transform.consumes"
+    def consumes(self, name_list):
+        print("Called Transform.consumes")
         self.name_list = name_list
 
     """
@@ -18,7 +18,7 @@ class Transform(Module.Module):
     the data product name and a pointer to a schema
     """
     def produces(self, name_schema_id_list):
-        print "Called Transform.produces"
+        print("Called Transform.produces")
         return None
 
     """
@@ -30,5 +30,5 @@ class Transform(Module.Module):
     products promised in the produces list
     """
     def transform(self):
-        print "Called Transform.transform"
+        print("Called Transform.transform")
         return True

--- a/framework/taskmanager/TaskManager.py
+++ b/framework/taskmanager/TaskManager.py
@@ -74,7 +74,7 @@ class Channel(object):
 
 # states
 
-BOOT, STEADY, OFFLINE, SHUTTINGDOWN, SHUTDOWN = range(5)
+BOOT, STEADY, OFFLINE, SHUTTINGDOWN, SHUTDOWN = list(range(5))
 STATE_NAMES = ['BOOT', 'STEADY', 'OFFLINE', 'SHUTTINGDOWN', 'SHUTDOWN']
 
 class TaskManager(object):
@@ -273,7 +273,7 @@ class TaskManager(object):
         :arg src: source Worker
         """
 
-        while 1:
+        while True:
             try:
                 logging.getLogger().info('Src %s calling acquire'%(src.name,))
                 data = src.worker.acquire()
@@ -372,9 +372,9 @@ class TaskManager(object):
         data_to = self.channel.task_manager.get('data_TO', TRANSFORMS_TO)
         consume_keys = transform.worker.consumes()
 
-        logging.getLogger().info('transform: %s expected keys: %s provided keys: %s'%(transform.name, consume_keys, data_block.keys()))
+        logging.getLogger().info('transform: %s expected keys: %s provided keys: %s'%(transform.name, consume_keys, list(data_block.keys())))
         loop_counter = 0
-        while 1:
+        while True:
             # Check if data is ready
             if set(consume_keys) <= set(data_block.keys()):
                 # data is ready -  may run transform()
@@ -462,15 +462,15 @@ if __name__ == '__main__':
     config_manager = configmanager.ConfigManager()
     config_manager.load()
     global_config = config_manager.get_global_config()
-    print 'GLOBAL CONF', global_config
+    print('GLOBAL CONF', global_config)
 
 
     try:
         de_logger.set_logging(log_file_name=global_config['logger']['log_file'],
                               max_file_size=global_config['logger']['max_file_size'],
                               max_backup_count=global_config['logger']['max_backup_count'])
-    except Exception, e:
-        print e
+    except Exception as e:
+        print(e)
         sys.exit(1)
 
     my_logger = logging.getLogger('decision_engine')
@@ -499,7 +499,7 @@ if __name__ == '__main__':
     for ch in channels:
         task_managers[ch] = TaskManager(ch, taskmanager_id, generation_id, channels[ch], global_config)
 
-    for key, value in task_managers.iteritems():
+    for key, value in task_managers.items():
         p = multiprocessing.Process(target=value.run, args=(), name='Process-%s'%(key,), kwargs={})
         p.start()
 
@@ -507,8 +507,8 @@ if __name__ == '__main__':
         while True:
             if len(multiprocessing.active_children()) < 1:
                 break
-            for tm_name, tm in task_managers.iteritems():
-                print 'TM %s state %s'%(tm_name, STATE_NAMES[tm.get_state()])
+            for tm_name, tm in task_managers.items():
+                print('TM %s state %s'%(tm_name, STATE_NAMES[tm.get_state()]))
             time.sleep(10)
     except (SystemExit, KeyboardInterrupt):
         pass

--- a/framework/tests/dataspace/test_datablock.py
+++ b/framework/tests/dataspace/test_datablock.py
@@ -33,8 +33,8 @@ config = config_object_db
 
 def are_dicts_same(x, y):
 
-    xitems = x.items()
-    yitems = y.items()
+    xitems = list(x.items())
+    yitems = list(y.items())
     shared_items = set(xitems) & set(yitems)
 
     return len(xitems) == len(yitems) and len(shared_items) == len(xitems)
@@ -42,7 +42,7 @@ def are_dicts_same(x, y):
 class TestDataBlock:
 
     def test_datablock(self):
-        print "Hello test_datablock"
+        print("Hello test_datablock")
         if config['dataspace']['db_driver']['name'] == 'SQLite3DB':
             filename = config['dataspace']['db_driver']['config']['filename']
             if os.path.exists(filename):
@@ -63,28 +63,28 @@ class TestDataBlock:
                         schema_id=0)
         metadata = Metadata(taskmanager_id, generation_time=timestamp, generation_id=generation_id)
 
-        print 'Doing put:\nkey=%s\nvalue=%s\n\nheader=%s\n\nmetadata=%s\n\n' % (
-            key, value, header, metadata)
+        print('Doing put:\nkey=%s\nvalue=%s\n\nheader=%s\n\nmetadata=%s\n\n' % (
+            key, value, header, metadata))
         datablock.put(key, value, header, metadata)
         datablock.put('zKey', {'mz': 'vz'}, header, metadata)
 
-        print 'Doing get: key=%s ...\n' % key
+        print('Doing get: key=%s ...\n' % key)
         db_value = datablock.get(key)
-        print db_value
-        print 'Doing get_header: key=%s ...\n' % key
+        print(db_value)
+        print('Doing get_header: key=%s ...\n' % key)
         db_header = datablock.get_header(key)
-        print db_header
-        print 'Doing get_metadata: key=%s ...\n' % key
+        print(db_header)
+        print('Doing get_metadata: key=%s ...\n' % key)
         db_metadata = datablock.get_metadata(key)
-        print db_metadata
+        print(db_metadata)
 
-        print 'Performing comparison of value, header and metadata ...'
+        print('Performing comparison of value, header and metadata ...')
         if (are_dicts_same(value, db_value) and
            are_dicts_same(header, db_header) and
            are_dicts_same(metadata, db_metadata)):
-            print 'DICTS CONSISTENCY CHECK PASSED\n'
+            print('DICTS CONSISTENCY CHECK PASSED\n')
         else:
-            print 'DICTS CONSISTENCY CHECK FAILED\n'
+            print('DICTS CONSISTENCY CHECK FAILED\n')
         assert (are_dicts_same(value, db_value) and
                 are_dicts_same(header, db_header) and
                 are_dicts_same(metadata, db_metadata))
@@ -92,11 +92,11 @@ class TestDataBlock:
 
         # TEST: Insert new value for same key
         new_value = {"m2": "v2"}
-        print 'Doing put:\nkey=%s\nvalue=%s\nheader=%s\nmetadata=%s\n' % (
-            key, new_value, header, metadata)
+        print('Doing put:\nkey=%s\nvalue=%s\nheader=%s\nmetadata=%s\n' % (
+            key, new_value, header, metadata))
         datablock.put(key, new_value, header, metadata)
-        print 'Doing get: key=%s ...\n' % key
-        print datablock.get(key)
+        print('Doing get: key=%s ...\n' % key)
+        print(datablock.get(key))
         db_new_value = datablock.get(key)
         db_header = datablock.get_header(key)
         db_metadata = datablock.get_metadata(key)
@@ -108,35 +108,35 @@ class TestDataBlock:
 
         # TEST: Duplicate functionality
 
-        print '-----------------------'
-        print 'Duplicating datablock ...\n'
+        print('-----------------------')
+        print('Duplicating datablock ...\n')
         dup_datablock = datablock.duplicate()
 
-        print '---'
-        print 'datablock.generation_id = ', datablock.generation_id
-        print 'Doing get: key=%s ...\n' % key
-        print datablock.get(key)
-        print 'Doing get_header: key=%s ...\n' % key
-        print datablock.get_header(key)
-        print 'Doing get_metadata: key=%s ...\n' % key
-        print datablock.get_metadata(key)
-        print '---'
-        print 'dup_datablock.generation_id = ', dup_datablock.generation_id
-        print 'Doing get on dup_datablock: key=%s\n' % key
-        print dup_datablock.get(key)
-        print 'Doing get_header on dup_datablock: key=%s ...\n' % key
-        print dup_datablock.get_header(key)
-        print 'Doing get_metadata on dup_datablock: key=%s ...\n' % key
-        print dup_datablock.get_metadata(key)
-        print '---'
+        print('---')
+        print('datablock.generation_id = ', datablock.generation_id)
+        print('Doing get: key=%s ...\n' % key)
+        print(datablock.get(key))
+        print('Doing get_header: key=%s ...\n' % key)
+        print(datablock.get_header(key))
+        print('Doing get_metadata: key=%s ...\n' % key)
+        print(datablock.get_metadata(key))
+        print('---')
+        print('dup_datablock.generation_id = ', dup_datablock.generation_id)
+        print('Doing get on dup_datablock: key=%s\n' % key)
+        print(dup_datablock.get(key))
+        print('Doing get_header on dup_datablock: key=%s ...\n' % key)
+        print(dup_datablock.get_header(key))
+        print('Doing get_metadata on dup_datablock: key=%s ...\n' % key)
+        print(dup_datablock.get_metadata(key))
+        print('---')
 
         # TEST: Insert new value on duplicated datablock
         new_value3 = {"m3": "v3"}
         dup_datablock.put(key, new_value3, dup_datablock.get_header(key), dup_datablock.get_metadata(key))
 
-        print dup_datablock.get(key)
-        print dup_datablock.get_header(key)
-        print dup_datablock.get_metadata(key)
+        print(dup_datablock.get(key))
+        print(dup_datablock.get_header(key))
+        print(dup_datablock.get_metadata(key))
 
         db_dup_value = dup_datablock.get(key)
         db_dup_header = dup_datablock.get_header(key)

--- a/framework/util/tsort.py
+++ b/framework/util/tsort.py
@@ -20,8 +20,6 @@ else
     return L (a topologically sorted order)
 """
 
-import types
-
 
 def tsort(graph):
     """
@@ -35,13 +33,13 @@ def tsort(graph):
 
     """
 
-    if isinstance(graph, types.ListType):
+    if isinstance(graph, list):
         graph = dict(graph)
     """
     count incoming edges for each vertex
     """
     incoming_edges = {}
-    for vertex, edges in graph.items():
+    for vertex, edges in list(graph.items()):
         incoming_edges.setdefault(vertex, 0)
         for edge in edges:
             incoming_edges[edge] = incoming_edges.get(edge, 0)+1
@@ -49,7 +47,7 @@ def tsort(graph):
     """
     create dict of vertices that have no incoming edges
     """
-    empty = {v for v, count in incoming_edges.items() if count == 0}
+    empty = {v for v, count in list(incoming_edges.items()) if count == 0}
 
     sorted_graph = []
 
@@ -71,7 +69,7 @@ def tsort(graph):
             if incoming_edges[edge] == 0:
                 empty.add(edge)
 
-    cyclic_graph = [v for v, count in incoming_edges.items() if count != 0]
+    cyclic_graph = [v for v, count in list(incoming_edges.items()) if count != 0]
 
     """
      if there are no cyclic dependencies the above list is None


### PR DESCRIPTION
This is all the super easy - and fully syntax compatible with python 2.7 - bits for the python3 migration.

There are a number of remaining issues identified by 2to3 as well as a need to check for `str` typing.

None of this should alter the runtime behaviour.  Note, it will use more memory on python2.7 than before.