### PR TITLE
Python3 forward compatible syntax

### DIFF
--- a/framework/modules/SourceProxy.py
+++ b/framework/modules/SourceProxy.py
@@ -85,7 +85,7 @@ class SourceProxy(Source.Source):
           data_keys[key1] = (data_product_name, data_product_name_translation)
           ....
           or
-         
+
           data_keys[key1] = data_product_name
           ....
         """
@@ -134,7 +134,7 @@ class SourceProxy(Source.Source):
                         break
                     else:
                         retry_cnt += 1
-                        time.sleep(self.retry_to/3) # retry in 1/3 of configured TO
+                        time.sleep(self.retry_to//3) # retry in 1/3 of configured TO
                 else:
                     retry_cnt += 1
                     time.sleep(self.retry_to)

--- a/framework/tests/dataspace/test_datablock.py
+++ b/framework/tests/dataspace/test_datablock.py
@@ -39,7 +39,7 @@ def are_dicts_same(x, y):
 
     return len(xitems) == len(yitems) and len(shared_items) == len(xitems)
 
-class TestDataBlock:
+class TestDataBlock(object):
 
     def test_datablock(self):
         print("Hello test_datablock")

--- a/framework/util/tests/test_tsort.py
+++ b/framework/util/tests/test_tsort.py
@@ -2,7 +2,7 @@ import pytest
 from decisionengine.framework.util import tsort
 
 
-class TestTsort:
+class TestTsort(object):
 
     def test_tsort(self):
         a = [(3, [8, 10]),


### PR DESCRIPTION
This addresses some of the forward compatible bits.  The big one being `/` can return `int` or `float` whereas `sleep` wants an `int`.

And a few missing `(object)` items to make pylint a bit happier.