### PR TITLE
Add support to use custom base docker container to run tests

### DIFF
--- a/.Jenkinsfile
+++ b/.Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                             cd ..
                         '''
                         echo "prepare docker image ${pylintStageDockerImage}"
-                        sh "docker build --pull -t ${pylintStageDockerImage} -f decisionengine/.github/actions/pylint-in-sl7-docker/Dockerfile.jenkins decisionengine/.github/actions/pylint-in-sl7-docker/"
+                        sh "docker build --pull --tag ${pylintStageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg USER=\$(id -u) --build-arg GROUP=\$(id -g) -f decisionengine/.github/actions/pylint-in-sl7-docker/Dockerfile.jenkins decisionengine/.github/actions/pylint-in-sl7-docker/"
                         echo "Run ${STAGE_NAME} tests"
                         sh "docker run --rm -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${pylintStageDockerImage}"
                     }
@@ -83,7 +83,7 @@ pipeline {
                             cd ..
                         '''
                         echo "prepare docker image ${unit_testsStageDockerImage}"
-                        sh "docker build --pull -t ${unit_testsStageDockerImage} -f decisionengine/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins decisionengine/.github/actions/unittest-in-sl7-docker"
+                        sh "docker build --pull --tag ${unit_testsStageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg USER=\$(id -u) --build-arg GROUP=\$(id -g) -f decisionengine/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins decisionengine/.github/actions/unittest-in-sl7-docker"
                         echo "Run ${STAGE_NAME} tests"
                         sh "docker run --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${unit_testsStageDockerImage}"
                     }
@@ -124,7 +124,7 @@ pipeline {
                             cd ..
                         '''
                         echo "prepare docker image ${rpmbuildStageDockerImage}"
-                        sh "docker build --pull -t ${rpmbuildStageDockerImage} -f decisionengine/.github/actions/rpmbuild-in-sl7-docker/Dockerfile.jenkins decisionengine/.github/actions/rpmbuild-in-sl7-docker"
+                        sh "docker build --pull --tag ${rpmbuildStageDockerImage} --build-arg BASEIMAGE=hepcloud/decision-engine-ci:${BRANCH} --build-arg USER=\$(id -u) --build-arg GROUP=\$(id -g) -f decisionengine/.github/actions/rpmbuild-in-sl7-docker/Dockerfile.jenkins decisionengine/.github/actions/rpmbuild-in-sl7-docker"
                         echo "Run ${STAGE_NAME} tests"
                         sh "docker run --rm -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} ${rpmbuildStageDockerImage}"
                     }

--- a/.github/actions/pylint-in-sl7-docker/Dockerfile.jenkins
+++ b/.github/actions/pylint-in-sl7-docker/Dockerfile.jenkins
@@ -1,6 +1,9 @@
-FROM hepcloud/decision-engine-ci
+ARG BASEIMAGE=${BASEIMAGE:-hepcloud/decision-engine-ci}
+FROM ${BASEIMAGE:-hepcloud/decision-engine-ci}
+ARG USER
+ARG GROUP
 COPY entrypoint.sh /entrypoint.sh
-RUN groupadd -g 500 decision-engine-ci
-RUN useradd -u 500 -g 500 decision-engine-ci
+RUN groupadd -g ${GROUP:-500} decision-engine-ci
+RUN useradd -u ${USER:-500} -g ${GROUP:-500} decision-engine-ci
 USER decision-engine-ci
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/rpmbuild-in-sl7-docker/Dockerfile.jenkins
+++ b/.github/actions/rpmbuild-in-sl7-docker/Dockerfile.jenkins
@@ -1,6 +1,9 @@
-FROM hepcloud/decision-engine-ci
+ARG BASEIMAGE=${BASEIMAGE:-hepcloud/decision-engine-ci}
+FROM ${BASEIMAGE:-hepcloud/decision-engine-ci}
+ARG USER
+ARG GROUP
 COPY entrypoint.sh /entrypoint.sh
-RUN groupadd -g 500 decision-engine-ci
-RUN useradd -u 500 -g 500 decision-engine-ci
+RUN groupadd -g ${GROUP:-500} decision-engine-ci
+RUN useradd -u ${USER:-500} -g ${GROUP:-500} decision-engine-ci
 USER decision-engine-ci
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
+++ b/.github/actions/unittest-in-sl7-docker/Dockerfile.jenkins
@@ -1,6 +1,9 @@
-FROM hepcloud/decision-engine-ci
+ARG BASEIMAGE=${BASEIMAGE:-hepcloud/decision-engine-ci}
+FROM ${BASEIMAGE:-hepcloud/decision-engine-ci}
+ARG USER
+ARG GROUP
 COPY entrypoint.sh /entrypoint.sh
-RUN groupadd -g 500 decision-engine-ci
-RUN useradd -u 500 -g 500 decision-engine-ci
+RUN groupadd -g ${GROUP:-500} decision-engine-ci
+RUN useradd -u ${USER:-500} -g ${GROUP:-500} decision-engine-ci
 USER decision-engine-ci
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Add support to use custom docker layer as base of the docker image used to run tests
this allows to use different docker container for different branches.

This code change is also needed for branch 1.4
By looking at the current status of branch 1.4, it also needs commit 0bcabc982ad663986f6f17470d0858fd9bc69b66
that corresponds to PR#210 https://github.com/HEPCloud/decisionengine/pull/210
This way the code change in this RB can be applied as is to 1.4 branch.

RB: https://fermicloud140.fnal.gov/reviews/r/284/