### PR TITLE
Fix faulty TaskManager state type

### DIFF
--- a/framework/taskmanager/TaskManager.py
+++ b/framework/taskmanager/TaskManager.py
@@ -172,14 +172,14 @@ class TaskManager():
 
     def set_state(self, state):
         with self.state.get_lock():
-            self.state.value = state
+            self.state.value = state.value
 
     def get_state(self):
         with self.state.get_lock():
-            return self.state.value
+            return State(self.state.value)
 
     def get_state_name(self):
-        return State(self.get_state()).name
+        return self.get_state().name
 
     def set_loglevel(self, log_level):
         """Assumes log_level is a string corresponding to the supported logging-module levels."""


### PR DESCRIPTION
The bug was introduced when moving to the Python-supported `enum` module.

The reason the `de-client --status` printout showed the `BOOT` state is because the task-manager process had finished and stale memory was lying around.  I will work on fixing that.