### PR TITLE
Add missing runtime requirement

### DIFF
--- a/requirements/requirements-runtime.txt
+++ b/requirements/requirements-runtime.txt
@@ -1,5 +1,6 @@
 # for runtime
 jsonnet  >= 0.17.0
+numpy >= 1.19
 pandas >= 1.1.5
 tabulate >= 0.8.7
 toposort >= 1.6


### PR DESCRIPTION
The python only logic engine uses numpy directly.