### PR TITLE
Migrate from boost-python to pybind11

### DIFF
--- a/.github/actions/unittest-in-sl7-docker/entrypoint.sh
+++ b/.github/actions/unittest-in-sl7-docker/entrypoint.sh
@@ -7,9 +7,8 @@ le_builddir=decisionengine/framework/logicengine/cxx/build
 [ -e $le_buildir ] && rm -rf $le_builddir
 mkdir $le_builddir
 cd $le_builddir
-cmake3 -Wno-dev --debug-output -DPYVER=3.6 ..
-make --debug
-make --debug liblinks
+cmake3 -Wno-dev --debug-output -DPYVER=3.6 .. -Dpybind11_DIR=$(pybind11-config --cmakedir)
+make install --debug
 cd -
 export PYTHONPATH=$PWD:$PYTHONPATH
 source venv/bin/activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ python:
 jobs:
   allow_failures:
     # These don't need to work, but be nice if they did
-    # https://svn.boost.org/trac10/ticket/4125 / https://github.com/boostorg/python/pull/291
     - python: "pypy3"
     # Latest python tested for future planning purposes
     - python: "nightly"
@@ -62,7 +61,7 @@ before_install:
 
 # Environment variables
 env:
-  - LD_LIBRARY_PATH="${TRAVIS_BUILD_DIR}/framework/logicengine/"   PYTHONPATH=$(dirname ${TRAVIS_BUILD_DIR})    PYTHON_PATH=${PYTHONPATH}
+  - PYTHONPATH=$(dirname ${TRAVIS_BUILD_DIR})    PYTHON_PATH=${PYTHONPATH}
 
 # commands to install any dependencies
 install:
@@ -83,22 +82,20 @@ install:
   - travis_retry wget -c http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz
   - tar xf boost_1_58_0.tar.gz
   - cd boost_1_58_0
-  - ./bootstrap.sh --with-python=$(which python) --with-python-root=/opt/python/${TRAVIS_PYTHON_VERSION}/ --with-libraries=python,regex,system
-  - ./b2 -q --prefix=/usr/local/ cxxflags=-fpermissive include=/opt/python/${TRAVIS_PYTHON_VERSION}/include/ install  -j 6
+  - ./bootstrap.sh --with-libraries=system
+  - ./b2 -q --prefix=/usr/local/ cxxflags=-fpermissive install -j 6
 
     # Setup pkg-config and cmake search paths to use the virtualenv python from travis
   - export PKG_CONFIG_PATH="/opt/python/${TRAVIS_PYTHON_VERSION}/lib/pkgconfig"
-  - export CMAKE_INCLUDE_PATH="/opt/python/${TRAVIS_PYTHON_VERSION}/include/python${TRAVIS_PYTHON_VERSION}m/include/;/opt/python/${TRAVIS_PYTHON_VERSION}/include/python${TRAVIS_PYTHON_VERSION}/include/;/opt/python/${TRAVIS_PYTHON_VERSION}/include/"
-  - export CMAKE_LIBRARY_PATH="/opt/python/${TRAVIS_PYTHON_VERSION}/lib/;/opt/python/${TRAVIS_PYTHON_VERSION}/lib_pypy/"
   - export PYVER=$(python -c 'import sys; print("%d.%d" % (sys.version_info.major, sys.version_info.minor))')
 
   # run cmake and build logic engine
   - sudo apt-get -y install cmake g++
+  - pip install -U pybind11
   - mkdir -p ${TRAVIS_BUILD_DIR}/framework/logicengine/cxx/build
   - cd ${TRAVIS_BUILD_DIR}/framework/logicengine/cxx/build
-  - cmake -DPYVER=${PYVER} -DCMAKE_LIBRARY_PATH="${CMAKE_LIBRARY_PATH}" -DCMAKE_INCLUDE_PATH="${CMAKE_INCLUDE_PATH}" ..
-  - make
-  - make liblinks
+  - cmake -DPYVER=${PYVER} -Dpybind11_DIR=$(pybind11-config --cmakedir) ..
+  - make install
 
   # pull in any listed python requirements
   - cd ${TRAVIS_BUILD_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,6 @@ RUN yum -y install \
   rpm-devel \
   mock \
   cmake3 python3-devel make \
-  boost-python36-devel \
-  boost-regex \
-  boost-system \
-  boost-python-devel \
   python-devel \
   redhat-lsb-core \
   python36-virtualenv \

--- a/README.md
+++ b/README.md
@@ -53,11 +53,7 @@ yum -y install \
   && easy_install DBUtils
 yum -y install \
     cmake3 python3-devel make \
-    boost-python36-devel \
     python3-devel \
-    boost-regex \
-    boost-system \
-    boost-python-devel \
     python-devel \
     redhat-lsb-core \
     python36-virtualenv \

--- a/build/packaging/rpm/decisionengine.spec
+++ b/build/packaging/rpm/decisionengine.spec
@@ -15,6 +15,8 @@
 
 %define le_builddir %{_builddir}/decisionengine/framework/logicengine/cxx/build
 
+%define python3_sitebin %(%{__python3} -m site --user-base)/bin
+
 # From http://fedoraproject.org/wiki/Packaging:Python
 # Define python_sitelib
 %if ! (0%{?fedora} > 12 || 0%{?rhel} > 5)
@@ -37,10 +39,6 @@ URL:            http://hepcloud.fnal.gov
 Source0:        decisionengine.tar.gz
 
 BuildArch:      x86_64
-Requires:       boost-python36-devel >= 1.53.0
-Requires:       boost-python36 >= 1.53.0
-Requires:       boost-regex >= 1.53.0
-Requires:       boost-system >= 1.53.0
 Requires:       python3
 BuildRequires:  cmake3
 BuildRequires:  python36-devel
@@ -79,14 +77,12 @@ The testcase used to try out the Decision Engine.
 
 %build
 pwd
+python3 -m pip install --user --upgrade pip
+python3 -m pip install --user --upgrade pybind11
 mkdir %{le_builddir}
 cd %{le_builddir}
-cmake3 .. -DPYVER=3.6
-make
-[ -e ../../RE.so ] && rm ../../RE.so
-[ -e ../../libLogicEngine.so ] && rm ../../libLogicEngine.so
-cp RE.so ../..
-cp libLogicEngine.so ../..
+cmake3 .. -DPYVER=3.6 -Dpybind11_DIR=$(%{python3_sitebin}/pybind11-config --cmakedir)
+make install
 
 
 %install

--- a/build/scripts/run_pylint.sh
+++ b/build/scripts/run_pylint.sh
@@ -44,12 +44,8 @@ process_branch() {
     [ -e $le_buildir ] && rm -rf $le_builddir
     mkdir $le_builddir
     cd $le_builddir
-    cmake3 -Wno-dev --debug-output ..
-    make --debug
-    [ -e ../../RE.so ] && rm ../../RE.so
-    [ -e ../../libLogicEngine.so ] && rm ../../libLogicEngine.so
-    cp RE.so ../..
-    cp libLogicEngine.so ../..
+    cmake3 -Wno-dev --debug-output .. -Dpybind11_DIR=$(pybind11-config --cmakedir)
+    make install --debug
     echo "Building Logic Engine ... DONE"
 
     cd $WORKSPACE

--- a/doc/source/unittest.rst
+++ b/doc/source/unittest.rst
@@ -10,8 +10,8 @@ Prerequisites:
 
    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
    yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-   yum install -y python3 python3-pip cmake3 boost-devel python36-devel boost-python36-devel postgresql11 postgresql11-server
-   pip3 install pandas DBUtils psycopg2-binary tabulate mock pytest
+   yum install -y python3 python3-pip cmake3 boost-devel python36-devel postgresql11 postgresql11-server
+   pip3 install pandas DBUtils psycopg2-binary tabulate mock pytest pybind11
 
 Build & test
 ^^^^^^^^^^^^
@@ -25,31 +25,41 @@ Build & test
 
    mkdir decisionengine/framework/logicengine/cxx/build
    cd decisionengine/framework/logicengine/cxx/build
-   cmake3 .. -DPYVER=3.6
-   make -j <number> # say number of CPUs on your box
-   cd ../../
-   ln -s cxx/build/RE.so
-   ln -s cxx/build/libLogicEngine.so
-   export LD_LIBRARY_PATH=`pwd`
-   cd ../../
-   #pytest -v --tb=native
+   cmake3 .. -DPYVER=3.6 -Dpybind11_DIR=$(pybind11-config --cmakedir)
+   make install -j <number> # say number of CPUs on your box
+   cd ../../../../
    python3 -m pytest
 
-   ==================================== test session starts =====================================
-   platform linux -- Python 3.6.8, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
-   rootdir: /root/junjk/decisionengine
-   collected 26 items
+   ==================================== test session starts ====================================
+   platform linux -- Python 3.6.8, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
+   rootdir: /cloud/login/knoepfel/de-devel/decisionengine
+   plugins: timeout-1.4.2, postgresql-2.5.1, profiling-1.7.0
+   collected 89 items
 
-   framework/dataspace/tests/test_Reaper.py .......                                       [ 26%]
-   framework/logicengine/tests/test_cascaded_rules.py ..                                  [ 34%]
-   framework/logicengine/tests/test_construction.py .....                                 [ 53%]
-   framework/logicengine/tests/test_facts.py .....                                        [ 73%]
-   framework/logicengine/tests/test_pandas_fact.py ..                                     [ 80%]
-   framework/logicengine/tests/test_rule_with_negated_fact.py ..                          [ 88%]
-   framework/logicengine/tests/test_simple_configuration.py ..                            [ 96%]
-   framework/util/tests/test_tsort.py .                                                   [100%]
+   framework/config/tests/test_config.py .............                                   [ 14%]
+   framework/config/tests/test_policies.py ....                                          [ 19%]
+   framework/dataspace/datasources/tests/test_postgresql.py ......                       [ 25%]
+   framework/dataspace/tests/test_Reaper.py .......                                      [ 33%]
+   framework/dataspace/tests/test_datablock.py ..............                            [ 49%]
+   framework/engine/tests/test_client_only.py ..                                         [ 51%]
+   framework/engine/tests/test_startup.py ..                                             [ 53%]
+   framework/logicengine/tests/test_cascaded_rules.py ..                                 [ 56%]
+   framework/logicengine/tests/test_construction.py .....                                [ 61%]
+   framework/logicengine/tests/test_facts.py .....                                       [ 67%]
+   framework/logicengine/tests/test_pandas_fact.py ..                                    [ 69%]
+   framework/logicengine/tests/test_rule_with_negated_fact.py ..                         [ 71%]
+   framework/logicengine/tests/test_simple_configuration.py ..                           [ 74%]
+   framework/taskmanager/tests/test_processing_state.py .....                            [ 79%]
+   framework/taskmanager/tests/test_task_manager.py ...                                  [ 83%]
+   framework/tests/test_defaults.py ...                                                  [ 86%]
+   framework/tests/test_reaper.py ...                                                    [ 89%]
+   framework/tests/test_restart_channel.py .                                             [ 91%]
+   framework/tests/test_sample_config.py ...                                             [ 94%]
+   framework/tests/test_start_with_no_channels.py .                                      [ 95%]
+   framework/util/tests/test_fs.py ...                                                   [ 98%]
+   framework/util/tests/test_tsort.py .                                                  [100%]
 
-   ==================================== 26 passed in 23.86s =====================================
+   =============================== 89 passed in 90.01s (0:01:30) ===============================
 
 Decisionengine_modules
 ======================

--- a/framework/logicengine/cxx/CMakeLists.txt
+++ b/framework/logicengine/cxx/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(logicengine)
+project(logicengine LANGUAGES CXX)
 
-set(logicengine_version_major 2)
+set(logicengine_version_major 3)
 set(logicengine_version_minor 0)
 
 set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS} -pedantic -Wall -g -O3")
@@ -10,35 +10,27 @@ set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS} -pedantic -Wall -g -O3")
 find_package(PythonInterp ${PYVER} REQUIRED)
 find_package(PythonLibs REQUIRED)
 find_package(Boost REQUIRED)
+find_package(pybind11 REQUIRED)
 
 # for vim ycm plugin
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 
-set(BOOST_PY_SUFFIX 3)
-if(PYTHONLIBS_VERSION_STRING VERSION_LESS "3.0.0")
-  set(BOOST_PY_SUFFIX)
-endif()
-
-include_directories(
-    ${PROJECT_SOURCE_DIR}
-    ${Boost_INCLUDE_DIRS}
-    ${PYTHON_INCLUDE_DIRS}
-)
-
-add_library(LogicEngine SHARED
+pybind11_add_module(RE
+    MODULE
+    NO_EXTRAS
     ma_boolean_andexpr.cpp
     ma_boolean_cond.cpp
     ma_boolean_expr.cpp
     ma_parse.cpp
     Rule.cpp
     RuleEngine.cpp
+    py_rule_engine.cc
 )
-target_link_libraries(LogicEngine boost_regex)
 
-python_add_module(RE py_rule_engine.cc)
-target_link_libraries(RE LogicEngine
-                      boost_python${BOOST_PY_SUFFIX}
-                      boost_system
-                      ${PYTHON_LIBRARIES})
+target_include_directories(RE PRIVATE ${PYTHON_INCLUDE_DIRS} pybind11::headers)
+target_link_libraries(RE PRIVATE pybind11::module pybind11::embed)
+set_target_properties(RE PROPERTIES SUFFIX ".so")
 
-add_custom_target(liblinks ln -s ${CMAKE_BINARY_DIR}/RE.so ${CMAKE_SOURCE_DIR}/../ COMMAND ln -s ${CMAKE_BINARY_DIR}/libLogicEngine.so ${CMAKE_SOURCE_DIR}/../)
+# Install in decisionengine/framework/logicengine subdirectory for
+# Python runtime availability
+install(TARGETS RE DESTINATION ${CMAKE_SOURCE_DIR}/../)

--- a/framework/logicengine/cxx/RuleEngine.h
+++ b/framework/logicengine/cxx/RuleEngine.h
@@ -1,6 +1,8 @@
 #ifndef logicengine_cxx_RuleEngine_h
 #define logicengine_cxx_RuleEngine_h
 
+#include <pybind11/pybind11.h>
+
 #include "Fact.h"
 #include "Rule.h"
 #include "ma_types.h"
@@ -9,8 +11,8 @@ namespace logic_engine {
 
   class RuleEngine {
   public:
-    RuleEngine(boost::python::dict const& facts,
-               boost::python::dict const& rules);
+    RuleEngine(pybind11::dict const& facts,
+               pybind11::dict const& rules);
 
     void execute(std::map<std::string, bool> const& fact_vals,
                  std::map<std::string, strings_t>& actions,

--- a/framework/logicengine/cxx/py_rule_engine.cc
+++ b/framework/logicengine/cxx/py_rule_engine.cc
@@ -1,5 +1,5 @@
-#include <boost/python.hpp>
-#include <iostream>
+#include <pybind11/pybind11.h>
+
 #include <map>
 #include <string>
 #include <vector>
@@ -7,22 +7,21 @@
 #include "RuleEngine.h"
 
 using namespace std;
-namespace bp = boost::python;
+namespace py = pybind11;
 
 struct RuleEngine {
-  RuleEngine(bp::dict const& facts, bp::dict const& rules)
+  RuleEngine(py::dict const& facts, py::dict const& rules)
     : engine{facts, rules}
   {}
 
-  bp::tuple
-  execute(bp::dict const& facts)
+  py::tuple
+  execute(py::dict const& facts)
   {
     std::map<std::string, bool> fact_vals;
 
-    auto fnames = facts.keys();
-    for (int i = 0; i < len(fnames); ++i) {
-      fact_vals.emplace(bp::extract<string>(fnames[i]),
-                        bp::extract<bool>(facts[fnames[i]]));
+    for (auto const& pr : facts) {
+      fact_vals.emplace(py::cast<string>(pr.first),
+                        py::cast<bool>(pr.second));
     }
 
     std::map<std::string, std::vector<std::string>> out_actions;
@@ -30,35 +29,35 @@ struct RuleEngine {
 
     engine.execute(fact_vals, out_actions, out_facts);
 
-    bp::dict py_actions;
-    bp::dict py_facts;
+    py::dict py_actions;
+    py::dict py_facts;
 
     for (auto const& act : out_actions) {
-      bp::list act_names;
+      py::list act_names;
       for (auto const& act_name : act.second)
         act_names.append(act_name);
 
-      py_actions[act.first] = act_names;
+      py_actions[act.first.c_str()] = act_names;
     }
 
     for (auto const& rule_facts : out_facts) {
-      bp::dict py_rule_facts;
+      py::dict py_rule_facts;
       for (auto const& fact_val : rule_facts.second)
-        py_rule_facts[fact_val.first] = fact_val.second;
+        py_rule_facts[fact_val.first.c_str()] = fact_val.second;
 
-      py_facts[rule_facts.first] = py_rule_facts;
+      py_facts[rule_facts.first.c_str()] = py_rule_facts;
     }
 
-    return bp::make_tuple(py_actions, py_facts);
+    return py::make_tuple(py_actions, py_facts);
   }
 
 private:
   logic_engine::RuleEngine engine;
 };
 
-BOOST_PYTHON_MODULE(RE)
+PYBIND11_MODULE(RE, m)
 {
-  bp::class_<RuleEngine, boost::noncopyable>(
-    "RuleEngine", bp::init<bp::dict, bp::dict>())
+  py::class_<RuleEngine>(m, "RuleEngine")
+    .def(py::init<py::dict, py::dict>())
     .def("execute", &RuleEngine::execute);
 }

--- a/framework/logicengine/readme
+++ b/framework/logicengine/readme
@@ -1,18 +1,7 @@
-1. to build the  c++ library:
+To build this library and make it available for the Python runtime, execute the following steps:
 
   $ cd cxx
   $ mkdir build
   $ cd build
-  $ cmake ..
-  $ make
-  $ cd ../../
-
-2. to make the RulesEngine class available to Python:
-
-  $ ln -s cxx/build/RE.so RE.so
-
-3. run the tests for LogicEngine.py
-
-  $ cd ../../
-  [ you should now be in the 'decisionengine' directory]
-  $ PYTHONPATH=$PWD/..  py.test
+  $ cmake3 .. -DPYVER=3.6 -Dpybind11_DIR=$(pybind11-config --cmakedir)
+  $ make install [-j <num>]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# for buildtime
+pybind11
+
 # for runtime
 jsonnet
 pandas


### PR DESCRIPTION
This commit removes the boost-python dependency and replaces it with pybind11, which purportedly supports pypy3.