### PR TITLE
Adding log rotation by time

### DIFF
--- a/framework/configmanager/ConfigManager.py
+++ b/framework/configmanager/ConfigManager.py
@@ -74,10 +74,13 @@ def _make_logger(global_config):
         raise RuntimeError("No logger configuration has been specified.")
     try:
         logger_config = global_config['logger']
-        de_logger.set_logging(log_file_name=logger_config['log_file'],
+        de_logger.set_logging(log_level=logger_config.get('log_level', 'INFO'),
+                              file_rotate_by=logger_config.get('file_rotate_by', "size"),
+                              rotation_time_unit=logger_config.get('rotation_time_unit', 'D'),
+                              rotation_interval=logger_config.get('rotation_time_interval', 1),
+                              max_backup_count=logger_config.get('max_backup_count', 6),
                               max_file_size=logger_config['max_file_size'],
-                              max_backup_count=logger_config['max_backup_count'],
-                              log_level=logger_config.get('log_level', 'WARNING'))
+                              log_file_name=logger_config['log_file'])
         return de_logger.get_logger()
     except Exception as msg:
         raise RuntimeError(f"Failed to create log: {msg}")

--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -46,14 +46,25 @@ class Worker(multiprocessing.Process):
 
     def run(self):
         logger = logging.getLogger()
-        file_handler = logging.handlers.RotatingFileHandler(os.path.join(
-                                                            os.path.dirname(
-                                                                self.logger_config["log_file"]),
-                                                            self.task_manager.name + ".log"),
-                                                            maxBytes=self.logger_config.get("max_file_size",
-                                                                                            200 * 1000000),
-                                                            backupCount=self.logger_config.get("max_backup_count",
-                                                                                               6))
+        logger_rotate_by = self.logger_config.get("file_rotate_by", "size")
+
+        if logger_rotate_by == "size":
+            file_handler = logging.handlers.RotatingFileHandler(os.path.join(
+                                                                os.path.dirname(
+                                                                  self.logger_config["log_file"]),
+                                                                self.task_manager.name + ".log"),
+                                                                maxBytes=self.logger_config.get("max_file_size",
+                                                                200 * 1000000),
+                                                                backupCount=self.logger_config.get("max_backup_count",
+                                                                6))
+        else:
+            file_handler = logging.handlers.TimedRotatingFileHandler(os.path.join(
+                                                                     os.path.dirname(
+                                                                       self.logger_config["log_file"]),
+                                                                     self.task_manager.name + ".log"),
+                                                                     when=self.logger_config.get("rotation_time_unit", 'D'),
+                                                                     interval=self.logger_config.get("rotation_time_interval", '1'))
+
         file_handler.setFormatter(FORMATTER)
         logger.setLevel(logging.WARNING)
         logger.addHandler(file_handler)

--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -51,7 +51,7 @@ class Worker(multiprocessing.Process):
         if logger_rotate_by == "size":
             file_handler = logging.handlers.RotatingFileHandler(os.path.join(
                                                                 os.path.dirname(
-                                                                  self.logger_config["log_file"]),
+                                                                    self.logger_config["log_file"]),
                                                                 self.task_manager.name + ".log"),
                                                                 maxBytes=self.logger_config.get("max_file_size",
                                                                 200 * 1000000),
@@ -60,7 +60,7 @@ class Worker(multiprocessing.Process):
         else:
             file_handler = logging.handlers.TimedRotatingFileHandler(os.path.join(
                                                                      os.path.dirname(
-                                                                       self.logger_config["log_file"]),
+                                                                         self.logger_config["log_file"]),
                                                                      self.task_manager.name + ".log"),
                                                                      when=self.logger_config.get("rotation_time_unit", 'D'),
                                                                      interval=self.logger_config.get("rotation_time_interval", '1'))

--- a/framework/modules/de_logger.py
+++ b/framework/modules/de_logger.py
@@ -5,13 +5,25 @@ import os
 import logging
 import logging.handlers
 
-LOG_FILE = '/tmp/decision_engine_logs/decision_engine_log'
 MB = 1000000
-ROTATE_AFTER = 6
 
-def set_logging(log_file_name=LOG_FILE, max_file_size=200 * MB, max_backup_count=ROTATE_AFTER, log_level="DEBUG"):
+def set_logging(log_level,
+                file_rotate_by,
+                rotation_time_unit,
+                rotation_interval,
+                max_backup_count,
+                max_file_size=200 * MB,
+                log_file_name='/tmp/decision_engine_logs/decision_engine_log'):
     """
 
+    :type log_level: :obj:`str`
+    :arg log_level: log level
+    :type file_rotate_by: :obj: `str`
+    :arg file_rotate_by: files rotation by size or by time
+    :type rotation_time_unit: :obj:`str`
+    :arg rotation_time_unit: unit of time for file rotation
+    :type rotation_interval: :obj:`int`
+    :arg rotation_interval: time in rotation_time_units between file rotations
     :type log_file_name: :obj:`str`
     :arg log_file_name: log file name
     :type  max_file_size: :obj:`int`
@@ -31,17 +43,29 @@ def set_logging(log_file_name=LOG_FILE, max_file_size=200 * MB, max_backup_count
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(module)s - %(threadName)s - %(levelname)s - %(message)s")
 
-    file_handler = logging.handlers.RotatingFileHandler(log_file_name,
-                                                        maxBytes=max_file_size,
-                                                        backupCount=max_backup_count)
+    if file_rotate_by == "size":
+        file_handler = logging.handlers.RotatingFileHandler(log_file_name,
+                                                            maxBytes=max_file_size,
+                                                            backupCount=max_backup_count)
+    else:
+        file_handler = logging.handlers.TimedRotatingFileHandler(log_file_name,
+                                                                 when=rotation_time_unit,
+                                                                 interval=rotation_interval)
+
     file_handler.setFormatter(formatter)
     file_handler.setLevel(logging.INFO)
     logger.addHandler(file_handler)
 
     if log_file_name != '/dev/null':
-        debug_handler = logging.handlers.RotatingFileHandler("%s_debug" % (log_file_name,),
-                                                             maxBytes=max_file_size,
-                                                             backupCount=max_backup_count)
+        if file_rotate_by == "size":
+            debug_handler = logging.handlers.RotatingFileHandler("%s_debug" % (log_file_name,),
+                                                                 maxBytes=max_file_size,
+                                                                 backupCount=max_backup_count)
+        else:
+            debug_handler = logging.handlers.TimedRotatingFileHandler(log_file_name,
+                                                                      when=rotation_time_unit,
+                                                                      interval=rotation_interval)
+
         debug_handler.setFormatter(formatter)
         debug_handler.setLevel(logging.DEBUG)
         logger.addHandler(debug_handler)
@@ -83,10 +107,13 @@ def set_stream_logging(logger_name=''):
 
 if __name__ == '__main__':
     my_logger = logging.getLogger("decision_engine")
-    set_logging(log_file_name='%s/de_log/decision_engine_log0' % (os.environ.get('HOME')),
-                max_file_size=100000,
+    set_logging("ERROR",
+                "size",
+                'D',
+                1,
                 max_backup_count=5,
-                log_level="DEBUG")
+                max_file_size=10000,
+                log_file_name='%s/de_log/decision_engine_log0' % (os.environ.get('HOME')))
     my_logger.info("THIS IS INFO")
-    my_logger.error("THIS IS ERROR")
+    my_logger.info("THIS IS INFO")
     my_logger.debug("THIS IS DEBUG")

--- a/framework/modules/de_logger.py
+++ b/framework/modules/de_logger.py
@@ -112,7 +112,7 @@ if __name__ == '__main__':
                 'D',
                 1,
                 max_backup_count=5,
-                max_file_size=10000,
+                max_file_size=100000,
                 log_file_name='%s/de_log/decision_engine_log0' % (os.environ.get('HOME')))
     my_logger.info("THIS IS INFO")
     my_logger.info("THIS IS INFO")

--- a/framework/tests/etc/decisionengine/decision_engine.jsonnet
+++ b/framework/tests/etc/decisionengine/decision_engine.jsonnet
@@ -3,7 +3,10 @@
     'log_file': '/tmp/decisionengine.log',
     'max_file_size': 200*1000000,
     'max_backup_count': 6,
-    'log_level': "WARNING",
+    'rotation_time_unit':'D',
+    'rotation_time_interval':1,
+    'file_rotate_by':"size",
+    'log_level': "INFO",
     'global_channel_log_level':"WARNING",
   },
 


### PR DESCRIPTION
Changes to add ability to rotate the log files according to a time interval. The choice for whether to rotate log files according to time or file size is made in the config file (decision_engine.jsonnet) in the "file_rotate_by" parameter. The config file includes parameters for the unit of time and the time interval. The time interval is the same for both the DE log file and the channel log files, just as the size is.

RB : https://fermicloud140.fnal.gov/reviews/r/212/