### PR TITLE
Fix build of Logic Engine for unittests in branch 1.5

### DIFF
--- a/framework/logicengine/cxx/CMakeLists.txt
+++ b/framework/logicengine/cxx/CMakeLists.txt
@@ -38,3 +38,5 @@ set_target_properties(RE PROPERTIES SUFFIX ${EXT_SUFFIX})
 # Install in decisionengine/framework/logicengine subdirectory for
 # Python runtime availability
 install(TARGETS RE DESTINATION ${CMAKE_SOURCE_DIR}/../)
+
+add_custom_target(liblinks ln -s ${CMAKE_BINARY_DIR}/RE.so ${CMAKE_SOURCE_DIR}/../ COMMAND ln -s ${CMAKE_BINARY_DIR}/libLogicEngine.so ${CMAKE_SOURCE_DIR}/../)


### PR DESCRIPTION
This change needs to be applied to branch 1.5 of decisionengine.
This is propaedeutic to change in RB#334 (https://fermicloud140.fnal.gov/reviews/r/334/) that is associated to decisionengine_modules PR#307

RB: https://fermicloud140.fnal.gov/reviews/r/335