### PR TITLE
Remove unused make target from Logic Engine CMakeFiles.txt in branch 1.5

### DIFF
--- a/framework/logicengine/cxx/CMakeLists.txt
+++ b/framework/logicengine/cxx/CMakeLists.txt
@@ -38,5 +38,3 @@ set_target_properties(RE PROPERTIES SUFFIX ${EXT_SUFFIX})
 # Install in decisionengine/framework/logicengine subdirectory for
 # Python runtime availability
 install(TARGETS RE DESTINATION ${CMAKE_SOURCE_DIR}/../)
-
-add_custom_target(liblinks ln -s ${CMAKE_BINARY_DIR}/RE.so ${CMAKE_SOURCE_DIR}/../ COMMAND ln -s ${CMAKE_BINARY_DIR}/libLogicEngine.so ${CMAKE_SOURCE_DIR}/../)


### PR DESCRIPTION
This PR is for branch 1.5
Remove unused make 'liblinks' target from Logic Engine CMakeFiles.txt

RB: https://fermicloud140.fnal.gov/reviews/r/353/