### PR TITLE
Fix coveralls reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 # .coveragerc to control coverage.py
 
 [run]
+concurrency = multiprocessing
 branch = True
 source = framework
 omit = */tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,6 @@ install:
 # command to run tests
 script:
   - cd ${TRAVIS_BUILD_DIR}
-  - coverage run -m pytest -v -l --durations=0 --tb=native ${TRAVIS_BUILD_DIR}/../
+  - coverage run -p -m pytest -v -l --durations=0 --tb=native ${TRAVIS_BUILD_DIR}/../
   - coverage combine
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,5 +91,5 @@ install:
 script:
   - cd ${TRAVIS_BUILD_DIR}
   - coverage run -m pytest -v -l --durations=0 --tb=native ${TRAVIS_BUILD_DIR}/../
-
+  - coverage combine
   - coveralls

--- a/framework/taskmanager/TaskManager.py
+++ b/framework/taskmanager/TaskManager.py
@@ -294,7 +294,8 @@ class TaskManager:
         :arg src: source Worker
         """
 
-        while True:
+        # If task manager is in offline state, do not keep executing sources.
+        while self.get_state() != State.OFFLINE:
             try:
                 logging.getLogger().info(f'Src {src.name} calling acquire')
                 data = src.worker.acquire()
@@ -385,7 +386,7 @@ class TaskManager:
         logging.getLogger().info('transform: %s expected keys: %s provided keys: %s',
                                  transform.name, consume_keys, list(data_block.keys()))
         loop_counter = 0
-        while True:
+        while self.get_state() != State.OFFLINE:
             # Check if data is ready
             if set(consume_keys) <= set(data_block.keys()):
                 # data is ready -  may run transform()

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -33,9 +33,10 @@ class RunChannel:
         return self._tm
 
     def __exit__(self, type, value, traceback):
-        self._process.join()
         if type:
+            self._process.terminate()
             return False
+        self._process.join()
 
 
 def test_task_manager_construction(mock_data_block):  # noqa: F811

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -47,12 +47,19 @@ def test_task_manager_construction(mock_data_block):  # noqa: F811
 def test_take_task_manager_offline(mock_data_block):  # noqa: F811
     with RunChannel('test_channel') as task_manager:
         time.sleep(2)
-        assert task_manager.get_state() == State.STEADY
+        task_state = task_manager.get_state()
+        if task_state != State.STEADY:
+            time.sleep(2)  # extra sleep if test host is overloaded
+            task_state = task_manager.get_state()
+        assert task_state == State.STEADY
         task_manager._take_offline(None)
         assert task_manager.get_state() == State.OFFLINE
 
 
 def test_failing_publisher(mock_data_block):  # noqa: F811
     with RunChannel('failing_publisher') as task_manager:
-        time.sleep(2)
+        task_state = task_manager.get_state()
+        if task_state != State.OFFLINE:
+            time.sleep(5)  # extra sleep if test host is overloaded
+            task_state = task_manager.get_state()
         assert task_manager.get_state() == State.OFFLINE

--- a/framework/tests/test_restart_channel.py
+++ b/framework/tests/test_restart_channel.py
@@ -46,6 +46,10 @@ def deserver_mock_data_block(mock_data_block):  # noqa: F811
 def test_restart_channel(deserver_mock_data_block):
     # Verify that nothing is active
     output = de_client_request("--status")
+    if not re.search('test_channel.*state = STEADY', output):
+        # wait just a bit longer in case the test server is over loaded
+        time.sleep(2)
+        output = de_client_request("--status")
     assert re.search('test_channel.*state = STEADY', output)
 
     # Take channel offline


### PR DESCRIPTION
After #196 was merged, it seemed odd to me that the coveralls report suggested that much of the `TaskManager` code had not been exercised.   Upon further investigation, it became clear this was because the `multiprocessing` concurrency option was not chosen--the DE relies heavily on the `multiprocessing` facilities.

This PR changes the coverage 'concurrency' option to 'multiprocessing'.  In this case the `coveralls combine` must be called.  The resulting report (at least for the `test_task_manager` unit test) now looks accurate).  I'd like @jcpunk to review this.