### PR TITLE
The latest m2crypto seems to need swig now

### DIFF
--- a/package/container/Dockerfile
+++ b/package/container/Dockerfile
@@ -31,8 +31,8 @@ RUN yum -y install postgresql$(echo -n ${PG_VERSION} | tr -d '.')-server \
 
 # Install utils
 RUN yum -y install \
-    python3 python3-devel python3-pip python3-setuptools python3-wheel \
-    gcc gcc-c++ make \
+    python3 python3-pip python3-setuptools python3-wheel \
+    gcc gcc-c++ make python3-devel swig openssl-devel \
     git \
     rpm-build \
  && yum -y clean all


### PR DESCRIPTION
The decisionengine_modules python libraries use M2Crypto which now requires `swig` in the build root.