### PR TITLE
Some repos may error out, don't let them kill the build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Install sphinx expected fonts within the container
         run: |
-          sudo apt-get update
+          sudo apt-get update || true
           sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
           sudo pip install -U pip
           sudo pip3 install sphinx

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Install sphinx expected fonts within the container
       run: |
-        sudo apt-get update
+        sudo apt-get update || true
         sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
         sudo python3 -m pip install -U pip
         sudo python3 -m pip install sphinx


### PR DESCRIPTION
With the default container switching to a new version not all gh-repos are fully ready