### PR TITLE
Improved DE client usage

### DIFF
--- a/framework/tests/test_restart_channel.py
+++ b/framework/tests/test_restart_channel.py
@@ -39,7 +39,7 @@ def test_restart_channel(deserver_mock_data_block):
 
     # Take channel offline
     output = deserver_mock_data_block.rpc_stop_channel('test_channel')
-    assert output == 'OK'
+    assert output == 'Channel test_channel stopped cleanly.'
 
     # Verify no channels are active
     output = deserver_mock_data_block.rpc_status()

--- a/framework/tests/test_start_with_no_channels.py
+++ b/framework/tests/test_start_with_no_channels.py
@@ -56,11 +56,21 @@ def test_start_from_nothing(deserver_mock_data_block):
 
     # Take channel offline
     output = deserver.rpc_stop_channel('test_channel')
-    assert output == 'OK'
+    assert output == 'Channel test_channel stopped cleanly.'
 
     # Verify no channels are active
     output = deserver.rpc_status()
     assert "No channels are currently active" in output
+
+    # Bring channel back online
+    deserver.rpc_start_channel('test_channel')
+    deserver.block_while(State.BOOT)
+    output = deserver.rpc_status()
+    assert re.search('test_channel.*state = STEADY', output)
+
+    # Kill channel
+    output = deserver.rpc_kill_channel('test_channel', 0)
+    assert output == 'Channel test_channel has been killed.'
 
     # Verify that the relevant configuration file still exists.
     assert os.path.exists(new_config_path)


### PR DESCRIPTION
This PR adjusts the behavior of the stopping channels.  Input is desired whether these behaviors are acceptable.

----

## Stopping channels

The `de-client --stop-channel` command will not longer forcibly terminate a channel process.  The DE server will wait until the channel stops cleanly, and then return to the client.  Typical CLI:

```console
$ de-client --stop-channel resource_request
Channel resource_requested stopped cleanly.
```

See option 1 below for achieving the current `--stop-channel` behavior.

## Killing channels

To forcibly terminate a channel, there is a `--kill-channel` are several options:

1. `de-client --kill-channel` attempts to cleanly shutdown the channel based on the DE server's configured `shutdown_timeout` parameter.  If the timeout is exceeded, then the channel process is terminated, returning to the client.   This option is identical to the current `de-client --stop-channel` behavior.   Typical CLI: 
    ```console
    $ de-client --kill-channel resource_request
    Channel resource_request has been killed due to shutdown timeout (10 seconds).
    ```
2. `de-client --timeout 60 --kill-channel` is the same as 1. except the DE-server configured timeout is overridden by the `--timeout` value (60 seconds in this case).  Typical CLI: 
    ```console
    $ de-client --timeout 60 --kill-channel resource_request 
    Channel resource_request has been killed due to shutdown timeout (60 seconds).
    ```
3. `de-client --force --kill-channel resource_request` immediately terminates the channel with no attempt to cleanly stop the channel process.  Typical CLI: 
    ```console
    $ de-client --force --kill-channel resource_request
    Channel resource_request has been killed.
    ```