### PR TITLE
Configuration-manager fixes

### DIFF
--- a/framework/configmanager/ConfigManager.py
+++ b/framework/configmanager/ConfigManager.py
@@ -239,8 +239,10 @@ class ConfigManager():
             name, path = entry.name, entry.path
             if not name.endswith((".conf", ".jsonnet")):
                 continue
+            # Remove extension
+            basename = os.path.splitext(name)[0]
             try:
-                self.channels[name] = _config_from_file(path)
+                self.channels[basename] = _config_from_file(path)
             except Exception as msg:
                 self.logger.error(f"Failed to open channel configuration file {path} "
                                   f"contains error\n-> {msg}\nSKIPPING channel")
@@ -250,10 +252,10 @@ class ConfigManager():
             # If keys are missing, the channel is removed and an error
             # message is logged.
             try:
-                _validate_channel(self.channels[name])
+                _validate_channel(self.channels[basename])
             except Exception as msg:
                 self.logger.error(f"{name} {msg}, REMOVING the channel")
-                del self.channels[name]
+                del self.channels[basename]
                 continue
 
     @staticmethod

--- a/framework/configmanager/ConfigManager.py
+++ b/framework/configmanager/ConfigManager.py
@@ -57,7 +57,7 @@ def _config_from_file(config_file):
     try:
         config_str = _jsonnet.evaluate_file(config_file)
         basename, ext = os.path.splitext(config_file)
-        if ext != 'jsonnet':
+        if ext != '.jsonnet':
             print(f"Please rename '{config_file}' to '{basename}.jsonnet'.",
                   file=sys.stderr)
     except Exception:
@@ -237,10 +237,9 @@ class ConfigManager():
     def _load_channels(self):
         for entry in os.scandir(self.channel_config_dir):
             name, path = entry.name, entry.path
-            if not name.endswith((".conf", ".jsonnet")):
+            basename, ext = os.path.splitext(name)
+            if ext not in {'.conf', '.jsonnet'}:
                 continue
-            # Remove extension
-            basename = os.path.splitext(name)[0]
             try:
                 self.channels[basename] = _config_from_file(path)
             except Exception as msg:

--- a/framework/configmanager/tests/test_configmanager.py
+++ b/framework/configmanager/tests/test_configmanager.py
@@ -20,7 +20,7 @@ def load(monkeypatch):
                                os.path.join(_this_dir, relative_channel_config_dir))
         manager = ConfigManager.ConfigManager(program_options)
         manager.load(filename)
-        return manager.get_global_config()
+        return manager
     return _call
 
 
@@ -75,17 +75,17 @@ def test_minimal_jsonnet_wrong_extension(load, capsys):
 def test_program_options_default(load):
     address = ['localhost', 1234]
     config = load('minimal.jsonnet',
-                  program_options={'server_address': address})
+                  program_options={'server_address': address}).get_global_config()
     assert config.get('server_address') == address
 
 def test_program_options_update(load):
     # Verify non-modified 'server_address' value
-    config = load('minimal_with_address.jsonnet')
+    config = load('minimal_with_address.jsonnet').get_global_config()
     assert config.get('server_address') == ['localhost', 0]
     # Override value with program option
     address = ['localhost', 1234]
     config = load('minimal_with_address.jsonnet',
-                  program_options={'server_address': address})
+                  program_options={'server_address': address}).get_global_config()
     assert config.get('server_address') == address
 
 # --------------------------------------------------------------------
@@ -107,3 +107,9 @@ def test_channel_empty_dictionary(load, caplog):
 
 def test_channel_no_modules(load):
     load('minimal_python.conf', 'channels/no_modules')
+
+# --------------------------------------------------------------------
+# Test channel names based on channel configuration file names
+def test_channel_names(load):
+    manager = load('minimal_python.conf', 'channels/no_modules')
+    assert list(manager.get_channels().keys()) == ['no_modules']

--- a/framework/configmanager/tests/test_configmanager.py
+++ b/framework/configmanager/tests/test_configmanager.py
@@ -26,7 +26,7 @@ def load(monkeypatch):
 
 # --------------------------------------------------------------------
 # These tests demonstrate failure modes when reading a DE
-# applicaation configuration file.
+# application configuration file.
 def test_empty_config(load):
     with pytest.raises(RuntimeError) as e:
         load('empty.conf')
@@ -68,6 +68,12 @@ def test_minimal_jsonnet_wrong_extension(load, capsys):
     assert not stdout
     expected = r"Please rename '.*/minimal_jsonnet\.conf' to '.*/minimal_jsonnet\.jsonnet'"
     assert re.match(expected, stderr)
+
+def test_minimal_jsonnet_right_extension(load, capsys):
+    load('minimal.jsonnet')
+    stdout, stderr = capsys.readouterr()
+    assert not stdout
+    assert not stderr
 
 # --------------------------------------------------------------------
 # These tests verify that program options are correctly included


### PR DESCRIPTION
The keys of the channel-configuration map unintentionally included the extensions of the channel configuration files.  This commit ensures that the extension is stripped and only the basename of the file is used as the channel key.

The checking of the filename extension was also incorrect.  That has been fixed.