### PR TITLE
Move postgres-specific implementation to postgres source

### DIFF
--- a/framework/dataspace/datablock.py
+++ b/framework/dataspace/datablock.py
@@ -334,10 +334,9 @@ class DataBlock(object):
         """
 
         try:
-            value_row = self.dataspace.get_dataproduct(self.sequence_id,
-                                                       self.generation_id, key)
-
-            value = ast.literal_eval(decompress(value_row['value'].tobytes()))
+            value = self.dataspace.get_dataproduct(self.sequence_id,
+                                                   self.generation_id, key)
+            value = ast.literal_eval(decompress(value))
         except KeyError:
             value = default
 

--- a/framework/dataspace/datasources/postgresql.py
+++ b/framework/dataspace/datasources/postgresql.py
@@ -238,7 +238,8 @@ class Postgresql(ds.DataSource):
     def get_dataproduct(self, taskmanager_id, generation_id, key):
         q = SELECT_QUERY.format(ds.DataSource.dataproduct_table)
         try:
-            return self._select_dictresult(q, (taskmanager_id, generation_id, key))[0]
+            value_row = self._select_dictresult(q, (taskmanager_id, generation_id, key))[0]
+            return value_row['value'].tobytes()
         except IndexError:
             raise KeyError("taskmanager_id={} or generation_id={} or key={} not found".format(
                 taskmanager_id, generation_id, key))


### PR DESCRIPTION
The `datablock` code assumes the data product returned by the data source is of type `memoryview`, after which the `tobytes()` method is called.  This is a postgres-chosen implementation, which should be part of the postgres data source.

This PR moves the `tobytes()` call to the data postgres data source.