### PR TITLE
Switch to Jsonnet configuration system

### DIFF
--- a/framework/configmanager/ConfigManager.py
+++ b/framework/configmanager/ConfigManager.py
@@ -15,7 +15,7 @@ MANDATORY_MODULE_KEYS = {"module", "name", "parameters"}
 
 CONFIG_FILE_NAME = "decision_engine.conf"
 
-def _attempt_conversion_to_json(config_file):
+def _convert_to_json(config_file):
     global_config = None
     try:
         with open(config_file) as f:
@@ -41,12 +41,10 @@ def _attempt_conversion_to_json(config_file):
           file=sys.stderr)
     return json_config
 
-def _verify_not_empty(config_file):
+def _config_from_file(config_file):
     if os.path.getsize(config_file) == 0:
         raise RuntimeError(f"Empty configuration file {config_file}")
 
-def _config_from_file(config_file):
-    _verify_not_empty(config_file)
     config_str = None
     try:
         config_str = _jsonnet.evaluate_file(config_file)
@@ -55,7 +53,7 @@ def _config_from_file(config_file):
             print(f"Please rename '{config_file}' to '{basename}.jsonnet'.",
                   file=sys.stderr)
     except Exception:
-        config_str = _attempt_conversion_to_json(config_file)
+        config_str = _convert_to_json(config_file)
 
     return json.loads(config_str)
 

--- a/framework/configmanager/ConfigManager.py
+++ b/framework/configmanager/ConfigManager.py
@@ -16,6 +16,14 @@ MANDATORY_MODULE_KEYS = {"module", "name", "parameters"}
 CONFIG_FILE_NAME = "decision_engine.conf"
 
 def _convert_to_json(config_file):
+    """
+    Attempt to convert JSON non-compliant configuration into a compliant one.
+
+    This is a temporary facility to aid the migration of Python-based
+    configurations to Jsonnet-based ones.  Python dictionaries that
+    are similar in structure to JSON documents are generally trivially
+    convertible.
+    """
     global_config = None
     try:
         with open(config_file) as f:

--- a/framework/configmanager/tests/de/minimal_jsonnet.conf
+++ b/framework/configmanager/tests/de/minimal_jsonnet.conf
@@ -1,0 +1,8 @@
+{
+  'logger': {
+    'log_file': 'de.log',
+    'max_file_size': 200000000,
+    'max_backup_count': 6,
+    'log_level': "DEBUG",
+  }
+}

--- a/framework/configmanager/tests/test_configmanager.py
+++ b/framework/configmanager/tests/test_configmanager.py
@@ -30,7 +30,7 @@ def test_empty_config(load):
 def test_wrong_type(load):
     with pytest.raises(RuntimeError) as e:
         load('wrong_type.conf')
-    assert e.match('The configuration file must be a Python dictionary')
+    assert e.match('The supplied configuration must be a valid Jsonnet/JSON document')
 
 def test_empty_dict(load):
     with pytest.raises(RuntimeError) as e:
@@ -42,18 +42,32 @@ def test_empty_dict_with_leading_comment(load):
         load('empty_dict_with_leading_comment.conf')
     assert e.match('No logger configuration has been specified')
 
-# -------------------------------------------------
-def test_minimal_python(load):
+#--------------------------------
+
+def test_minimal_python(load, capsys):
     load('minimal_python.conf')
+    stdout, stderr = capsys.readouterr()
+    assert not stdout
+    expected = "The supplied configuration.*has been converted to a valid JSON construct"
+    assert re.search(expected, stderr, flags=re.DOTALL)
+
+def test_minimal_jsonnet_wrong_extension(load, capsys):
+    load('minimal_jsonnet.conf')
+    stdout, stderr = capsys.readouterr()
+    assert not stdout
+    expected = r"Please rename '.*/minimal_jsonnet\.conf' to '.*/minimal_jsonnet\.jsonnet'"
+    assert re.match(expected, stderr)
 
 # -------------------------------------------------
 def test_channel_no_config_files(load):
     load('minimal_python.conf', 'channels/no_config_files')
 
-def test_channel_empty_config(load):
-    with pytest.raises(RuntimeError) as e:
-        load('minimal_python.conf', 'channels/empty_config')
-    assert e.match('Empty configuration file .*\\.conf')
+def test_channel_empty_config(load, capsys, caplog):
+    load('minimal_python.conf', 'channels/empty_config')
+    stdout, stderr = capsys.readouterr()
+    expected = "The supplied configuration.*has been converted to a valid JSON construct"
+    assert re.search(expected, stderr, flags=re.DOTALL)
+    assert re.search('Empty configuration file .*\\.jsonnet', caplog.text)
 
 def test_channel_empty_dictionary(load, caplog):
     load('minimal_python.conf', 'channels/empty_dictionary')

--- a/framework/configmanager/tests/test_configmanager.py
+++ b/framework/configmanager/tests/test_configmanager.py
@@ -21,7 +21,9 @@ def load(monkeypatch):
     return _call
 
 
-#-------------------------------------------------
+# --------------------------------------------------------------------
+# These tests demonstrate failure modes when reading a DE
+# applicaation configuration file.
 def test_empty_config(load):
     with pytest.raises(RuntimeError) as e:
         load('empty.conf')
@@ -32,6 +34,10 @@ def test_wrong_type(load):
         load('wrong_type.conf')
     assert e.match('The supplied configuration must be a valid Jsonnet/JSON document')
 
+# --------------------------------------------------------------------
+# These tests yield valid DE configuration structures. However, the
+# configurations are missing a logger configuration, which is the next
+# failure mode after reading the configuration files.
 def test_empty_dict(load):
     with pytest.raises(RuntimeError) as e:
         load('empty_dict.conf')
@@ -42,8 +48,10 @@ def test_empty_dict_with_leading_comment(load):
         load('empty_dict_with_leading_comment.conf')
     assert e.match('No logger configuration has been specified')
 
-#--------------------------------
-
+# --------------------------------------------------------------------
+# These tests validate well-formed DE configurations, but they also
+# check that the appropriate warning messages are emitted regarding
+# Python support for a Jsonnet configuration system.
 def test_minimal_python(load, capsys):
     load('minimal_python.conf')
     stdout, stderr = capsys.readouterr()
@@ -58,7 +66,9 @@ def test_minimal_jsonnet_wrong_extension(load, capsys):
     expected = r"Please rename '.*/minimal_jsonnet\.conf' to '.*/minimal_jsonnet\.jsonnet'"
     assert re.match(expected, stderr)
 
-# -------------------------------------------------
+# --------------------------------------------------------------------
+# These tests verify expected behavior for channel (not DE)
+# configurations.
 def test_channel_no_config_files(load):
     load('minimal_python.conf', 'channels/no_config_files')
 


### PR DESCRIPTION
**This is a breaking change.**

All configuration files must now be Jsonnet/JSON compliant, or convertible to JSON from the Python-based configuration.  Suitable warnings are printed if a configuration file is:

1. named with extension `.conf` instead of `.jsonnet`
2. convertible to JSON but not expressible as a Jsonnet/JSON document

Documents that cannot be converted to JSON trigger a hard error and must be adjusted.