### PR TITLE
Constrain gh-pages creation to pushed tags

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -2,11 +2,11 @@
 name: Make Our Github Pages
 
 # Controls when the action will run. Triggers the workflow on push
-# events - but only for the master branch
+# events - but only for pushed tags
 on:
   push:
-    branches:
-      - master
+    tags:
+      - [0-9].[0-9]+
 
 jobs:
   build-docs:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -6,7 +6,7 @@ name: Make Our Github Pages
 on:
   push:
     tags:
-      - [0-9].[0-9]+
+      - '[0-9].[0-9]+'
 
 jobs:
   build-docs:


### PR DESCRIPTION
Every time I update my fork's `master` branch, the GitHub pages are re-created.  This PR adjusts the settings so that the documentation is created only when a tag is pushed.

This is mostly a conversation starter.  Perhaps there is an equivalent way to achieve this.