### PR TITLE
changed to ISO-8601 time format in logging

### DIFF
--- a/framework/config/ChannelConfigHandler.py
+++ b/framework/config/ChannelConfigHandler.py
@@ -20,7 +20,7 @@ _MANDATORY_CHANNEL_KEYS = {'sources', 'logicengines', 'transforms', 'publishers'
 _ALLOWED_CHANNEL_KEYS = _MANDATORY_CHANNEL_KEYS | {'task_manager'}
 _MANDATORY_MODULE_KEYS = {"module", "name", "parameters"}
 
-def _make_logger(global_config):
+def _make_de_logger(global_config):
     if 'logger' not in global_config:
         raise RuntimeError("No logger configuration has been specified.")
     try:
@@ -134,7 +134,7 @@ class ChannelConfigHandler():
     def __init__(self, global_config, channel_config_dir):
         self.channel_config_dir = channel_config_dir
         self.channels = {}
-        self.logger = _make_logger(global_config)
+        self.logger = _make_de_logger(global_config)
 
     def get_produces(self, channel_config):
         produces = {}

--- a/framework/engine/DecisionEngine.py
+++ b/framework/engine/DecisionEngine.py
@@ -385,7 +385,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
             log_level_code = getattr(logging, log_level)
             if worker.task_manager.get_loglevel() == log_level_code:
                 return f"Nothing to do. Current log level is : {log_level}"
-            worker.task_manager.set_loglevel(log_level)
+            worker.task_manager.set_loglevel_value(log_level)
         return f"Log level changed to : {log_level}"
 
     def rpc_reaper_start(self, delay=0):

--- a/framework/engine/Workers.py
+++ b/framework/engine/Workers.py
@@ -6,7 +6,8 @@ import threading
 import decisionengine.framework.taskmanager.ProcessingState as ProcessingState
 
 FORMATTER = logging.Formatter(
-    "%(asctime)s - %(name)s - %(module)s - %(process)d - %(threadName)s - %(levelname)s - %(message)s")
+    "%(asctime)s - %(name)s - %(module)s - %(process)d - %(threadName)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S%z")
 
 
 class Worker(multiprocessing.Process):
@@ -41,6 +42,7 @@ class Worker(multiprocessing.Process):
 
     def run(self):
         logger = logging.getLogger()
+        logger.setLevel(logging.WARNING)
         logger_rotate_by = self.logger_config.get("file_rotate_by", "size")
 
         if logger_rotate_by == "size":
@@ -61,10 +63,10 @@ class Worker(multiprocessing.Process):
                                                                      interval=self.logger_config.get("rotation_time_interval", '1'))
 
         file_handler.setFormatter(FORMATTER)
-        logger.setLevel(logging.WARNING)
         logger.addHandler(file_handler)
+
         channel_log_level = self.logger_config.get("global_channel_log_level", "WARNING")
-        self.task_manager.set_loglevel(channel_log_level)
+        self.task_manager.set_loglevel_value(channel_log_level)
         self.task_manager.run()
 
 

--- a/framework/modules/de_logger.py
+++ b/framework/modules/de_logger.py
@@ -41,7 +41,8 @@ def set_logging(log_level,
         return
 
     formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(module)s - %(threadName)s - %(levelname)s - %(message)s")
+        "%(asctime)s - %(name)s - %(module)s - %(threadName)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S%z")
 
     if file_rotate_by == "size":
         file_handler = logging.handlers.RotatingFileHandler(log_file_name,
@@ -97,7 +98,8 @@ def set_stream_logging(logger_name=''):
     """
     logger = logging.getLogger("decision_engine")
     formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(module)s - %(levelname)s - %(message)s")
+        "%(asctime)s - %(name)s - %(module)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S%z")
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/framework/taskmanager/TaskManager.py
+++ b/framework/taskmanager/TaskManager.py
@@ -176,7 +176,6 @@ class TaskManager:
 
         while not self.state.should_stop():
             try:
-                logging.getLogger().setLevel(self.loglevel.value)
                 self.wait_for_any(done_events)
                 self.decision_cycle()
                 if self.state.should_stop():
@@ -207,7 +206,7 @@ class TaskManager:
     def get_state_name(self):
         return self.get_state().name
 
-    def set_loglevel(self, log_level):
+    def set_loglevel_value(self, log_level):
         """Assumes log_level is a string corresponding to the supported logging-module levels."""
         with self.loglevel.get_lock():
             # Convert from string to int form using technique


### PR DESCRIPTION
- logging times are now listed in ISO-8601 format
- changed name of two functions to make code clearer

RB: https://fermicloud140.fnal.gov/reviews/r/344/