### PR TITLE
logicengine: get rid of compuler warnings

### DIFF
--- a/framework/logicengine/cxx/ErrorHandler/ma_cell.cpp
+++ b/framework/logicengine/cxx/ErrorHandler/ma_cell.cpp
@@ -34,7 +34,7 @@ ma_cell::hit(msg_t const& msg,
   what_ = w;
 
   // push new message
-  time_t latest; // = msg.timestamp().tv_sec;
+  time_t latest = msg.timestamp().tv_sec;
   msgs.push_back(msg);
 
   if (on && cond.persistent()) {

--- a/framework/logicengine/cxx/ErrorHandler/ma_rule.cpp
+++ b/framework/logicengine/cxx/ErrorHandler/ma_rule.cpp
@@ -241,7 +241,7 @@ ma_rule::boolean_evaluate(ma_domain& value,
   //std::cout << "now evaluate boolean_expr with given value \n";
 
   // make sure all conditions are defined
-  for (int i = 0; i < conditions.size(); ++i)
+  for (size_t i = 0; i < conditions.size(); ++i)
     if (!conditions[i]->get_defined(value[i])) return false;
 
   // evaluate as true with given set of values

--- a/framework/logicengine/cxx/ErrorHandler/py_rule_engine.cc
+++ b/framework/logicengine/cxx/ErrorHandler/py_rule_engine.cc
@@ -73,4 +73,4 @@ BOOST_PYTHON_MODULE(RE)
 {
   class_<RuleEngine, boost::noncopyable>("RuleEngine", init<string, string>())
     .def("execute", &RuleEngine::execute);
-};
+}


### PR DESCRIPTION
This patch handles 3 warnings generated by compiler. The fix for uninitialized
variable can be seen as controversial as the fix reverts commented out code.
It looks correct in the spirit of the function logic, but in the absence of
code history can be cinsidered dangerous.

Unit tests pass.

https://fermicloud140.fnal.gov/reviews/r/56/

