### PR TITLE
Enable DE class inference based on configuration

### DIFF
--- a/src/decisionengine/framework/config/ChannelConfigHandler.py
+++ b/src/decisionengine/framework/config/ChannelConfigHandler.py
@@ -18,7 +18,7 @@ import decisionengine.framework.util.tsort as tsort
 
 _MANDATORY_CHANNEL_KEYS = {'sources', 'logicengines', 'transforms', 'publishers'}
 _ALLOWED_CHANNEL_KEYS = _MANDATORY_CHANNEL_KEYS | {'task_manager'}
-_MANDATORY_MODULE_KEYS = {"module", "name", "parameters"}
+_MANDATORY_MODULE_KEYS = {"module", "parameters"}
 
 def _make_de_logger(global_config):
     if 'logger' not in global_config:

--- a/src/decisionengine/framework/taskmanager/tests/NoSource.py
+++ b/src/decisionengine/framework/taskmanager/tests/NoSource.py
@@ -1,0 +1,3 @@
+class NoSource:
+    def __init__(self, parameters):
+        pass

--- a/src/decisionengine/framework/taskmanager/tests/TwoSources.py
+++ b/src/decisionengine/framework/taskmanager/tests/TwoSources.py
@@ -1,0 +1,9 @@
+from decisionengine.framework.modules.Source import Source
+
+class Source1(Source):
+    def __init__(self, params):
+        pass
+
+class Source2(Source):
+    def __init__(self, params):
+        pass

--- a/src/decisionengine/framework/taskmanager/tests/channels/failing_publisher.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/failing_publisher.jsonnet
@@ -2,7 +2,6 @@
   sources: {
     source1: {
       module: "decisionengine.framework.tests.SourceNOP",
-      name: "SourceNOP",
       parameters: {},
       schedule: 1,
      }
@@ -11,14 +10,12 @@
   transforms: {
     bar_maker: {
       module: "decisionengine.framework.tests.TransformNOP",
-      name: "TransformNOP",
       parameters: {}
     }
   },
   logicengines: {
     le: {
       module: "decisionengine.framework.logicengine.LogicEngine",
-      name: 'LogicEngine',
       parameters: {
         facts: {
           pass_all: "fail_on_error(True)"
@@ -35,7 +32,6 @@
   publishers: {
     fail: {
       module: "decisionengine.framework.tests.FailingPublisher",
-      name: "FailingPublisher",
       parameters: {}
     }
   }

--- a/src/decisionengine/framework/taskmanager/tests/test_module_inference.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_module_inference.py
@@ -1,0 +1,23 @@
+from decisionengine.framework.taskmanager.TaskManager import _create_module_instance
+from decisionengine.framework.modules.Source import Source
+
+import pytest
+
+
+def test_no_module():
+    config = {'module': 'decisionengine.framework.taskmanager.tests.NoSource',
+              'parameters': {}}
+    with pytest.raises(RuntimeError, match="Could not find a decision-engine 'Source'"):
+        _create_module_instance(config, Source)
+
+def test_too_many_modules():
+    config = {'module': 'decisionengine.framework.taskmanager.tests.TwoSources',
+              'parameters': {}}
+    with pytest.raises(RuntimeError, match="Found more than one decision-engine 'Source'"):
+        _create_module_instance(config, Source)
+
+def test_select_one_of_two_modules():
+    config = {'module': 'decisionengine.framework.taskmanager.tests.TwoSources',
+              'name': 'Source2',
+              'parameters': {}}
+    _create_module_instance(config, Source)


### PR DESCRIPTION
The DE configuration system requires operators to separately specify (a) the Python `module` that contains the DE module definition, and (b) the `name` of the class inside that module that will be used to create the DE module instance.  Python's introspection facilities are good enough that specifying the `name` should not be necessary.

This PR makes the `name` configuration parameter optional in almost all cases, thus removing unnecessary boilerplate.  In other words, the following change can be made in all Jsonnet configurations (e.g.):

```diff
  sources: {
    source1: {
      module: "module.specification.for.MySource"
-     name: "MySource"
      ...
    }
  }
```

The behavior is as follows:

- If the `name` parameter is specified, it will be honored.
- If the `name` parameter is not specified, the framework will search inside the specified Python module for the (sub)class of the correct type (e.g. for the sources, the framework will look for a class in the module that inherits from `Source`).
- It is an error if no (sub)class can be found or if multiple (sub)classes are found; if the latter, the operator must specify the `name` parameter to disambiguate between classes.

This PR is a feature enhancement and introduces no breaking changes.
