### PR TITLE
Insulate multiprocessing test from parent environment

### DIFF
--- a/framework/engine/tests/test_as_multiprocessing.py
+++ b/framework/engine/tests/test_as_multiprocessing.py
@@ -16,6 +16,11 @@ def get_random_port():
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]
 
+
+# Insulate from parent environments
+multiprocessing.set_start_method('spawn')
+
+
 class TestClientServerPython(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
When using environment variables in unit tests, there can be awkward
interactions between processes if 'forking' is used.  This commit,
which will be necessary for a forthcoming change, sets the starting
method to 'spawn', insulating the test from undesirable environment
collisions.

This commit also corrects a spelling error in the filename.