### PR TITLE
Fix double-logging problem

### DIFF
--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -295,6 +295,11 @@ class DecisionEngine(socketserver.ThreadingMixIn,
 
     def start_channels(self):
         self.channel_config_loader.load_all_channels()
+
+        if not self.channel_config_loader.get_channels():
+            self.logger.info("No channel configurations available in " +
+                             f"{self.channel_config_loader.channel_config_dir}")
+
         for name, config in self.channel_config_loader.get_channels().items():
             try:
                 self.start_channel(name, config)
@@ -452,9 +457,6 @@ def _get_de_conf_manager(global_config_dir, channel_config_dir, options):
 
     global_config = _get_global_config(config_file, options)
     conf_manager = ChannelConfigHandler.ChannelConfigHandler(global_config, channel_config_dir)
-
-    if not conf_manager.get_channels():
-        logging.info(f"No channel configurations available in {channel_config_dir}")
 
     return (global_config, conf_manager)
 


### PR DESCRIPTION
There were two problems that brought about this error:

1. An attempt was made to acccess the channel configurations before they were loaded.
2. Because of 1, a message was logged before the default error logger had been set.  In such a circumstance, the logging module will create a StreamHandler object that routes messages to STDERR with a severity threshold of WARNING.

These issues were addressed by accessing the channel configurations after they have been loaded, and then using the DecisionEngine logger instance variable to route messages when necessary.