### PR TITLE
Support fail_on_error with regular-expression matching

### DIFF
--- a/src/decisionengine/framework/dataspace/datablock.py
+++ b/src/decisionengine/framework/dataspace/datablock.py
@@ -363,11 +363,11 @@ class DataBlock(object):
                                                    self.generation_id, key)
             value = ast.literal_eval(decompress(value))
         except KeyError:
-            self.logger.error("Did not get key in datablock __getitem__")
+            self.logger.error(f"Did not get key '{key}' in datablock __getitem__")
             value = default
 
         if not value:
-            self.logger.exception("No Key in datablock __getitem__")
+            self.logger.exception(f"No key '{key}' in datablock __getitem__")
             raise KeyError
 
         if value.get('pickled'):

--- a/src/decisionengine/framework/logicengine/tests/test_facts.py
+++ b/src/decisionengine/framework/logicengine/tests/test_facts.py
@@ -1,4 +1,4 @@
-from decisionengine.framework.logicengine.BooleanExpression import BooleanExpression, facts_globals
+from decisionengine.framework.logicengine.BooleanExpression import BooleanExpression, _facts_globals
 import pytest
 
 
@@ -10,8 +10,14 @@ def test_simple_fact():
     assert fact.evaluate({"z": 200}) is False
 
 
-def test_compound_fact():
-    fact = BooleanExpression("z < 100 and a == 4")
+def test_syntax_error(caplog):
+    with pytest.raises(SyntaxError):
+        BooleanExpression("z <")
+    assert "The following expression string could not be parsed" in caplog.text
+
+
+def test_compound_fact_with_spaces():
+    fact = BooleanExpression(" z < 100 and a == 4 ")
     assert set(fact.required_names) == {"z", "a"}
     assert fact.evaluate({"z": 50, "a": 4}) is True
     assert fact.evaluate({"z": 100, "a": 4}) is False
@@ -26,11 +32,16 @@ def test_fact_with_nested_names():
     assert set(fact.required_names) == {"z", "b"}
 
 
+def test_fact_with_fail_on_error():
+    fact = BooleanExpression("fail_on_error(a[0])")
+    assert set(fact.required_names) == {"a"}
+
+
 # We need to use this helper function to make sure the name np is not
 # seen in the context of the use of the facts.
 #
 # Add in __builtins__ so we can use 'import numpy as np' under a BooleanExpression
-facts_globals.update({'__builtins__': __builtins__})
+_facts_globals.update({'__builtins__': __builtins__})
 def make_db(maximum):
     import numpy as np
     return {"vals": np.arange(maximum)}

--- a/src/decisionengine/framework/logicengine/tests/test_fail_on_error.py
+++ b/src/decisionengine/framework/logicengine/tests/test_fail_on_error.py
@@ -7,6 +7,26 @@ def logic_engine_with_fact(fact):
     rules = {"r1": {"expression": "f1"}}
     return LogicEngine({"facts": facts, "rules": rules})
 
+def test_true_literal_fact():
+    engine = logic_engine_with_fact("fail_on_error(True)")
+    facts = engine.evaluate_facts({})
+    assert facts == {"f1": True}
+
+def test_false_literal_fact():
+    engine = logic_engine_with_fact("fail_on_error(False)")
+    facts = engine.evaluate_facts({})
+    assert facts == {"f1": False}
+
+def test_true_fact():
+    engine = logic_engine_with_fact("fail_on_error(1 < 2)")
+    facts = engine.evaluate_facts({})
+    assert facts == {"f1": True}
+
+def test_false_fact_with_spaces():
+    engine = logic_engine_with_fact(" fail_on_error ( 2 < 1 )")
+    facts = engine.evaluate_facts({})
+    assert facts == {"f1": False}
+
 def test_misspecified_fact():
     engine = logic_engine_with_fact("val > 10")
     with pytest.raises(NameError, match="name 'val' is not defined"):
@@ -25,7 +45,7 @@ def test_conditional_fact():
     facts = engine.evaluate_facts({"val": []})
     assert facts == {"f1": False}
 
-def test_lookup_error():
+def test_index_error():
     engine = logic_engine_with_fact("val[0] == 42")
     with pytest.raises(IndexError, match="list index out of range"):
         engine.evaluate_facts({"val": []})

--- a/src/decisionengine/framework/taskmanager/tests/channels/failing_publisher.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/failing_publisher.jsonnet
@@ -21,7 +21,7 @@
       name: 'LogicEngine',
       parameters: {
         facts: {
-          pass_all: "(True)"
+          pass_all: "fail_on_error(True)"
         },
         rules: {
           r1: {


### PR DESCRIPTION
Fix `fail_on_error` error as reported in #318.