### PR TITLE
Address data races; remove need to sleep in unit tests

### DIFF
--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -302,9 +302,9 @@ class DecisionEngine(socketserver.ThreadingMixIn,
         return txt + self.reaper_status()
 
     def rpc_stop(self):
-        self.reaper_stop()
-        self.stop_channels()
         self.shutdown()
+        self.stop_channels()
+        self.reaper_stop()
         return "OK"
 
     def start_channel(self, channel_name, channel_config):

--- a/framework/engine/de_client.py
+++ b/framework/engine/de_client.py
@@ -3,6 +3,7 @@
 import argparse
 import xmlrpc.client
 
+
 def create_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -19,7 +20,6 @@ def create_parser():
         '-v', '--verbose',
         action='store_true',
         help="Include exception message in printout if server is inaccessible")
-
 
     server = parser.add_argument_group("Decision Engine server options")
     server.add_argument(
@@ -38,6 +38,9 @@ def create_parser():
         "--print-engine-loglevel",
         action='store_true',
         help="print engine log level")
+    server.add_argument(
+        "--block-while",
+        metavar='<state>')
 
     channels = parser.add_argument_group("Channel-specific options")
     channels.add_argument(
@@ -109,6 +112,7 @@ def create_parser():
 
     return parser
 
+
 def execute_command_from_args(argsparsed, de_socket):
     '''argsparsed should be from create_parser in this file'''
 
@@ -121,6 +125,8 @@ def execute_command_from_args(argsparsed, de_socket):
         return de_socket.stop()
     if argsparsed.print_engine_loglevel:
         return de_socket.get_log_level()
+    if argsparsed.block_while:
+        return de_socket.block_while(argsparsed.block_while)
 
     # Channel-specific options
     if argsparsed.stop_channel:
@@ -160,6 +166,7 @@ def execute_command_from_args(argsparsed, de_socket):
         return de_socket.reaper_start(argsparsed.reaper_start_delay_secs)
     if argsparsed.reaper_status:
         return de_socket.reaper_status()
+
 
 def main(args_to_parse=None):
     '''If you pass a list of args, they will be used instead of sys.argv'''

--- a/framework/taskmanager/ProcessingState.py
+++ b/framework/taskmanager/ProcessingState.py
@@ -1,0 +1,63 @@
+'''
+The ProcessingState class can represent any of the following task-manager states:
+
+  BOOT
+  STEADY
+  OFFLINE
+  SHUTTINGDOWN
+  SHUTDOWN
+  ERROR
+
+In addition, the class supports 'wait_until(state)' and 'wait_while(state)' methods,
+which, when called from a different process, block until the state has been entered
+or exited, respectively.
+'''
+
+import enum
+import multiprocessing
+
+
+class State(enum.Enum):
+    BOOT = 0
+    STEADY = 1
+    OFFLINE = 2
+    SHUTTINGDOWN = 3
+    SHUTDOWN = 4
+    ERROR = 5
+
+
+class ProcessingState:
+    def __init__(self, state=State.BOOT):
+        allowed_state = State(state)
+        self._cv = multiprocessing.Condition()
+        self._state = multiprocessing.Value('i', allowed_state.value)
+
+    def get(self):
+        value = None
+        with self._state.get_lock():
+            value = self._state.value
+        return State(value)
+
+    def set(self, state):
+        if not isinstance(state, State):
+            raise RuntimeError('Supplied value is not a State variable.')
+        with self._cv, self._state.get_lock():
+            self._state.value = state.value
+            self._cv.notify()
+
+    def has_value(self, state):
+        if not isinstance(state, State):
+            raise RuntimeError('Supplied value is not a State variable.')
+        return self.get() == state
+
+    def wait_until(self, state):
+        with self._cv:
+            self._cv.wait_for(lambda: self.has_value(state))
+
+    def wait_while(self, state):
+        with self._cv:
+            self._cv.wait_for(lambda: not self.has_value(state))
+
+    def should_stop(self):
+        value = self.get().value
+        return value > State.STEADY.value

--- a/framework/taskmanager/tests/test_processing_state.py
+++ b/framework/taskmanager/tests/test_processing_state.py
@@ -1,0 +1,53 @@
+import multiprocessing
+import time
+
+import pytest
+
+from decisionengine.framework.taskmanager.ProcessingState import State
+from decisionengine.framework.taskmanager.ProcessingState import ProcessingState
+
+
+class Worker(multiprocessing.Process):
+    def __init__(self, state):
+        super().__init__()
+        self._state = state
+
+    def run(self):
+        time.sleep(2)
+        self._state.set(State.STEADY)
+
+
+def test_shared_state_construction():
+    state = ProcessingState()
+    assert state.has_value(State.BOOT)
+    state = ProcessingState(State.STEADY)
+    assert state.has_value(State.STEADY)
+
+
+def test_wrong_value_on_creation():
+    with pytest.raises(Exception, match='1\\.3 is not a valid State'):
+        ProcessingState(1.3)
+
+
+def test_wrong_value_on_assignment():
+    state = ProcessingState()
+    with pytest.raises(Exception, match='Supplied value is not a State variable'):
+        state.set(1.3)
+
+
+def test_wait_until():
+    state = ProcessingState()
+    worker = Worker(state)
+    worker.start()
+    state.wait_until(State.STEADY)
+    assert state.has_value(State.STEADY)
+    worker.join()
+
+
+def test_wait_while():
+    state = ProcessingState()
+    worker = Worker(state)
+    worker.start()
+    state.wait_while(State.BOOT)
+    assert state.has_value(State.STEADY)
+    worker.join()

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -1,4 +1,4 @@
-import multiprocessing
+import threading
 import os
 
 import pytest
@@ -27,7 +27,7 @@ def task_manager_for(name):
 class RunChannel:
     def __init__(self, name):
         self._tm = task_manager_for(name)
-        self._process = multiprocessing.Process(target=self._tm.run)
+        self._process = threading.Thread(target=self._tm.run)
 
     def __enter__(self):
         self._process.start()
@@ -57,7 +57,6 @@ def test_take_task_manager_offline(mock_data_block):  # noqa: F811
 
 @pytest.mark.usefixtures("mock_data_block")
 def test_failing_publisher(mock_data_block):  # noqa: F811
-    with RunChannel('failing_publisher') as task_manager:
-        while task_manager.get_state() != State.OFFLINE:
-            pass
-        assert task_manager.get_state() == State.OFFLINE
+    task_manager = task_manager_for('failing_publisher')
+    task_manager.run()
+    assert task_manager.get_state() == State.OFFLINE

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -1,6 +1,8 @@
 import multiprocessing
 import os
 
+import pytest
+
 import decisionengine.framework.config.policies as policies
 from decisionengine.framework.config.ValidConfig import ValidConfig
 from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block  # noqa: F401
@@ -38,11 +40,13 @@ class RunChannel:
         self._process.join()
 
 
+@pytest.mark.usefixtures("mock_data_block")
 def test_task_manager_construction(mock_data_block):  # noqa: F811
     task_manager = task_manager_for('test_channel')
     assert task_manager.get_state() == State.BOOT
 
 
+@pytest.mark.usefixtures("mock_data_block")
 def test_take_task_manager_offline(mock_data_block):  # noqa: F811
     with RunChannel('test_channel') as task_manager:
         while task_manager.get_state() != State.STEADY:
@@ -51,6 +55,7 @@ def test_take_task_manager_offline(mock_data_block):  # noqa: F811
         assert task_manager.get_state() == State.OFFLINE
 
 
+@pytest.mark.usefixtures("mock_data_block")
 def test_failing_publisher(mock_data_block):  # noqa: F811
     with RunChannel('failing_publisher') as task_manager:
         while task_manager.get_state() != State.OFFLINE:

--- a/framework/taskmanager/tests/test_task_manager.py
+++ b/framework/taskmanager/tests/test_task_manager.py
@@ -1,6 +1,5 @@
 import multiprocessing
 import os
-import time
 
 import decisionengine.framework.config.policies as policies
 from decisionengine.framework.config.ValidConfig import ValidConfig
@@ -46,20 +45,14 @@ def test_task_manager_construction(mock_data_block):  # noqa: F811
 
 def test_take_task_manager_offline(mock_data_block):  # noqa: F811
     with RunChannel('test_channel') as task_manager:
-        time.sleep(2)
-        task_state = task_manager.get_state()
-        if task_state != State.STEADY:
-            time.sleep(2)  # extra sleep if test host is overloaded
-            task_state = task_manager.get_state()
-        assert task_state == State.STEADY
+        while task_manager.get_state() != State.STEADY:
+            pass
         task_manager._take_offline(None)
         assert task_manager.get_state() == State.OFFLINE
 
 
 def test_failing_publisher(mock_data_block):  # noqa: F811
     with RunChannel('failing_publisher') as task_manager:
-        task_state = task_manager.get_state()
-        if task_state != State.OFFLINE:
-            time.sleep(5)  # extra sleep if test host is overloaded
-            task_state = task_manager.get_state()
+        while task_manager.get_state() != State.OFFLINE:
+            pass
         assert task_manager.get_state() == State.OFFLINE

--- a/framework/tests/test_restart_channel.py
+++ b/framework/tests/test_restart_channel.py
@@ -1,16 +1,14 @@
-import multiprocessing
 import os
 import pathlib
 import re
-import time
 
 import pytest
 
-import decisionengine.framework.engine.de_client as de_client
 from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block  # noqa: F401
 from decisionengine.framework.engine.DecisionEngine import _get_de_conf_manager
-from decisionengine.framework.engine.DecisionEngine import _start_de_server
+from decisionengine.framework.engine.DecisionEngine import _create_de_server
 from decisionengine.framework.engine.DecisionEngine import parse_program_options
+from decisionengine.framework.taskmanager.TaskManager import State
 from decisionengine.framework.util.sockets import get_random_port
 
 _this_dir = pathlib.Path(__file__).parent.resolve()
@@ -20,46 +18,33 @@ _CHANNEL_CONFIG_PATH = os.path.join(_CONFIG_PATH, 'config.d')
 _port = get_random_port()
 
 
-def run_server():
+@pytest.fixture
+def deserver_mock_data_block(mock_data_block):  # noqa: F811
     global_config, channel_config_handler = _get_de_conf_manager(_CONFIG_PATH,
                                                                  _CHANNEL_CONFIG_PATH,
                                                                  parse_program_options([f'--port={_port}']))
-    _start_de_server(global_config, channel_config_handler)
-
-
-def de_client_request(*args):
-    return de_client.main([f"--port={_port}", *args])
-
-
-@pytest.fixture
-def deserver_mock_data_block(mock_data_block):  # noqa: F811
-    worker = multiprocessing.Process(target=run_server)
-    worker.start()
-    time.sleep(2)  # Make sure channels have enough time to start
-    yield
-    de_client_request("--stop")
-    worker.terminate()
+    server = _create_de_server(global_config, channel_config_handler)
+    server.start_channels()
+    server.block_while(State.BOOT)
+    yield server
+    server.stop_channels()
 
 
 # Because pytest will reorder the tests based on the method name,
 # we implement the whole 'workflow' as one unit test.
 def test_restart_channel(deserver_mock_data_block):
     # Verify that nothing is active
-    output = de_client_request("--status")
-    if not re.search('test_channel.*state = STEADY', output):
-        # wait just a bit longer in case the test server is over loaded
-        time.sleep(2)
-        output = de_client_request("--status")
+    output = deserver_mock_data_block.rpc_status()
     assert re.search('test_channel.*state = STEADY', output)
 
     # Take channel offline
-    output = de_client_request('--stop-channel', 'test_channel')
+    output = deserver_mock_data_block.rpc_stop_channel('test_channel')
     assert output == 'OK'
 
     # Verify no channels are active
-    output = de_client_request("--status")
+    output = deserver_mock_data_block.rpc_status()
     assert "No channels are currently active" in output
 
     # Take channel offline
-    output = de_client_request('--start-channel', 'test_channel')
+    output = deserver_mock_data_block.rpc_start_channel('test_channel')
     assert output == 'OK'

--- a/framework/tests/test_sample_config.py
+++ b/framework/tests/test_sample_config.py
@@ -1,27 +1,20 @@
 '''Fixture based DE Server tests of the defaults'''
 # pylint: disable=redefined-outer-name
 
-import time
-
 import pytest
 
-from decisionengine.framework.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA
-from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH
+from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH  # noqa: F401
 
-deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH) # pylint: disable=invalid-name
+deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH)  # pylint: disable=invalid-name
+
 
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_de_server_status(deserver):
     '''Verify channel enters stable state'''
-    # wait for a few seconds for the channels to finish starting
-    time.sleep(1)
+    deserver.de_client_run_cli('--block-while', 'BOOT'),
     output = deserver.de_client_run_cli('--status')
-    for _ in range(6): # pylint: disable=unused-variable
-        if 'BOOT' in output:
-            time.sleep(1)
-            output = deserver.de_client_run_cli('--status')
-
     assert 'state = STEADY' in output
+
 
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_de_server_show_config(deserver):
@@ -29,6 +22,7 @@ def test_client_can_get_de_server_show_config(deserver):
     output = deserver.de_client_run_cli('--show-config')
     assert 'decisionengine.framework.tests.SourceNOP' in output
     assert 'decisionengine.framework.tests.TransformNOP' in output
+
 
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_de_server_show_logger_level(deserver):

--- a/framework/tests/test_start_with_no_channels.py
+++ b/framework/tests/test_start_with_no_channels.py
@@ -5,60 +5,61 @@ import os
 import re
 import shutil
 import tempfile
-import time
 
 import pytest
 
-from decisionengine.framework.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA
-from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH
+from decisionengine.framework.engine.DecisionEngine import _get_de_conf_manager, _create_de_server, parse_program_options
+from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block  # noqa: F401
+from decisionengine.framework.taskmanager.TaskManager import State
+from decisionengine.framework.tests.fixtures import TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH
+from decisionengine.framework.util.sockets import get_random_port
+
+_port = get_random_port()
 
 EMPTY_DIR = tempfile.TemporaryDirectory()
 
-deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=EMPTY_DIR.name) # pylint: disable=invalid-name
 
-@pytest.fixture(autouse=True)
-def cleanup_tmpdir():
-    # Code to run before each test
-    if os.path.isdir(EMPTY_DIR.name):
-        shutil.rmtree(EMPTY_DIR.name)
-        os.mkdir(EMPTY_DIR.name)
+@pytest.fixture
+def deserver_mock_data_block(mock_data_block):  # noqa: F811
+    global_config, channel_config_handler = _get_de_conf_manager(TEST_CONFIG_PATH,
+                                                                 EMPTY_DIR.name,
+                                                                 parse_program_options([f'--port={_port}']))
+    server = _create_de_server(global_config, channel_config_handler)
+    server.start_channels()
+    server.block_while(State.BOOT)
+    yield server
+    server.stop_channels()
 
-    # test runs under 'yield' here
-    yield
 
-    # Code to run after each test
-    #pass
-
-@pytest.mark.usefixtures("deserver")
-def test_start_from_nothing(deserver):
-    # Because pytest will reorder the tests based on the method name,
-    # we implement the whole 'workflow' as one unit test.
+# Because pytest will reorder the tests based on the method name,
+# we implement the whole 'workflow' as one unit test.
+def test_start_from_nothing(deserver_mock_data_block):
+    deserver = deserver_mock_data_block
 
     # Verify that nothing is active
-    output = deserver.de_client_run_cli("--status")
+    output = deserver.rpc_status()
     assert "No channels are currently active" in output
 
-    output = deserver.de_client_run_cli("--print-products")
+    output = deserver.rpc_print_products()
     assert "No channels are currently active" in output
 
     # Add channel config to directory
-    channel_config = os.path.join(TEST_CHANNEL_CONFIG_PATH, 'test_channel.jsonnet') # noqa: F405
+    channel_config = os.path.join(TEST_CHANNEL_CONFIG_PATH, 'test_channel.jsonnet')  # noqa: F405
     new_config_path = shutil.copy(channel_config, EMPTY_DIR.name)
     assert os.path.exists(new_config_path)
 
     # Activate channel and check for steady state
-    output = deserver.de_client_run_cli('--start-channel', 'test_channel')
-    assert output == 'OK'
-    time.sleep(5)
-    output = deserver.de_client_run_cli('--status')
+    deserver.rpc_start_channel('test_channel')
+    deserver.block_while(State.BOOT)
+    output = deserver.rpc_status()
     assert re.search('test_channel.*state = STEADY', output)
 
     # Take channel offline
-    output = deserver.de_client_run_cli('--stop-channel', 'test_channel')
+    output = deserver.rpc_stop_channel('test_channel')
     assert output == 'OK'
 
     # Verify no channels are active
-    output = deserver.de_client_run_cli("--status")
+    output = deserver.rpc_status()
     assert "No channels are currently active" in output
 
     # Verify that the relevant configuration file still exists.


### PR DESCRIPTION
This PR adds some utilities that removes the guessing often required in doing `time.sleep(...)` calls.  In doing so, some data races were detected.  This PR addresses those.