### PR TITLE
Test task manager

### DIFF
--- a/framework/dataspace/datasources/tests/fixtures.py
+++ b/framework/dataspace/datasources/tests/fixtures.py
@@ -1,11 +1,11 @@
 '''pytest fixtures/constants'''
+import os
+import threading
+from collections import UserDict
+
 import mock
 import pytest
 from pytest_postgresql import factories
-
-from collections import UserDict
-import os
-import threading
 
 DE_DB_HOST = '127.0.0.1'
 DE_DB_USER = 'postgres'
@@ -21,6 +21,21 @@ DE_DB = factories.postgresql('PG_PROG', db_name=DE_DB_NAME, load=DE_SCHEMA)
 
 @pytest.fixture
 def mock_data_block():
+    '''
+    This fixture replaces the standard datablock implementation.
+
+    The current DataBlock implementation does not own any data
+    products but forwards them immediately to a backend datasource.
+    The only implemented datasource requires Postgres, which is
+    overkill when needing to test simple data-product communication
+    between modules.
+
+    This mock datablock class directly owns the data products, thus
+    avoiding the need for a datasource backend.  It is anticipated
+    that a future design of the DataBlock will own the data products,
+    thus making this mock class unnecessary.
+    '''
+
     class MockDataBlock(UserDict):
         def __init__(self, products={}):
             self.lock = threading.Lock()

--- a/framework/dataspace/datasources/tests/fixtures.py
+++ b/framework/dataspace/datasources/tests/fixtures.py
@@ -1,6 +1,11 @@
 '''pytest fixtures/constants'''
-import os
+import mock
+import pytest
 from pytest_postgresql import factories
+
+from collections import UserDict
+import os
+import threading
 
 DE_DB_HOST = '127.0.0.1'
 DE_DB_USER = 'postgres'
@@ -12,3 +17,23 @@ DE_SCHEMA = [os.path.dirname(os.path.abspath(__file__)) + "/../postgresql.sql", 
 PG_PROG = factories.postgresql_proc(user=DE_DB_USER, password=DE_DB_PASS,
                                     host=DE_DB_HOST, port=None)
 DE_DB = factories.postgresql('PG_PROG', db_name=DE_DB_NAME, load=DE_SCHEMA)
+
+
+@pytest.fixture
+def mock_data_block():
+    class MockDataBlock(UserDict):
+        def __init__(self, products={}):
+            self.lock = threading.Lock()
+            self.taskmanager_id = None
+            self.generation_id = 1
+            self.data = products
+
+        def duplicate(self):
+            return MockDataBlock(self.data)
+
+        def put(self, key, product, header, metadata=None):
+            self.data[key] = product
+
+    with mock.patch('decisionengine.framework.dataspace.datablock.DataBlock') as mock_data_block:
+        mock_data_block.return_value = MockDataBlock()
+        yield

--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -15,7 +15,6 @@ import multiprocessing
 import pandas as pd
 import os
 import tabulate
-import uuid
 
 import socketserver
 import xmlrpc.server
@@ -282,9 +281,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
 
     def start_channel(self, channel_name, channel_config):
         generation_id = 1
-        taskmanager_id = str(uuid.uuid4()).upper()
         task_manager = TaskManager.TaskManager(channel_name,
-                                               taskmanager_id,
                                                generation_id,
                                                channel_config,
                                                self.global_config)

--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -28,13 +28,14 @@ CONFIG_UPDATE_PERIOD = 10  # seconds
 FORMATTER = logging.Formatter(
     "%(asctime)s - %(name)s - %(module)s - %(process)d - %(threadName)s - %(levelname)s - %(message)s")
 
+
 def _channel_preamble(name):
     header = f'Channel: {name}'
     rule = '=' * len(header)
     return '\n' + rule + '\n' + header + '\n' + rule + '\n\n'
 
 
-class WorkerInErrorState():
+class WorkerInErrorState:
     def __init__(self, task_manager_id):
         self.task_manager_id = task_manager_id
 
@@ -43,6 +44,7 @@ class WorkerInErrorState():
 
     def is_alive(self):
         return False
+
 
 class Worker(multiprocessing.Process):
 
@@ -419,6 +421,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
     def service_actions(self):
         self._disable_channels_with_terminated_processes()
 
+
 def parse_program_options(args=None):
     ''' If args is a list, it will be used instead of sys.argv '''
     parser = argparse.ArgumentParser()
@@ -435,6 +438,7 @@ def parse_program_options(args=None):
                         f"'{policies.GLOBAL_CONFIG_FILENAME}' located in the CONFIG_PATH directory.")
     return parser.parse_args(args)
 
+
 def _get_global_config(config_file, options):
     global_config = None
     try:
@@ -443,9 +447,10 @@ def _get_global_config(config_file, options):
         sys.exit(f"Failed to load configuration {config_file}\n{msg}")
 
     global_config.update({
-        'server_address': ['localhost', options.port] # Use Jsonnet-supported schema (i.e. not a tuple)
+        'server_address': ['localhost', options.port]  # Use Jsonnet-supported schema (i.e. not a tuple)
     })
     return global_config
+
 
 def _get_de_conf_manager(global_config_dir, channel_config_dir, options):
     config_file = os.path.join(global_config_dir, options.config)
@@ -457,6 +462,7 @@ def _get_de_conf_manager(global_config_dir, channel_config_dir, options):
 
     return (global_config, conf_manager)
 
+
 def _start_de_server(global_config, channel_config_loader):
     '''start the DE server with the passed global configuration and config manager'''
     server_address = tuple(global_config.get('server_address'))
@@ -466,6 +472,7 @@ def _start_de_server(global_config, channel_config_loader):
     server.reaper_start(delay=global_config['dataspace'].get('reaper_start_delay_seconds', 1818))
     server.start_channels()
     server.serve_forever()
+
 
 def main(args=None):
     '''

--- a/framework/taskmanager/TaskManager.py
+++ b/framework/taskmanager/TaskManager.py
@@ -14,8 +14,9 @@ import uuid
 from decisionengine.framework.dataspace import dataspace
 from decisionengine.framework.dataspace import datablock
 
-_TRANSFORMS_TO = 300 # 5 minutes
-_DEFAULT_SCHEDULE = 300 # ""
+_TRANSFORMS_TO = 300  # 5 minutes
+_DEFAULT_SCHEDULE = 300  # ""
+
 
 def _create_worker(module_name, class_name, parameters):
     """
@@ -25,7 +26,8 @@ def _create_worker(module_name, class_name, parameters):
     class_type = getattr(my_module, class_name)
     return class_type(parameters)
 
-class Worker():
+
+class Worker:
     """
     Provides interface to loadable modules an events to sycronise
     execution
@@ -47,10 +49,12 @@ class Worker():
         self.data_updated = threading.Event()
         self.stop_running = threading.Event()
 
+
 def _make_workers_for(configs):
     return {name: Worker(e) for name, e in configs.items()}
 
-class Channel():
+
+class Channel:
     """
     Decision Channel.
     Instantiates workers according to channel configuration
@@ -76,15 +80,16 @@ class State(enum.Enum):
     SHUTTINGDOWN = 3
     SHUTDOWN = 4
 
-class TaskManager():
+
+class TaskManager:
     """
     Task Manager
     """
 
     def __init__(self, name, generation_id, channel_dict, global_config):
         """
-        :type task_manager_id: :obj:`int`
-        :arg task_manager_id: Task Manager id provided by caller
+        :type name: :obj:`str`
+        :arg name: Name of channel corresponding to this task manager
         :type generation_id: :obj:`int`
         :arg generation_id: Task Manager generation id provided by caller
         :type channel_dict: :obj:`dict`
@@ -181,7 +186,6 @@ class TaskManager():
                                           self.id, self.get_state_name())
                 break
             time.sleep(1)
-
 
     def set_state(self, state):
         with self.state.get_lock():
@@ -280,7 +284,6 @@ class TaskManager():
             except Exception as e:
                 logging.getLogger().exception(f'error in decision cycle(publishers) {e}')
                 self._take_offline(data_block_t1)
-
 
     def run_source(self, src):
         """

--- a/framework/taskmanager/TaskManager.py
+++ b/framework/taskmanager/TaskManager.py
@@ -9,6 +9,7 @@ import time
 import sys
 import multiprocessing
 import pandas
+import uuid
 
 from decisionengine.framework.dataspace import dataspace
 from decisionengine.framework.dataspace import datablock
@@ -80,7 +81,7 @@ class TaskManager():
     Task Manager
     """
 
-    def __init__(self, name, task_manager_id, generation_id, channel_dict, global_config):
+    def __init__(self, name, generation_id, channel_dict, global_config):
         """
         :type task_manager_id: :obj:`int`
         :arg task_manager_id: Task Manager id provided by caller
@@ -91,13 +92,13 @@ class TaskManager():
         :type global_config: :obj:`dict`
         :arg global_config: global configuration
          """
+        self.id = str(uuid.uuid4()).upper()
         self.dataspace = dataspace.DataSpace(global_config)
         self.data_block_t0 = datablock.DataBlock(self.dataspace,
                                                  name,
-                                                 task_manager_id,
+                                                 self.id,
                                                  generation_id)  # my current data block
         self.name = name
-        self.id = task_manager_id
         self.channel = Channel(channel_dict)
         self.state = multiprocessing.Value('i', State.BOOT.value)
         self.loglevel = multiprocessing.Value('i', logging.WARNING)

--- a/framework/taskmanager/tests/channels/failing_publisher.jsonnet
+++ b/framework/taskmanager/tests/channels/failing_publisher.jsonnet
@@ -1,0 +1,42 @@
+{
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.SourceNOP",
+      name: "SourceNOP",
+      parameters: {},
+      schedule: 1,
+     }
+   },
+
+  transforms: {
+    bar_maker: {
+      module: "decisionengine.framework.tests.TransformNOP",
+      name: "TransformNOP",
+      parameters: {}
+    }
+  },
+  logicengines: {
+    le: {
+      module: "decisionengine.framework.logicengine.LogicEngine",
+      name: 'LogicEngine',
+      parameters: {
+        facts: {
+          pass_all: "(True)"
+        },
+        rules: {
+          r1: {
+            expression: 'pass_all',
+            actions: ['fail']
+          }
+        }
+      }
+    }
+  },
+  publishers: {
+    fail: {
+      module: "decisionengine.framework.tests.FailingPublisher",
+      name: "FailingPublisher",
+      parameters: {}
+    }
+  }
+}

--- a/framework/taskmanager/tests/channels/test_channel.jsonnet
+++ b/framework/taskmanager/tests/channels/test_channel.jsonnet
@@ -1,0 +1,22 @@
+{
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.SourceNOP",
+      name: "SourceNOP",
+      parameters: {},
+      schedule: 1,
+     }
+   },
+
+   transforms: {
+     transform1: {
+       module: "decisionengine.framework.tests.TransformNOP",
+       name : "TransformNOP",
+       parameters: {},
+       schedule: 1
+     }
+   },
+
+  logicengines: {},
+  publishers: {}
+}

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -1,0 +1,48 @@
+from decisionengine.framework.engine.DecisionEngine import _get_de_conf_manager, _start_de_server, parse_program_options
+from decisionengine.framework.taskmanager.TaskManager import TaskManager, State
+from decisionengine.framework.util.sockets import get_random_port
+
+import os
+import pytest
+import threading
+import time
+import uuid
+
+_CWD = os.path.dirname(os.path.abspath(__file__))
+_CONFIG_PATH = os.path.join(_CWD, "../../tests/etc/decisionengine")
+_CHANNEL_CONFIG_DIR = os.path.join(_CONFIG_PATH, 'config.d')
+
+_port = get_random_port()
+
+@pytest.fixture(scope="module")
+def config():
+    global_config, channel_config_handler = _get_de_conf_manager(_CONFIG_PATH,
+                                                                 _CHANNEL_CONFIG_DIR,
+                                                                 parse_program_options([f'--port={_port}']))
+    channel_config_handler.load_all_channels()
+    return (global_config, channel_config_handler.get_channels())
+
+def run(task_manager):
+    task_manager.run()
+
+def test_task_manager_construction(config):
+    global_config, channel_configs = config
+    task_manager_id = str(uuid.uuid4()).upper()
+    generation_id = 1
+    assert len(channel_configs) == 1
+    channel_name = list(channel_configs.keys())[0]
+    assert channel_name == 'test_channel'
+    task_manager = TaskManager(channel_name,
+                               task_manager_id,
+                               generation_id,
+                               channel_configs[channel_name],
+                               global_config)
+    assert task_manager.get_state() == State.BOOT
+    thread = threading.Thread(target=run,
+                              args=(task_manager,))
+    thread.start()
+    time.sleep(3)
+    assert task_manager.get_state() == State.STEADY
+    task_manager._take_offline(None)
+    assert task_manager.get_state() == State.OFFLINE
+    thread.join()

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -1,11 +1,12 @@
-import os
 import multiprocessing
+import os
 import time
 
-from decisionengine.framework.config.ValidConfig import ValidConfig
 import decisionengine.framework.config.policies as policies
-from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block # noqa: F401
-from decisionengine.framework.taskmanager.TaskManager import TaskManager, State
+from decisionengine.framework.config.ValidConfig import ValidConfig
+from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block  # noqa: F401
+from decisionengine.framework.taskmanager.TaskManager import State
+from decisionengine.framework.taskmanager.TaskManager import TaskManager
 
 _CWD = os.path.dirname(os.path.abspath(__file__))
 _CONFIG_PATH = os.path.join(_CWD, "../../tests/etc/decisionengine")
@@ -17,8 +18,10 @@ _global_config = ValidConfig(policies.global_config_file(_CONFIG_PATH))
 def channel_config(name):
     return ValidConfig(os.path.join(_CHANNEL_CONFIG_DIR, name + '.jsonnet'))
 
+
 def task_manager_for(name):
     return TaskManager(name, 1, channel_config(name), _global_config)
+
 
 class RunChannel:
     def __init__(self, name):
@@ -35,18 +38,20 @@ class RunChannel:
             return False
 
 
-def test_task_manager_construction(mock_data_block): # noqa: F811
+def test_task_manager_construction(mock_data_block):  # noqa: F811
     task_manager = task_manager_for('test_channel')
     assert task_manager.get_state() == State.BOOT
 
-def test_take_task_manager_offline(mock_data_block): # noqa: F811
+
+def test_take_task_manager_offline(mock_data_block):  # noqa: F811
     with RunChannel('test_channel') as task_manager:
         time.sleep(2)
         assert task_manager.get_state() == State.STEADY
         task_manager._take_offline(None)
         assert task_manager.get_state() == State.OFFLINE
 
-def test_failing_publisher(mock_data_block): # noqa: F811
+
+def test_failing_publisher(mock_data_block):  # noqa: F811
     with RunChannel('failing_publisher') as task_manager:
         time.sleep(2)
         assert task_manager.get_state() == State.OFFLINE

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -1,46 +1,49 @@
-from decisionengine.framework.engine.DecisionEngine import _get_de_conf_manager, _start_de_server, parse_program_options
+from decisionengine.framework.config.ValidConfig import ValidConfig
+import decisionengine.framework.config.policies as policies
 from decisionengine.framework.taskmanager.TaskManager import TaskManager, State
-from decisionengine.framework.util.sockets import get_random_port
 
 import os
-import pytest
 import threading
 import time
 import uuid
 
 _CWD = os.path.dirname(os.path.abspath(__file__))
 _CONFIG_PATH = os.path.join(_CWD, "../../tests/etc/decisionengine")
-_CHANNEL_CONFIG_DIR = os.path.join(_CONFIG_PATH, 'config.d')
+_CHANNEL_CONFIG_DIR = os.path.join(_CWD, 'channels')
 
-_port = get_random_port()
+_global_config = ValidConfig(policies.global_config_file(_CONFIG_PATH))
 
-@pytest.fixture(scope="module")
-def config():
-    global_config, channel_config_handler = _get_de_conf_manager(_CONFIG_PATH,
-                                                                 _CHANNEL_CONFIG_DIR,
-                                                                 parse_program_options([f'--port={_port}']))
-    channel_config_handler.load_all_channels()
-    return (global_config, channel_config_handler.get_channels())
+def channel_config(name):
+    return ValidConfig(os.path.join(_CHANNEL_CONFIG_DIR, name + '.jsonnet'))
 
-def run(task_manager):
-    task_manager.run()
+def task_manager_for(name):
+    return TaskManager(name, 1, channel_config(name), _global_config)
 
-def test_task_manager_construction(config):
-    global_config, channel_configs = config
-    generation_id = 1
-    assert len(channel_configs) == 1
-    channel_name = list(channel_configs.keys())[0]
-    assert channel_name == 'test_channel'
-    task_manager = TaskManager(channel_name,
-                               generation_id,
-                               channel_configs[channel_name],
-                               global_config)
+class RunChannel():
+    def __init__(self, name):
+        self._tm = task_manager_for(name)
+        self._thread = threading.Thread(target=self._tm.run)
+
+    def __enter__(self):
+        self._thread.start()
+        return self._tm
+
+    def __exit__(self, type, value, traceback):
+        self._thread.join()
+
+
+def test_task_manager_construction():
+    task_manager = task_manager_for('test_channel')
     assert task_manager.get_state() == State.BOOT
-    thread = threading.Thread(target=run,
-                              args=(task_manager,))
-    thread.start()
-    time.sleep(3)
-    assert task_manager.get_state() == State.STEADY
-    task_manager._take_offline(None)
-    assert task_manager.get_state() == State.OFFLINE
-    thread.join()
+
+def test_take_task_manager_offline():
+    with RunChannel('test_channel') as task_manager:
+        time.sleep(3)
+        assert task_manager.get_state() == State.STEADY
+        task_manager._take_offline(None)
+        assert task_manager.get_state() == State.OFFLINE
+
+def test_failing_publisher():
+    with RunChannel('failing_publisher') as task_manager:
+        time.sleep(3)
+        assert task_manager.get_state() == State.OFFLINE

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -1,40 +1,17 @@
-from collections import UserDict
-import mock
 import os
 import multiprocessing
-import pytest
-import threading
 import time
 
 from decisionengine.framework.config.ValidConfig import ValidConfig
 import decisionengine.framework.config.policies as policies
+from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block # pylint: disable=unused-import
 from decisionengine.framework.taskmanager.TaskManager import TaskManager, State
-import decisionengine.framework.dataspace.datablock
 
 _CWD = os.path.dirname(os.path.abspath(__file__))
 _CONFIG_PATH = os.path.join(_CWD, "../../tests/etc/decisionengine")
 _CHANNEL_CONFIG_DIR = os.path.join(_CWD, 'channels')
 
 _global_config = ValidConfig(policies.global_config_file(_CONFIG_PATH))
-
-class MockDataBlock(UserDict):
-    def __init__(self, products={}):
-        self.lock = threading.Lock()
-        self.taskmanager_id = None
-        self.generation_id = 1
-        self.data = products
-
-    def duplicate(self):
-        return MockDataBlock(self.data)
-
-    def put(self, key, product, header, metadata=None):
-        self.data[key] = product
-
-@pytest.fixture
-def mock_data_block():
-    with mock.patch('decisionengine.framework.dataspace.datablock.DataBlock') as mock_data_block:
-        mock_data_block.return_value = MockDataBlock()
-        yield
 
 
 def channel_config(name):
@@ -56,6 +33,7 @@ class RunChannel:
         self._process.join()
         if type:
             return False
+
 
 def test_task_manager_construction(mock_data_block):
     task_manager = task_manager_for('test_channel')

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -43,7 +43,7 @@ def channel_config(name):
 def task_manager_for(name):
     return TaskManager(name, 1, channel_config(name), _global_config)
 
-class RunChannel():
+class RunChannel:
     def __init__(self, name):
         self._tm = task_manager_for(name)
         self._process = multiprocessing.Process(target=self._tm.run)

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -27,13 +27,11 @@ def run(task_manager):
 
 def test_task_manager_construction(config):
     global_config, channel_configs = config
-    task_manager_id = str(uuid.uuid4()).upper()
     generation_id = 1
     assert len(channel_configs) == 1
     channel_name = list(channel_configs.keys())[0]
     assert channel_name == 'test_channel'
     task_manager = TaskManager(channel_name,
-                               task_manager_id,
                                generation_id,
                                channel_configs[channel_name],
                                global_config)

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -1,17 +1,41 @@
+from collections import UserDict
+import mock
+import os
+import multiprocessing
+import pytest
+import threading
+import time
+
 from decisionengine.framework.config.ValidConfig import ValidConfig
 import decisionengine.framework.config.policies as policies
 from decisionengine.framework.taskmanager.TaskManager import TaskManager, State
-
-import os
-import threading
-import time
-import uuid
+import decisionengine.framework.dataspace.datablock
 
 _CWD = os.path.dirname(os.path.abspath(__file__))
 _CONFIG_PATH = os.path.join(_CWD, "../../tests/etc/decisionengine")
 _CHANNEL_CONFIG_DIR = os.path.join(_CWD, 'channels')
 
 _global_config = ValidConfig(policies.global_config_file(_CONFIG_PATH))
+
+class MockDataBlock(UserDict):
+    def __init__(self, products={}):
+        self.lock = threading.Lock()
+        self.taskmanager_id = None
+        self.generation_id = 1
+        self.data = products
+
+    def duplicate(self):
+        return MockDataBlock(self.data)
+
+    def put(self, key, product, header, metadata=None):
+        self.data[key] = product
+
+@pytest.fixture
+def mock_data_block():
+    with mock.patch('decisionengine.framework.dataspace.datablock.DataBlock') as mock_data_block:
+        mock_data_block.return_value = MockDataBlock()
+        yield
+
 
 def channel_config(name):
     return ValidConfig(os.path.join(_CHANNEL_CONFIG_DIR, name + '.jsonnet'))
@@ -22,28 +46,29 @@ def task_manager_for(name):
 class RunChannel():
     def __init__(self, name):
         self._tm = task_manager_for(name)
-        self._thread = threading.Thread(target=self._tm.run)
+        self._process = multiprocessing.Process(target=self._tm.run)
 
     def __enter__(self):
-        self._thread.start()
+        self._process.start()
         return self._tm
 
     def __exit__(self, type, value, traceback):
-        self._thread.join()
+        self._process.join()
+        if type:
+            return False
 
-
-def test_task_manager_construction():
+def test_task_manager_construction(mock_data_block):
     task_manager = task_manager_for('test_channel')
     assert task_manager.get_state() == State.BOOT
 
-def test_take_task_manager_offline():
+def test_take_task_manager_offline(mock_data_block):
     with RunChannel('test_channel') as task_manager:
-        time.sleep(3)
+        time.sleep(2)
         assert task_manager.get_state() == State.STEADY
         task_manager._take_offline(None)
         assert task_manager.get_state() == State.OFFLINE
 
-def test_failing_publisher():
+def test_failing_publisher(mock_data_block):
     with RunChannel('failing_publisher') as task_manager:
-        time.sleep(3)
+        time.sleep(2)
         assert task_manager.get_state() == State.OFFLINE

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -4,7 +4,7 @@ import time
 
 from decisionengine.framework.config.ValidConfig import ValidConfig
 import decisionengine.framework.config.policies as policies
-from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block # pylint: disable=unused-import
+from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block # noqa: F401
 from decisionengine.framework.taskmanager.TaskManager import TaskManager, State
 
 _CWD = os.path.dirname(os.path.abspath(__file__))
@@ -35,18 +35,18 @@ class RunChannel:
             return False
 
 
-def test_task_manager_construction(mock_data_block):
+def test_task_manager_construction(mock_data_block): # noqa: F811
     task_manager = task_manager_for('test_channel')
     assert task_manager.get_state() == State.BOOT
 
-def test_take_task_manager_offline(mock_data_block):
+def test_take_task_manager_offline(mock_data_block): # noqa: F811
     with RunChannel('test_channel') as task_manager:
         time.sleep(2)
         assert task_manager.get_state() == State.STEADY
         task_manager._take_offline(None)
         assert task_manager.get_state() == State.OFFLINE
 
-def test_failing_publisher(mock_data_block):
+def test_failing_publisher(mock_data_block): # noqa: F811
     with RunChannel('failing_publisher') as task_manager:
         time.sleep(2)
         assert task_manager.get_state() == State.OFFLINE

--- a/framework/tests/FailingPublisher.py
+++ b/framework/tests/FailingPublisher.py
@@ -1,0 +1,15 @@
+from decisionengine.framework.modules import Publisher
+
+CONSUMES = ["bar"]
+
+
+class FailingPublisher(Publisher.Publisher):
+
+    def __init__(self, config):
+        super().__init__(config)
+
+    def publish(self, data_block):
+        raise RuntimeError("Test error-handling")
+
+    def consumes(self, name_list):
+        return CONSUMES

--- a/framework/tests/test_restart_channel.py
+++ b/framework/tests/test_restart_channel.py
@@ -1,0 +1,55 @@
+import multiprocessing
+import pathlib
+import os
+import re
+import time
+
+import pytest
+
+import decisionengine.framework.engine.de_client as de_client
+from decisionengine.framework.engine.DecisionEngine import _get_de_conf_manager, _start_de_server, parse_program_options
+from decisionengine.framework.util.sockets import get_random_port
+from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block # noqa: F401
+
+_this_dir = pathlib.Path(__file__).parent.resolve()
+_CONFIG_PATH = os.path.join(_this_dir, "etc/decisionengine")
+_CHANNEL_CONFIG_PATH = os.path.join(_CONFIG_PATH, 'config.d')
+
+_port = get_random_port()
+
+def run_server():
+    global_config, channel_config_handler = _get_de_conf_manager(_CONFIG_PATH,
+                                                                 _CHANNEL_CONFIG_PATH,
+                                                                 parse_program_options([f'--port={_port}']))
+    _start_de_server(global_config, channel_config_handler)
+
+def de_client_request(*args):
+    return de_client.main([f"--port={_port}", *args])
+
+@pytest.fixture
+def deserver_mock_data_block(mock_data_block): # noqa: F811
+    worker = multiprocessing.Process(target=run_server)
+    worker.start()
+    time.sleep(2) # Make sure channels have enough time to start
+    yield
+    de_client_request("--stop")
+    worker.terminate()
+
+# Because pytest will reorder the tests based on the method name,
+# we implement the whole 'workflow' as one unit test.
+def test_restart_channel(deserver_mock_data_block):
+    # Verify that nothing is active
+    output = de_client_request("--status")
+    assert re.search('test_channel.*state = STEADY', output)
+
+    # Take channel offline
+    output = de_client_request('--stop-channel', 'test_channel')
+    assert output == 'OK'
+
+    # Verify no channels are active
+    output = de_client_request("--status")
+    assert "No channels are currently active" in output
+
+    # Take channel offline
+    output = de_client_request('--start-channel', 'test_channel')
+    assert output == 'OK'

--- a/framework/tests/test_restart_channel.py
+++ b/framework/tests/test_restart_channel.py
@@ -1,15 +1,17 @@
 import multiprocessing
-import pathlib
 import os
+import pathlib
 import re
 import time
 
 import pytest
 
 import decisionengine.framework.engine.de_client as de_client
-from decisionengine.framework.engine.DecisionEngine import _get_de_conf_manager, _start_de_server, parse_program_options
+from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block  # noqa: F401
+from decisionengine.framework.engine.DecisionEngine import _get_de_conf_manager
+from decisionengine.framework.engine.DecisionEngine import _start_de_server
+from decisionengine.framework.engine.DecisionEngine import parse_program_options
 from decisionengine.framework.util.sockets import get_random_port
-from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block # noqa: F401
 
 _this_dir = pathlib.Path(__file__).parent.resolve()
 _CONFIG_PATH = os.path.join(_this_dir, "etc/decisionengine")
@@ -17,23 +19,27 @@ _CHANNEL_CONFIG_PATH = os.path.join(_CONFIG_PATH, 'config.d')
 
 _port = get_random_port()
 
+
 def run_server():
     global_config, channel_config_handler = _get_de_conf_manager(_CONFIG_PATH,
                                                                  _CHANNEL_CONFIG_PATH,
                                                                  parse_program_options([f'--port={_port}']))
     _start_de_server(global_config, channel_config_handler)
 
+
 def de_client_request(*args):
     return de_client.main([f"--port={_port}", *args])
 
+
 @pytest.fixture
-def deserver_mock_data_block(mock_data_block): # noqa: F811
+def deserver_mock_data_block(mock_data_block):  # noqa: F811
     worker = multiprocessing.Process(target=run_server)
     worker.start()
-    time.sleep(2) # Make sure channels have enough time to start
+    time.sleep(2)  # Make sure channels have enough time to start
     yield
     de_client_request("--stop")
     worker.terminate()
+
 
 # Because pytest will reorder the tests based on the method name,
 # we implement the whole 'workflow' as one unit test.


### PR DESCRIPTION
This PR builds off of the fixtures that Pat put in place.  In particular, it:

- Introduces the `mock_data_block` fixture, which, when used, obviates the need for a Postgres DB backend.
- Adds a `FailingProducer` module, which tests the error-handling of the task manager.
- Encapsulates some `TaskManager` innards.