### PR TITLE
[BACKPORT]Setuptools uses entry return value as an error msg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         "console_scripts": [
             "de-reaper=decisionengine.framework.utils.reaper:main",
             "decisionengine=decisionengine.framework.engine.DecisionEngine:main",  # noqa: E501
-            "de-client=decisionengine.framework.engine.de_client:main",
+            "de-client=decisionengine.framework.engine.de_client:console_scripts_main",  # noqa: E501
         ],
     },
     options={

--- a/src/decisionengine/framework/engine/de_client.py
+++ b/src/decisionengine/framework/engine/de_client.py
@@ -226,6 +226,17 @@ def main(args_to_parse=None):
             msg += f'\n{e}'
         return msg
 
+def console_scripts_main(args_to_parse=None):
+    """
+    This is the entry point for the setuptools auto generated scripts.
+    Setuptools thinks a return from this function is an error message.
+    """
+    msg = main(args_to_parse)
+    if "An error occurred while trying to access a DE server" in msg:
+        return msg
+    else:
+        print(msg)
+
 
 if __name__ == "__main__":
-    print(main())
+    console_scripts_main()

--- a/src/decisionengine/framework/engine/tests/test_client_only.py
+++ b/src/decisionengine/framework/engine/tests/test_client_only.py
@@ -25,8 +25,18 @@ def test_client_with_no_server():
         "An error occurred while trying to access a DE server at 'http://localhost:8888'\n" + \
         "Please ensure that the host and port names correspond to a running DE instance."
 
+def test_client_with_no_server_verbose():
+    msg = de_client.main(['--status', '--verbose'])
+    if "Connection refused" not in msg and "Cannot assign requested address" not in msg:
+        raise ValueError(msg)
+
 def test_exclusive_options():
     assert de_client.main(['--force']) == \
         "The --force (-f) option may be used only with --kill-channel."
     assert de_client.main(['--timeout', '2']) == \
         "The --timeout option may be used only with --kill-channel."
+
+def test_client_err_returned_as_rc():
+    """no de server is running, so --status should error"""
+    msg = de_client.console_scripts_main(['--status'])
+    assert 'An error occurred' in msg

--- a/src/decisionengine/framework/tests/test_client_server.py
+++ b/src/decisionengine/framework/tests/test_client_server.py
@@ -1,12 +1,28 @@
 '''Fixture based DE Server for the de-client tests'''
 # pylint: disable=redefined-outer-name
 
+import io
+import sys
+
 import pytest
 
 from decisionengine.framework.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA # noqa: F401
 from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH # noqa: F401
 
 deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH) # pylint: disable=invalid-name
+
+@pytest.mark.usefixtures("deserver")
+def test_client_status_msg_to_stdout(deserver):
+    """Make sure the actuall client console call goes to stdout"""
+    import decisionengine.framework.engine.de_client as de_client
+
+    myoutput = io.StringIO()
+    sys.stdout = myoutput
+    de_client.console_scripts_main(['--host', deserver.server_address[0],
+                                    '--port', str(deserver.server_address[1]),
+                                    '--status'])
+    sys.stdout = sys.__stdout__
+    assert 'channel: test_channel' in myoutput.getvalue()
 
 @pytest.mark.usefixtures("deserver")
 def test_client_print_product(deserver):


### PR DESCRIPTION
Our unit tests use it to validate client behavior

Backport fix from main