### PR TITLE
Protect against missing values in logic-engine expressions

### DIFF
--- a/src/decisionengine/framework/logicengine/BooleanExpression.py
+++ b/src/decisionengine/framework/logicengine/BooleanExpression.py
@@ -12,14 +12,16 @@
 import ast
 import logging
 
-# If support for direct use of numpy and pandas functions becomes
-# wanted, then uncomment the following two import statements, and
-# switch the definition of facts_globals to the commented-out
-# version.#
+# If support for direct use of numpy and pandas functions is desired,
+# import the numpy and pandas modules and adjust the facts_globals:
+#   facts_globals.update(np=np, pd=pd)
 
-facts_globals = {}
-# facts_globals = {"np": np, "pd": pd}
 
+def fail_on_error(expr):
+    pass
+
+
+facts_globals = {'fail_on_error': fail_on_error}
 
 class LogicError(TypeError):
     pass
@@ -49,6 +51,7 @@ class BooleanExpression:
         syntax_tree = ast.parse(expr, source, mode)
         all_names = [n.id for n in ast.walk(syntax_tree) if isinstance(n, ast.Name)]
         func_names = [function_name_from_call(n) for n in ast.walk(syntax_tree) if isinstance(n, ast.Call)]
+        self.fail_on_error = func_names[0] == 'fail_on_error' if func_names else False
 
         self.required_names = list(set(all_names) - set(func_names))
         self.expr = compile(syntax_tree, source, mode)
@@ -57,7 +60,14 @@ class BooleanExpression:
         """Return the evaluated Boolen value of this expression in the context
         of the given data 'd'."""
         logging.getLogger().debug("calling NamedFact::evaluate()")
-        return bool(eval(self.expr, facts_globals, d))
+        try:
+            return bool(eval(self.expr, facts_globals, d))
+        except Exception:
+            if self.fail_on_error:
+                logging.getLogger().exception("The following exception was suppressed, and the "
+                                              "Boolean expression will evaluate to False.")
+                return False
+            raise
 
     def __str__(self):
         return f"{self.expr_str}"

--- a/src/decisionengine/framework/logicengine/LogicEngine.py
+++ b/src/decisionengine/framework/logicengine/LogicEngine.py
@@ -33,7 +33,21 @@ class LogicEngine(Module):
         :rtype: dict
         :returns: Evaluated fact values (e.g. True or False) for each fact name.
         """
-        return {name: f.evaluate(db) for name, f in self.facts.items()}
+        try:
+            return {name: f.evaluate(db) for name, f in self.facts.items()}
+        except NameError as e:
+            msg = f"The following error was encountered: {e}\n"
+            if len(db) == 0:
+                msg += "No fact names are available."
+            else:
+                msg += "Allowed fact names are:\n"
+                for key in db:
+                    msg += "  '" + key + "'\n"
+            self.logger.error(msg)
+            raise e
+        except Exception as e:
+            self.logger.exception("Unexpected exception while evaluating facts.")
+            raise e
 
     def evaluate(self, db):
         """

--- a/src/decisionengine/framework/logicengine/tests/test_missing_value.py
+++ b/src/decisionengine/framework/logicengine/tests/test_missing_value.py
@@ -1,0 +1,37 @@
+from decisionengine.framework.logicengine.LogicEngine import LogicEngine
+import pytest
+
+
+def logic_engine_with_fact(fact):
+    facts = {"f1": fact}
+    rules = {"r1": {"expression": "f1"}}
+    return LogicEngine({"facts": facts, "rules": rules})
+
+def test_misspecified_fact():
+    engine = logic_engine_with_fact("val > 10")
+    with pytest.raises(NameError, match="name 'val' is not defined"):
+        engine.evaluate_facts({"var": 20})
+
+def test_fact_with_misspecified_attribute():
+    class MissingValue:
+        pass
+    engine = logic_engine_with_fact("val.does_not_exist()")
+    with pytest.raises(Exception,
+                       match="'MissingValue' object has no attribute 'does_not_exist'"):
+        engine.evaluate_facts({"val": MissingValue()})
+
+def test_conditional_fact():
+    engine = logic_engine_with_fact("val[0] if val else False")
+    facts = engine.evaluate_facts({"val": []})
+    assert facts == {"f1": False}
+
+def test_lookup_error():
+    engine = logic_engine_with_fact("val[0] == 42")
+    with pytest.raises(IndexError, match="list index out of range"):
+        engine.evaluate_facts({"val": []})
+
+def test_fail_on_error(caplog):
+    engine = logic_engine_with_fact("fail_on_error(val[0])")
+    facts = engine.evaluate_facts({"val": []})
+    assert facts == {"f1": False}
+    assert "list index out of range" in caplog.text


### PR DESCRIPTION
This PR enables the conversion of an exception to a `False` return value for a logic-engine expression.  This is enabled with the following syntax:

```yaml
facts: {
  f1: "fail_on_error( ... )"
}
```

where the ellipsis  `...` is the expression that may raise an exception upon evaluation.  The behavior is that whenever `fail_on_error` is  specified and the evaluated expression results in an exception:

- The exception message will be logged, and
- The fact will evaluate to `False`