### PR TITLE
Synchronize access to the task managers

### DIFF
--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -68,7 +68,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
     def block_until(self, state):
         with self.workers.unguarded_access() as workers:
             if not workers:
-                self.logger.info('No active task managers.')
+                self.logger.info('No active channels.')
             for tm in workers.values():
                 if tm.is_alive():
                     tm.wait_until(state)
@@ -76,7 +76,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
     def block_while(self, state):
         with self.workers.unguarded_access() as workers:
             if not workers:
-                self.logger.info('No active task managers.')
+                self.logger.info('No active channels.')
             for tm in workers.values():
                 if tm.is_alive():
                     tm.wait_while(state)
@@ -86,7 +86,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
         try:
             allowed_state = ProcessingState.State[state_str]
         except Exception:
-            return f'{state_str} is not a valid task manager state.'
+            return f'{state_str} is not a valid channel state.'
         self.block_while(allowed_state)
         return f'No channels in {state_str} state.'
 

--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -11,7 +11,6 @@ import importlib
 import logging
 import signal
 import sys
-import multiprocessing
 import pandas as pd
 import os
 import tabulate
@@ -20,77 +19,17 @@ import socketserver
 import xmlrpc.server
 
 from decisionengine.framework.config import ChannelConfigHandler, ValidConfig, policies
+from decisionengine.framework.engine.Workers import Worker, Workers
 import decisionengine.framework.dataspace.datablock as datablock
 import decisionengine.framework.dataspace.dataspace as dataspace
 import decisionengine.framework.taskmanager.ProcessingState as ProcessingState
 import decisionengine.framework.taskmanager.TaskManager as TaskManager
-
-CONFIG_UPDATE_PERIOD = 10  # seconds
-FORMATTER = logging.Formatter(
-    "%(asctime)s - %(name)s - %(module)s - %(process)d - %(threadName)s - %(levelname)s - %(message)s")
 
 
 def _channel_preamble(name):
     header = f'Channel: {name}'
     rule = '=' * len(header)
     return '\n' + rule + '\n' + header + '\n' + rule + '\n\n'
-
-
-class WorkerInErrorState:
-    def __init__(self, task_manager_id):
-        self.task_manager_id = task_manager_id
-
-    def get_state_name(self):
-        return 'ERROR'
-
-    def is_alive(self):
-        return False
-
-
-class Worker(multiprocessing.Process):
-
-    def __init__(self, task_manager, logger_config):
-        super().__init__()
-        self.task_manager = task_manager
-        self.task_manager_id = task_manager.id
-        self.logger_config = logger_config
-
-    def wait_until(self, state):
-        return self.task_manager.state.wait_until(state)
-
-    def wait_while(self, state):
-        return self.task_manager.state.wait_while(state)
-
-    def get_state_name(self):
-        return self.task_manager.get_state_name()
-
-    def run(self):
-        logger = logging.getLogger()
-        logger_rotate_by = self.logger_config.get("file_rotate_by", "size")
-
-        if logger_rotate_by == "size":
-            file_handler = logging.handlers.RotatingFileHandler(os.path.join(
-                                                                os.path.dirname(
-                                                                    self.logger_config["log_file"]),
-                                                                self.task_manager.name + ".log"),
-                                                                maxBytes=self.logger_config.get("max_file_size",
-                                                                200 * 1000000),
-                                                                backupCount=self.logger_config.get("max_backup_count",
-                                                                6))
-        else:
-            file_handler = logging.handlers.TimedRotatingFileHandler(os.path.join(
-                                                                     os.path.dirname(
-                                                                         self.logger_config["log_file"]),
-                                                                     self.task_manager.name + ".log"),
-                                                                     when=self.logger_config.get("rotation_time_unit", 'D'),
-                                                                     interval=self.logger_config.get("rotation_time_interval", '1'))
-
-        file_handler.setFormatter(FORMATTER)
-        logger.setLevel(logging.WARNING)
-        logger.addHandler(file_handler)
-        channel_log_level = self.logger_config.get("global_channel_log_level", "WARNING")
-        self.task_manager.set_loglevel(channel_log_level)
-        self.task_manager.run()
 
 
 class RequestHandler(xmlrpc.server.SimpleXMLRPCRequestHandler):
@@ -108,7 +47,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
 
         self.logger = logging.getLogger("decision_engine")
         signal.signal(signal.SIGHUP, self.handle_sighup)
-        self.task_managers = {}
+        self.workers = Workers()
         self.channel_config_loader = channel_config_loader
         self.global_config = global_config
         self.dataspace = dataspace.DataSpace(self.global_config)
@@ -127,18 +66,20 @@ class DecisionEngine(socketserver.ThreadingMixIn,
         return func(*params)
 
     def block_until(self, state):
-        if not self.task_managers:
-            self.logger.info('No active task managers.')
-        for tm in self.task_managers.values():
-            if tm.is_alive():
-                tm.wait_until(state)
+        with self.workers.unguarded_access() as workers:
+            if not workers:
+                self.logger.info('No active task managers.')
+            for tm in workers.values():
+                if tm.is_alive():
+                    tm.wait_until(state)
 
     def block_while(self, state):
-        if not self.task_managers:
-            self.logger.info('No active task managers.')
-        for tm in self.task_managers.values():
-            if tm.is_alive():
-                tm.wait_while(state)
+        with self.workers.unguarded_access() as workers:
+            if not workers:
+                self.logger.info('No active task managers.')
+            for tm in workers.values():
+                if tm.is_alive():
+                    tm.wait_while(state)
 
     def rpc_block_while(self, state_str):
         allowed_state = None
@@ -176,133 +117,136 @@ class DecisionEngine(socketserver.ThreadingMixIn,
     def rpc_print_product(self, product, columns=None, query=None):
         found = False
         txt = "Product {}: ".format(product)
-        for ch, worker in self.task_managers.items():
-            if not worker:
-                txt += f"Channel {ch} is in ERROR state\n"
-                continue
+        with self.workers.access() as workers:
+            for ch, worker in workers.items():
+                if not worker.is_alive():
+                    txt += f"Channel {ch} is in not active\n"
+                    continue
 
-            channel_config = self.channel_config_loader.get_channels()[ch]
-            produces = self.channel_config_loader.get_produces(channel_config)
-            r = [x for x in list(produces.items()) if product in x[1]]
-            if not r:
-                continue
-            found = True
-            txt += " Found in channel {}\n".format(ch)
-            tm = self.dataspace.get_taskmanager(ch)
-            try:
-                data_block = datablock.DataBlock(self.dataspace,
-                                                 ch,
-                                                 taskmanager_id=tm['taskmanager_id'],
-                                                 sequence_id=tm['sequence_id'])
-                data_block.generation_id -= 1
-                df = data_block[product]
-                df = pd.read_json(df.to_json())
-                column_names = []
-                if columns:
-                    column_names = columns.split(",")
-                if query:
-                    if column_names:
-                        txt += "{}\n".format(tabulate.tabulate(df.loc[:, column_names].query(query),
-                                                               headers='keys',
-                                                               tablefmt='psql'))
-                    else:
-                        txt += "{}\n".format(tabulate.tabulate(df.query(query),
-                                                               headers='keys',
-                                                               tablefmt='psql'))
+                channel_config = self.channel_config_loader.get_channels()[ch]
+                produces = self.channel_config_loader.get_produces(channel_config)
+                r = [x for x in list(produces.items()) if product in x[1]]
+                if not r:
+                    continue
+                found = True
+                txt += " Found in channel {}\n".format(ch)
+                tm = self.dataspace.get_taskmanager(ch)
+                try:
+                    data_block = datablock.DataBlock(self.dataspace,
+                                                     ch,
+                                                     taskmanager_id=tm['taskmanager_id'],
+                                                     sequence_id=tm['sequence_id'])
+                    data_block.generation_id -= 1
+                    df = data_block[product]
+                    df = pd.read_json(df.to_json())
+                    column_names = []
+                    if columns:
+                        column_names = columns.split(",")
+                    if query:
+                        if column_names:
+                            txt += "{}\n".format(tabulate.tabulate(df.loc[:, column_names].query(query),
+                                                                   headers='keys',
+                                                                   tablefmt='psql'))
+                        else:
+                            txt += "{}\n".format(tabulate.tabulate(df.query(query),
+                                                                   headers='keys',
+                                                                   tablefmt='psql'))
 
-                else:
-                    if column_names:
-                        txt += "{}\n".format(tabulate.tabulate(df.loc[:, column_names],
-                                                               headers='keys',
-                                                               tablefmt='psql'))
                     else:
-                        txt += "{}\n".format(tabulate.tabulate(df,
-                                                               headers='keys',
-                                                               tablefmt='psql'))
-            except Exception as e:
-                txt += "\t\t{}\n".format(e)
+                        if column_names:
+                            txt += "{}\n".format(tabulate.tabulate(df.loc[:, column_names],
+                                                                   headers='keys',
+                                                                   tablefmt='psql'))
+                        else:
+                            txt += "{}\n".format(tabulate.tabulate(df,
+                                                                   headers='keys',
+                                                                   tablefmt='psql'))
+                except Exception as e:
+                    txt += "\t\t{}\n".format(e)
         if not found:
             txt += "Not produced by any module\n"
         return txt[:-1]
 
     def rpc_print_products(self):
-        channel_keys = self.task_managers.keys()
-        if not channel_keys:
-            return "No channels are currently active.\n"
+        with self.workers.access() as workers:
+            channel_keys = workers.keys()
+            if not channel_keys:
+                return "No channels are currently active.\n"
 
-        width = max([len(x) for x in channel_keys]) + 1
-        txt = ""
-        for ch, worker in self.task_managers.items():
-            if not worker.is_alive():
-                txt += f"Channel {ch} is in ERROR state\n"
-                continue
+            width = max([len(x) for x in channel_keys]) + 1
+            txt = ""
+            for ch, worker in workers.items():
+                if not worker.is_alive():
+                    txt += f"Channel {ch} is in ERROR state\n"
+                    continue
 
-            txt += "channel: {:<{width}}, id = {:<{width}}, state = {:<10} \n".format(ch,
-                                                                                      worker.task_manager_id,
-                                                                                      worker.get_state_name(),
-                                                                                      width=width)
-            tm = self.dataspace.get_taskmanager(ch)
-            data_block = datablock.DataBlock(self.dataspace,
-                                             ch,
-                                             taskmanager_id=tm['taskmanager_id'],
-                                             sequence_id=tm['sequence_id'])
-            data_block.generation_id -= 1
-            channel_config = self.channel_config_loader.get_channels()[ch]
-            produces = self.channel_config_loader.get_produces(channel_config)
-            for i in ("sources",
-                      "transforms",
-                      "logicengines",
-                      "publishers"):
-                txt += "\t{}:\n".format(i)
-                modules = channel_config.get(i, {})
-                for mod_name, mod_config in modules.items():
-                    txt += "\t\t{}\n".format(mod_name)
-                    products = produces.get(mod_name, [])
-                    for product in products:
-                        try:
-                            df = data_block[product]
-                            df = pd.read_json(df.to_json())
-                            txt += "{}\n".format(tabulate.tabulate(df,
-                                                                   headers='keys', tablefmt='psql'))
-                        except Exception as e:
-                            txt += "\t\t\t{}\n".format(e)
+                txt += "channel: {:<{width}}, id = {:<{width}}, state = {:<10} \n".format(ch,
+                                                                                          worker.task_manager_id,
+                                                                                          worker.get_state_name(),
+                                                                                          width=width)
+                tm = self.dataspace.get_taskmanager(ch)
+                data_block = datablock.DataBlock(self.dataspace,
+                                                 ch,
+                                                 taskmanager_id=tm['taskmanager_id'],
+                                                 sequence_id=tm['sequence_id'])
+                data_block.generation_id -= 1
+                channel_config = self.channel_config_loader.get_channels()[ch]
+                produces = self.channel_config_loader.get_produces(channel_config)
+                for i in ("sources",
+                          "transforms",
+                          "logicengines",
+                          "publishers"):
+                    txt += "\t{}:\n".format(i)
+                    modules = channel_config.get(i, {})
+                    for mod_name, mod_config in modules.items():
+                        txt += "\t\t{}\n".format(mod_name)
+                        products = produces.get(mod_name, [])
+                        for product in products:
+                            try:
+                                df = data_block[product]
+                                df = pd.read_json(df.to_json())
+                                txt += "{}\n".format(tabulate.tabulate(df,
+                                                                       headers='keys', tablefmt='psql'))
+                            except Exception as e:
+                                txt += "\t\t\t{}\n".format(e)
         return txt[:-1]
 
     def rpc_status(self):
-        channel_keys = self.task_managers.keys()
-        if not channel_keys:
-            return "No channels are currently active.\n" + self.reaper_status()
+        with self.workers.access() as workers:
+            channel_keys = workers.keys()
+            if not channel_keys:
+                return "No channels are currently active.\n" + self.reaper_status()
 
-        txt = ""
-        width = max([len(x) for x in channel_keys]) + 1
-        for ch, worker in self.task_managers.items():
-            txt += "channel: {:<{width}}, id = {:<{width}}, state = {:<10} \n".format(ch,
-                                                                                      worker.task_manager_id,
-                                                                                      worker.get_state_name(),
-                                                                                      width=width)
-            channel_config = self.channel_config_loader.get_channels()[ch]
-            for i in ("sources",
-                      "transforms",
-                      "logicengines",
-                      "publishers"):
-                txt += "\t{}:\n".format(i)
-                modules = channel_config.get(i, {})
-                for mod_name, mod_config in modules.items():
-                    txt += "\t\t{}\n".format(mod_name)
-                    my_module = importlib.import_module(
-                        mod_config.get('module'))
-                    produces = None
-                    consumes = None
-                    try:
-                        produces = getattr(my_module, 'PRODUCES')
-                    except AttributeError:
-                        pass
-                    try:
-                        consumes = getattr(my_module, 'CONSUMES')
-                    except AttributeError:
-                        pass
-                    txt += "\t\t\tconsumes : {}\n".format(consumes)
-                    txt += "\t\t\tproduces : {}\n".format(produces)
+            txt = ""
+            width = max([len(x) for x in channel_keys]) + 1
+            for ch, worker in workers.items():
+                txt += "channel: {:<{width}}, id = {:<{width}}, state = {:<10} \n".format(ch,
+                                                                                          worker.task_manager_id,
+                                                                                          worker.get_state_name(),
+                                                                                          width=width)
+                channel_config = self.channel_config_loader.get_channels()[ch]
+                for i in ("sources",
+                          "transforms",
+                          "logicengines",
+                          "publishers"):
+                    txt += "\t{}:\n".format(i)
+                    modules = channel_config.get(i, {})
+                    for mod_name, mod_config in modules.items():
+                        txt += "\t\t{}\n".format(mod_name)
+                        my_module = importlib.import_module(
+                            mod_config.get('module'))
+                        produces = None
+                        consumes = None
+                        try:
+                            produces = getattr(my_module, 'PRODUCES')
+                        except AttributeError:
+                            pass
+                        try:
+                            consumes = getattr(my_module, 'CONSUMES')
+                        except AttributeError:
+                            pass
+                        txt += "\t\t\tconsumes : {}\n".format(consumes)
+                        txt += "\t\t\tproduces : {}\n".format(produces)
         return txt + self.reaper_status()
 
     def rpc_stop(self):
@@ -318,7 +262,8 @@ class DecisionEngine(socketserver.ThreadingMixIn,
                                                channel_config,
                                                self.global_config)
         worker = Worker(task_manager, self.global_config['logger'])
-        self.task_managers[channel_name] = worker
+        with self.workers.access() as workers:
+            workers[channel_name] = worker
         worker.start()
         self.logger.info(f"Channel {channel_name} started")
 
@@ -336,8 +281,9 @@ class DecisionEngine(socketserver.ThreadingMixIn,
                 self.logger.error(f"Channel {name} failed to start : {e}")
 
     def rpc_start_channel(self, channel_name):
-        if channel_name in self.task_managers:
-            return f"ERROR, channel {channel_name} is running"
+        with self.workers.access() as workers:
+            if channel_name in workers:
+                return f"ERROR, channel {channel_name} is running"
 
         success, result = self.channel_config_loader.load_channel(channel_name)
         if not success:
@@ -352,23 +298,28 @@ class DecisionEngine(socketserver.ThreadingMixIn,
     def rpc_stop_channel(self, channel):
         if not self.stop_channel(channel):
             return f"No channel found with the name {channel}."
-        del self.task_managers[channel]
         return "OK"
 
-    def stop_channel(self, channel):
-        if channel not in self.task_managers:
-            return False
-
-        worker = self.task_managers[channel]
+    def stop_worker(self, worker):
         if worker.is_alive():
             worker.task_manager.take_offline(None)
             worker.join(self.global_config.get("shutdown_timeout", 10))
+        if worker.exitcode is None:
+            worker.terminate()
+
+    def stop_channel(self, channel):
+        with self.workers.access() as workers:
+            if channel not in workers:
+                return False
+            self.stop_worker(workers[channel])
+            del workers[channel]
         return True
 
     def stop_channels(self):
-        for channel_name in self.task_managers:
-            self.stop_channel(channel_name)
-        self.task_managers.clear()
+        with self.workers.access() as workers:
+            for worker in workers.values():
+                self.stop_worker(worker)
+            workers.clear()
 
     def rpc_stop_channels(self):
         self.stop_channels()
@@ -385,27 +336,29 @@ class DecisionEngine(socketserver.ThreadingMixIn,
         return logging.getLevelName(engineloglevel)
 
     def rpc_get_channel_log_level(self, channel):
-        if channel not in self.task_managers:
-            return f"No channel found with the name {channel}."
+        with self.workers.access() as workers:
+            if channel not in workers:
+                return f"No channel found with the name {channel}."
 
-        worker = self.task_managers[channel]
-        if not worker.is_alive():
-            return f"Channel {channel} is in ERROR state."
-        return logging.getLevelName(worker.task_manager.get_loglevel())
+            worker = workers[channel]
+            if not worker.is_alive():
+                return f"Channel {channel} is in ERROR state."
+            return logging.getLevelName(worker.task_manager.get_loglevel())
 
     def rpc_set_channel_log_level(self, channel, log_level):
         """Assumes log_level is a string corresponding to the supported logging-module levels."""
-        if channel not in self.task_managers:
-            return f"No channel found with the name {channel}."
+        with self.workers.access() as workers:
+            if channel not in workers:
+                return f"No channel found with the name {channel}."
 
-        worker = self.task_managers[channel]
-        if not worker.is_alive():
-            return f"Channel {channel} is in ERROR state."
+            worker = workers[channel]
+            if not worker.is_alive():
+                return f"Channel {channel} is in ERROR state."
 
-        log_level_code = getattr(logging, log_level)
-        if worker.task_manager.get_loglevel() == log_level_code:
-            return f"Nothing to do. Current log level is : {log_level}"
-        worker.task_manager.set_loglevel(log_level)
+            log_level_code = getattr(logging, log_level)
+            if worker.task_manager.get_loglevel() == log_level_code:
+                return f"Nothing to do. Current log level is : {log_level}"
+            worker.task_manager.set_loglevel(log_level)
         return f"Log level changed to : {log_level}"
 
     def rpc_reaper_start(self, delay=0):
@@ -438,19 +391,6 @@ class DecisionEngine(socketserver.ThreadingMixIn,
         state = self.reaper.get_state()
         txt = '\nreaper:\n\tstate: {}\n\tretention_interval: {}\n'.format(state, interval)
         return txt
-
-    def _disable_channels_with_terminated_processes(self):
-        for channel, process in self.task_managers.items():
-            if process.is_alive():
-                continue
-            self.task_managers[channel] = WorkerInErrorState(process.task_manager_id)
-
-    # The 'service_actions' method here overrides the socketserver
-    # base class' implementation.  It is called during the
-    # 'serve_forever' call for each iteration of the server-request
-    # loop, which is typically executed once every 0.5 seconds.
-    def service_actions(self):
-        self._disable_channels_with_terminated_processes()
 
 
 def parse_program_options(args=None):

--- a/framework/engine/Workers.py
+++ b/framework/engine/Workers.py
@@ -1,0 +1,109 @@
+import logging
+import multiprocessing
+import os
+import threading
+
+import decisionengine.framework.taskmanager.ProcessingState as ProcessingState
+
+FORMATTER = logging.Formatter(
+    "%(asctime)s - %(name)s - %(module)s - %(process)d - %(threadName)s - %(levelname)s - %(message)s")
+
+
+class Worker(multiprocessing.Process):
+
+    def __init__(self, task_manager, logger_config):
+        super().__init__()
+        self.task_manager = task_manager
+        self.task_manager_id = task_manager.id
+        self.logger_config = logger_config
+
+    def wait_until(self, state):
+        return self.task_manager.state.wait_until(state)
+
+    def wait_while(self, state):
+        return self.task_manager.state.wait_while(state)
+
+    def get_state_name(self):
+        return self.task_manager.get_state_name()
+
+    def run(self):
+        logger = logging.getLogger()
+        logger_rotate_by = self.logger_config.get("file_rotate_by", "size")
+
+        if logger_rotate_by == "size":
+            file_handler = logging.handlers.RotatingFileHandler(os.path.join(
+                                                                os.path.dirname(
+                                                                    self.logger_config["log_file"]),
+                                                                self.task_manager.name + ".log"),
+                                                                maxBytes=self.logger_config.get("max_file_size",
+                                                                200 * 1000000),
+                                                                backupCount=self.logger_config.get("max_backup_count",
+                                                                6))
+        else:
+            file_handler = logging.handlers.TimedRotatingFileHandler(os.path.join(
+                                                                     os.path.dirname(
+                                                                         self.logger_config["log_file"]),
+                                                                     self.task_manager.name + ".log"),
+                                                                     when=self.logger_config.get("rotation_time_unit", 'D'),
+                                                                     interval=self.logger_config.get("rotation_time_interval", '1'))
+
+        file_handler.setFormatter(FORMATTER)
+        logger.setLevel(logging.WARNING)
+        logger.addHandler(file_handler)
+        channel_log_level = self.logger_config.get("global_channel_log_level", "WARNING")
+        self.task_manager.set_loglevel(channel_log_level)
+        self.task_manager.run()
+
+
+class Workers:
+    def __init__(self):
+        self._workers = {}
+        self._lock = threading.Lock()
+
+    def access(self):
+        class Lock:
+            def __init__(self, workers, lock):
+                self._workers = workers
+                self._lock = lock
+
+            def _update_channel_states(self):
+                for channel, process in self._workers.items():
+                    if process.is_alive():
+                        continue
+                    if process.task_manager.state.inactive():
+                        continue
+                    process.task_manager.state.set(ProcessingState.State.ERROR)
+
+            def __enter__(self):
+                self._lock.acquire()
+                self._update_channel_states()
+                return self._workers
+
+            def __exit__(self, error, type, bt):
+                self._lock.release()
+
+        return Lock(self._workers, self._lock)
+
+    def unguarded_access(self):
+        class NoLock:
+            def __init__(self, workers, lock):
+                self._workers = workers
+                self._lock = lock  # Only used to update channels while entering context
+
+            def _update_channel_states(self):
+                for channel, process in self._workers.items():
+                    if process.is_alive():
+                        continue
+                    if process.task_manager.state.inactive():
+                        continue
+                    process.task_manager.state.set(ProcessingState.State.ERROR)
+
+            def __enter__(self):
+                with self._lock:
+                    self._update_channel_states()
+                return self._workers
+
+            def __exit__(self, error, type, bt):
+                pass
+
+        return NoLock(self._workers, self._lock)

--- a/framework/taskmanager/ProcessingState.py
+++ b/framework/taskmanager/ProcessingState.py
@@ -20,9 +20,9 @@ import multiprocessing
 class State(enum.Enum):
     BOOT = 0
     STEADY = 1
-    OFFLINE = 2
-    SHUTTINGDOWN = 3
-    SHUTDOWN = 4
+    SHUTTINGDOWN = 2
+    SHUTDOWN = 3
+    OFFLINE = 4
     ERROR = 5
 
 
@@ -59,5 +59,7 @@ class ProcessingState:
             self._cv.wait_for(lambda: not self.has_value(state))
 
     def should_stop(self):
-        value = self.get().value
-        return value > State.STEADY.value
+        return self.get().value > State.STEADY.value
+
+    def inactive(self):
+        return self.get().value > State.SHUTTINGDOWN.value


### PR DESCRIPTION
This commit is intended to address issue #213.  It introduces the `Workers` class, which provides context managers that serialize access to the task-manager dictionary.

In addition, it removes the `service_actions` call, which was largely unnecessary and did not remove the need for serialization.