### PR TITLE
Move Python C extension to versioned .so file

### DIFF
--- a/framework/logicengine/cxx/CMakeLists.txt
+++ b/framework/logicengine/cxx/CMakeLists.txt
@@ -15,6 +15,10 @@ find_package(pybind11 REQUIRED)
 # for vim ycm plugin
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 
+# python is starting to look at versioned .so suffix
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/abisuffix.py OUTPUT_VARIABLE EXT_SUFFIX)
+message(STATUS "Python suffix detected: '${EXT_SUFFIX}'")
+
 pybind11_add_module(RE
     MODULE
     NO_EXTRAS
@@ -29,7 +33,7 @@ pybind11_add_module(RE
 
 target_include_directories(RE PRIVATE ${PYTHON_INCLUDE_DIRS} pybind11::headers)
 target_link_libraries(RE PRIVATE pybind11::module pybind11::embed)
-set_target_properties(RE PROPERTIES SUFFIX ".so")
+set_target_properties(RE PROPERTIES SUFFIX ${EXT_SUFFIX})
 
 # Install in decisionengine/framework/logicengine subdirectory for
 # Python runtime availability

--- a/framework/logicengine/cxx/abisuffix.py
+++ b/framework/logicengine/cxx/abisuffix.py
@@ -1,0 +1,7 @@
+# CMAKE 3.12 introduces Python_SOABI which can obsolete this snippet
+from __future__ import print_function
+import sysconfig
+if sysconfig.get_config_var('EXT_SUFFIX'):
+    print(sysconfig.get_config_var('EXT_SUFFIX'), end='')
+else:
+    print('.so', end='')


### PR DESCRIPTION
Python 3.10 looks like it may drop imports of unversioned .so files that don't conform to PEP-384.

So I've added in logic to make the versioned .so files so we don't need to worry about the conversion.