### PR TITLE
Since we are python3 only now, drop python-six compat layer

### DIFF
--- a/framework/dataspace/datasource.py
+++ b/framework/dataspace/datasource.py
@@ -1,9 +1,7 @@
 import abc
-import six
 
 
-@six.add_metaclass(abc.ABCMeta)
-class DataSource(object):
+class DataSource(object, metaclass=abc.ABCMeta):
 
     #: Name of the taskmanager table
     taskmanager_table = 'taskmanager'

--- a/framework/dataspace/dataspace.py
+++ b/framework/dataspace/dataspace.py
@@ -1,7 +1,6 @@
 import enum
 import importlib
 import logging
-import six
 import threading
 
 
@@ -51,8 +50,7 @@ class Singleton(type):
 
         return cls._instances[cls]
 
-@six.add_metaclass(Singleton)
-class DataSourceLoader():
+class DataSourceLoader(object, metaclass=Singleton):
 
     _ds = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ pybind11
 # for runtime
 jsonnet
 pandas
-six
 tabulate
 
 # for tests


### PR DESCRIPTION
RB: https://fermicloud140.fnal.gov/reviews/r/313/