### PR TITLE
Add timeout support for unit test on Jenkins

### DIFF
--- a/.Jenkinsfile
+++ b/.Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
                         echo "prepare docker image ${unit_testsStageDockerImage}"
                         sh "docker build -t ${unit_testsStageDockerImage} -f decisionengine/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins decisionengine/.github/actions/unittest-in-sl7-docker"
                         echo "Run ${STAGE_NAME} tests"
-                        sh "docker run --rm -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${unit_testsStageDockerImage}"
+                        sh "docker run --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${unit_testsStageDockerImage}"
                     }
                     post {
                         always {

--- a/build/scripts/utils.sh
+++ b/build/scripts/utils.sh
@@ -30,7 +30,7 @@ setup_python_venv() {
 
     # Install dependancies first so we don't get uncompatible ones
     # Following RPMs need to be installed on the machine:
-    pip_packages="argparse WebOb astroid pylint pycodestyle unittest2 coverage sphinx tabulate DBUtils psycopg2-binary pytest mock pandas ipython pytest-postgresql jsonnet"
+    pip_packages="argparse WebOb astroid pylint pycodestyle unittest2 coverage sphinx tabulate DBUtils psycopg2-binary pytest mock pandas ipython pytest-postgresql jsonnet pytest-timeout"
     for package in $pip_packages; do
         echo "Installing $package ..."
         status="DONE"


### PR DESCRIPTION
This feature add support to timeout for unit tests on Jenkins.
Among different way to set the timeout, this implementation uses the environment variable PYTEST_TIMEOUT that can be set as parameter in the Jenkins build and injected as environment variable in the docker container that run unit tests.
The timeout is set in seconds and it is applied to each unit test individually, so in principle it doesn't need to be updated in case new unit tests are added.
The default timeout has been set in the Jenkins configuration to 300.

RB: https://fermicloud140.fnal.gov/reviews/r/225/