### PR TITLE
We aren't testing 'unversioned" releases

### DIFF
--- a/src/decisionengine/framework/about.py
+++ b/src/decisionengine/framework/about.py
@@ -5,7 +5,7 @@
 try:
     # This is built by setuptools_scm
     from .version import version as __version__  # noqa: F401
-except ImportError:
+except ImportError:  # pragma: no cover
     __version__ = 'DEVELOPMENT'
 
 __title__ = 'decisionengine'


### PR DESCRIPTION
Since the testing code ensures `__version__` is defined, we may as well note what we expect.