### PR TITLE
Adjust global configuration to include program-option values

### DIFF
--- a/framework/configmanager/ConfigManager.py
+++ b/framework/configmanager/ConfigManager.py
@@ -173,7 +173,7 @@ def _validate_channel(channel):
 
 class ConfigManager():
 
-    def __init__(self):
+    def __init__(self, program_options=None):
         self.config_dir = os.getenv("CONFIG_PATH", "/etc/decisionengine")
         if not os.path.isdir(self.config_dir):
             raise Exception(f"Config dir '{self.config_dir}' not found")
@@ -181,7 +181,8 @@ class ConfigManager():
                                             os.path.join(self.config_dir, "config.d"))
         if not os.path.isdir(self.channel_config_dir):
             raise Exception(f"Channel config dir '{self.channel_config_dir}' not found")
-        self.global_config = {}
+        self.program_options = program_options
+        self.global_config = None
         self.channels = {}
         self.config = {}
         self.logger = None
@@ -216,6 +217,10 @@ class ConfigManager():
             raise Exception(f"Config file '{config_file}' not found")
         self.last_update_time = os.stat(config_file).st_mtime
         self.global_config = _config_from_file(config_file)
+        # If present, the configuration as specified via program
+        # options takes precedence.
+        if self.program_options:
+            self.global_config.update(self.program_options)
         if not self.logger:
             self.logger = _make_logger(self.global_config)
         self._load_channels()

--- a/framework/configmanager/tests/de/minimal.jsonnet
+++ b/framework/configmanager/tests/de/minimal.jsonnet
@@ -1,0 +1,8 @@
+{
+  logger: {
+    log_file: 'de.log',
+    max_file_size: 200 * 1000000,
+    max_backup_count: 6,
+    log_level: "DEBUG",
+  }
+}

--- a/framework/configmanager/tests/de/minimal_with_address.jsonnet
+++ b/framework/configmanager/tests/de/minimal_with_address.jsonnet
@@ -1,0 +1,9 @@
+{
+  server_address: ['localhost', 0],
+  logger: {
+    log_file: 'de.log',
+    max_file_size: 200 * 1000000,
+    max_backup_count: 6,
+    log_level: "DEBUG",
+  }
+}

--- a/framework/configmanager/tests/test_configmanager.py
+++ b/framework/configmanager/tests/test_configmanager.py
@@ -8,7 +8,9 @@ _this_dir = os.path.dirname(os.path.abspath(__file__))
 
 @pytest.fixture()
 def load(monkeypatch):
-    def _call(filename, relative_channel_config_dir=None):
+    def _call(filename,
+              relative_channel_config_dir=None,
+              program_options=None):
         monkeypatch.setenv('CONFIG_PATH', os.path.join(_this_dir, 'de'))
         if relative_channel_config_dir is None:
             monkeypatch.setenv('CHANNEL_CONFIG_PATH',
@@ -16,8 +18,9 @@ def load(monkeypatch):
         else:
             monkeypatch.setenv('CHANNEL_CONFIG_PATH',
                                os.path.join(_this_dir, relative_channel_config_dir))
-        manager = ConfigManager.ConfigManager()
+        manager = ConfigManager.ConfigManager(program_options)
         manager.load(filename)
+        return manager.get_global_config()
     return _call
 
 
@@ -65,6 +68,25 @@ def test_minimal_jsonnet_wrong_extension(load, capsys):
     assert not stdout
     expected = r"Please rename '.*/minimal_jsonnet\.conf' to '.*/minimal_jsonnet\.jsonnet'"
     assert re.match(expected, stderr)
+
+# --------------------------------------------------------------------
+# These tests verify that program options are correctly included
+# as/override part of the final configuration.
+def test_program_options_default(load):
+    address = ['localhost', 1234]
+    config = load('minimal.jsonnet',
+                  program_options={'server_address': address})
+    assert config.get('server_address') == address
+
+def test_program_options_update(load):
+    # Verify non-modified 'server_address' value
+    config = load('minimal_with_address.jsonnet')
+    assert config.get('server_address') == ['localhost', 0]
+    # Override value with program option
+    address = ['localhost', 1234]
+    config = load('minimal_with_address.jsonnet',
+                  program_options={'server_address': address})
+    assert config.get('server_address') == address
 
 # --------------------------------------------------------------------
 # These tests verify expected behavior for channel (not DE)


### PR DESCRIPTION
This PR takes program options and presents them to the `ConfigManager` so that the global configuration can be updated accordingly.  The consequence is that the decision engine object is now constructed using configuration information only (which is desirable) instead of configuration plus program options.  The supported configuration schema is not affected.

The PR also includes some minor cleanups in the relevant code:
- `sys.stderr.write("..."); sys.exit(1)` can be replaced with just `sys.exit("...")`
- The parsing of program options (i.e. `parser.parse_args(args)`) does not need to be handled separately if `args` is `None` vs. a list of arguments--`argparse` will figure it out for us
- Renaming of some variables for clarity