### PR TITLE
Factorize configuration-loading steps

### DIFF
--- a/framework/configmanager/tests/test_configmanager.py
+++ b/framework/configmanager/tests/test_configmanager.py
@@ -16,7 +16,7 @@ def load(filename):
 def test_empty_config():
     with pytest.raises(RuntimeError) as e:
         load('empty.conf')
-    assert e.match('invalid syntax')
+    assert e.match('Empty configuration file .*/empty\\.conf')
 
 def test_wrong_type():
     with pytest.raises(RuntimeError) as e:
@@ -31,4 +31,4 @@ def test_empty_dict():
 def test_empty_dict_with_leading_comment():
     with pytest.raises(RuntimeError) as e:
         load('empty_dict_with_leading_comment.conf')
-    assert e.match('invalid syntax')
+    assert e.match('No logger configuration has been specified')


### PR DESCRIPTION
This exercise inadvertently added support for leading comments in the
current configuration system.  This is due to how the configuration
file is read (heuristically):

```python
exec("self.global_config=" + file.read()) # Before
self.global_config = eval(file.read())    # After
```
In this commit, the leading comments are removed first by the 'eval'
function, and then the assignment is made to the variable.