### PR TITLE
Support Python 3 for Boost Python

### DIFF
--- a/framework/logicengine/cxx/CMakeLists.txt
+++ b/framework/logicengine/cxx/CMakeLists.txt
@@ -7,12 +7,17 @@ set(logicengine_version_minor 0)
 
 set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS} -pedantic -Wall")
 
-find_package(Boost REQUIRED)
 find_package(PythonInterp ${PYVER} REQUIRED)
 find_package(PythonLibs REQUIRED)
+find_package(Boost REQUIRED)
 
 # for vim ycm plugin
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
+
+set(BOOST_PY_SUFFIX 3)
+if(PYTHONLIBS_VERSION_STRING VERSION_LESS "3.0.0")
+  set(BOOST_PY_SUFFIX)
+endif()
 
 add_subdirectory(ErrorHandler)
 

--- a/framework/logicengine/cxx/ErrorHandler/CMakeLists.txt
+++ b/framework/logicengine/cxx/ErrorHandler/CMakeLists.txt
@@ -33,4 +33,7 @@ add_executable(test_main test_main.cc)
 target_link_libraries(test_main LogicEngine boost_regex boost_system)
 
 python_add_module(RE py_rule_engine.cc)
-target_link_libraries(RE LogicEngine boost_python boost_regex boost_system ${PYTHON_LIBRARIES})
+target_link_libraries(RE LogicEngine
+                      boost_python${BOOST_PY_SUFFIX}
+                      boost_system
+                      ${PYTHON_LIBRARIES})


### PR DESCRIPTION
The CMakeLists.txt files needed to be adjusted in order to support Python 3-compatible Boost Python dependencies.