### PR TITLE
Add de-query-tool

### DIFF
--- a/src/decisionengine/framework/dataspace/datablock.py
+++ b/src/decisionengine/framework/dataspace/datablock.py
@@ -330,8 +330,8 @@ class DataBlock(object):
         else:
             self._insert(key, store_value, header, metadata)
 
-    def get_dataproducts(self):
-        values = self.dataspace.get_dataproducts(self.sequence_id)
+    def get_dataproducts(self, key=None):
+        values = self.dataspace.get_dataproducts(self.sequence_id, key)
         result = []
 
         try:

--- a/src/decisionengine/framework/dataspace/datasource.py
+++ b/src/decisionengine/framework/dataspace/datasource.py
@@ -162,12 +162,14 @@ class DataSource(object, metaclass=abc.ABCMeta):  # pragma: no cover
         return
 
     @abc.abstractmethod
-    def get_dataproducts(self, taskmanager_id):
+    def get_dataproducts(self, taskmanager_id, key):
         """
         Return list of all data products associated with
         with taskmanager_id
 
         :type taskmanager_id: :obj:`string`
+        :type key: :obj:`string`
+        :arg key: data product key
         """
         self.logger.info('datasource is getting all dataproducts for a taskmanger')
         return

--- a/src/decisionengine/framework/dataspace/datasources/postgresql.py
+++ b/src/decisionengine/framework/dataspace/datasources/postgresql.py
@@ -49,9 +49,9 @@ and foo.taskmanager_id=%s AND foo.generation_id=%s AND foo.key=%s
 """
 
 SELECT_PRODUCTS = """
-SELECT tm.taskmanager_id, foo.* FROM {} foo, taskmanager tm
-WHERE tm.sequence_id = foo.taskmanager_id
-and foo.taskmanager_id=%s
+SELECT tm.taskmanager_id, foo.* FROM {} foo JOIN taskmanager tm
+ON tm.sequence_id = foo.taskmanager_id
+WHERE foo.taskmanager_id=%s
 """
 
 SELECT_LAST_GENERATION_ID_BY_NAME = """
@@ -291,8 +291,10 @@ class Postgresql(ds.DataSource):
             raise KeyError("taskmanager_id={} or generation_id={} or key={} not found".format(
                 taskmanager_id, generation_id, key))
 
-    def get_dataproducts(self, taskmanager_id):
+    def get_dataproducts(self, taskmanager_id, key=None):
         q = SELECT_PRODUCTS.format(ds.DataSource.dataproduct_table)
+        if key:
+            q += f"AND foo.key = '{key}'"
         try:
             result = []
             rows = self._select_dictresult(q, (taskmanager_id,))

--- a/src/decisionengine/framework/dataspace/datasources/tests/test_postgresql.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/test_postgresql.py
@@ -133,6 +133,20 @@ def test_get_last_generation_id(datasource, taskmanager, data):
     except Exception as e:
         assert e.__class__ == KeyError
 
+def test_get_dataproducts(datasource, taskmanager, data):
+    # test retrieved dataproducts
+    result = datasource.get_dataproducts(data["taskmanager"][0]["taskmanager_id"])
+    assert result[0]["key"] == data["dataproduct"][0]["key"]
+
+    result = datasource.get_dataproducts(data["taskmanager"][0]["taskmanager_id"], data["dataproduct"][0]["key"])
+    assert result[0]["key"] == data["dataproduct"][0]["key"]
+
+    # test taskmanager not present in the database
+    try:
+        datasource.get_dataproducts(taskmanager["taskmanager_id"])
+    except Exception as e:
+        assert e.__class__ == IndexError
+
 def test_insert(datasource, dataproduct, header, metadata):
     datasource.insert(dataproduct["taskmanager_id"], dataproduct["generation_id"], dataproduct["key"],
                       dataproduct["value"].encode(), header, metadata)

--- a/src/decisionengine/framework/dataspace/dataspace.py
+++ b/src/decisionengine/framework/dataspace/dataspace.py
@@ -144,8 +144,8 @@ class DataSpace():
     def get_dataproduct(self, taskmanager_id, generation_id, key):
         return self.datasource.get_dataproduct(taskmanager_id, generation_id, key)
 
-    def get_dataproducts(self, taskmanager_id):
-        return self.datasource.get_dataproducts(taskmanager_id)
+    def get_dataproducts(self, taskmanager_id, key=None):
+        return self.datasource.get_dataproducts(taskmanager_id, key)
 
     def get_header(self, taskmanager_id, generation_id, key):
         return self.datasource.get_header(taskmanager_id, generation_id, key)

--- a/src/decisionengine/framework/engine/de_query_tool.py
+++ b/src/decisionengine/framework/engine/de_query_tool.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import argparse
+import xmlrpc.client
+
+def create_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "product",
+        metavar='<product>',
+        help="product to query")
+    parser.add_argument(
+        "--format",
+        metavar='<format>',
+        help="Possible formats are 'csv', 'json'.")
+    parser.add_argument(
+        "--since",
+        metavar='<time>',
+        help="Minimum start time for task managers. "
+             "If omitted, searches only the current task manager.\n"
+             "(e.g. 2021-03-21 11:00:00)")
+    parser.add_argument(
+        "--port",
+        metavar='<port number>',
+        default="8888",
+        help="Default port is 8888")
+    parser.add_argument(
+        "--host",
+        metavar='<hostname>',
+        default="localhost",
+        help="Default hostname is 'localhost'")
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help="Include exception message in printout if server is inaccessible")
+
+    return parser
+
+def execute_command_from_args(argsparsed, de_socket):
+    """Calls the proper function for the arguments passed to de_query_tool.
+
+    Args:
+        argsparsed (Namespace): Should be from create_parser in this file.
+        de_socket (ServerProxy): RPC Server Proxy.
+
+    Returns:
+        str: Output of the command.
+    """
+
+    return de_socket.query_tool(argsparsed.product, argsparsed.format, argsparsed.since)
+
+def main(args_to_parse=None):
+    """Main function for de_query_tool
+
+    Args:
+        args_to_parse (list, optional): If you pass a list of args, they will be used instead of sys.argv. Defaults to None.
+
+    Returns:
+        str: Query result
+    """
+
+    parser = create_parser()
+    args = parser.parse_args(args_to_parse)
+    url = f"http://{args.host}:{args.port}"
+    de_socket = xmlrpc.client.ServerProxy(url, allow_none=True)
+    try:
+        return execute_command_from_args(args, de_socket)
+    except OSError as e:
+        msg = f"An error occurred while trying to access a DE server at '{url}'\n" + \
+            "Please ensure that the host and port names correspond to a running DE instance."
+        if args.verbose:
+            msg += f'\n{e}'
+        return msg
+    except Exception as e:  # pragma: no cover
+        msg = f"An error occurred while trying to access a DE server at '{url}'."
+        if args.verbose:
+            msg += f'\n{e}'
+        return msg
+
+
+if __name__ == "__main__":
+    print(main())

--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -8,6 +8,7 @@ import pytest
 from pytest_postgresql.janitor import DatabaseJanitor
 
 import decisionengine.framework.engine.de_client as de_client
+import decisionengine.framework.engine.de_query_tool as de_query_tool
 
 from decisionengine.framework.dataspace.datasources.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA, PG_PROG, DE_DB
 from decisionengine.framework.engine.DecisionEngine import _get_de_conf_manager, _create_de_server, parse_program_options
@@ -54,6 +55,18 @@ class DETestWorker(threading.Thread):
         return de_client.main(["--host", self.server_address[0],
                                "--port", str(self.server_address[1]),
                                *args])
+
+    def de_query_tool_run_cli(self, *args):
+        """
+        Run the DE Query Tool CLI with these args.
+        The DE Server host/port are automatically set for you.
+
+        Returns:
+            str: Query result
+        """
+        return de_query_tool.main(["--host", self.server_address[0],
+                                   "--port", str(self.server_address[1]),
+                                   *args])
 
 
 # pylint: disable=invalid-name

--- a/src/decisionengine/framework/engine/tests/test_query_tool_only.py
+++ b/src/decisionengine/framework/engine/tests/test_query_tool_only.py
@@ -1,0 +1,28 @@
+import decisionengine.framework.engine.de_query_tool as de_query_tool
+
+import re
+import subprocess
+
+# Unfortunately, because argparse short-circuits the '-h' process, we
+# need to run the -h option as a separate process, capturing the
+# output for testing.
+def test_query_tool_help():
+    de_query_tool_cmd = de_query_tool.__file__
+    output = subprocess.run([de_query_tool_cmd, "-h"], stdout=subprocess.PIPE)
+    assert re.match(b"usage: de_query_tool.py.*"
+                    b"positional arguments.*"
+                    b"optional arguments.*",
+                    output.stdout,
+                    flags=re.DOTALL)
+
+def test_query_tool_with_no_server():
+    assert de_query_tool.main(['foo']) == \
+        "An error occurred while trying to access a DE server at 'http://localhost:8888'\n" + \
+        "Please ensure that the host and port names correspond to a running DE instance."
+
+def test_query_tool_with_no_server_verbose():
+    msg = de_query_tool.main(['foo', '--verbose'])
+    if "Connection refused" not in msg \
+            and "Cannot assign requested address" not in msg \
+            and "Network is unreachable" not in msg:
+        raise ValueError(msg)

--- a/src/decisionengine/framework/tests/test_query_tool_server.py
+++ b/src/decisionengine/framework/tests/test_query_tool_server.py
@@ -1,0 +1,97 @@
+'''Fixture based DE Server for the de-query-tool tests'''
+# pylint: disable=redefined-outer-name
+
+import re
+
+from datetime import datetime
+
+from decisionengine.framework.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA # noqa: F401
+from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH # noqa: F401
+
+deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH) # pylint: disable=invalid-name
+
+DEFAULT_OUTPUT = (
+    "Product foo:  Found in channel test_channel\n"
+    "+----+--------+--------+--------------+------------------+-----------------+\n"
+    "|    | key1   | key2   | channel      |   taskmanager_id |   generation_id |\n"
+    "|----+--------+--------+--------------+------------------+-----------------|\n"
+    "|  0 | value1 | 0.1    | test_channel |                1 |               1 |\n"
+    "|  1 | value2 | 2      | test_channel |                1 |               1 |\n"
+    "|  2 | value3 | Test   | test_channel |                1 |               1 |\n"
+    "|  3 | value1 | 0.1    | test_channel |                1 |               2 |\n"
+    "|  4 | value2 | 2      | test_channel |                1 |               2 |\n"
+    "|  5 | value3 | Test   | test_channel |                1 |               2 |\n"
+    "|  6 | value1 | 0.1    | test_channel |                1 |               3 |\n"
+    "|  7 | value2 | 2      | test_channel |                1 |               3 |\n"
+    "|  8 | value3 | Test   | test_channel |                1 |               3 |\n"
+    "+----+--------+--------+--------------+------------------+-----------------+\n"
+)
+
+def test_query_tool_default(deserver):
+    # Test default output
+    output = deserver.de_query_tool_run_cli('foo')
+    assert output == DEFAULT_OUTPUT
+
+def test_query_tool_csv(deserver):
+    # Test csv output
+    output = deserver.de_query_tool_run_cli('foo', '--format=csv')
+    assert output == (
+        "Product foo:  Found in channel test_channel\n"
+        ",key1,key2,channel,taskmanager_id,generation_id\n"
+        "0,value1,0.1,test_channel,1,1\n"
+        "1,value2,2,test_channel,1,1\n"
+        "2,value3,Test,test_channel,1,1\n"
+        "3,value1,0.1,test_channel,1,2\n"
+        "4,value2,2,test_channel,1,2\n"
+        "5,value3,Test,test_channel,1,2\n"
+        "6,value1,0.1,test_channel,1,3\n"
+        "7,value2,2,test_channel,1,3\n"
+        "8,value3,Test,test_channel,1,3\n"
+        "\n"
+    )
+
+def test_query_tool_json(deserver):
+    # Test json output
+    output = deserver.de_query_tool_run_cli('foo', '--format=json')
+    assert re.match(
+        r'Product foo:  Found in channel test_channel\n'
+        r'{\n'
+        r'\s*"key1":\s*{\n'
+        r'\s*"0":\s*"value1",\n\s*"1":\s*"value2",\n\s*"2":\s*"value3",\n'
+        r'\s*"3":\s*"value1",\n\s*"4":\s*"value2",\n\s*"5":\s*"value3",\n'
+        r'\s*"6":\s*"value1",\n\s*"7":\s*"value2",\n\s*"8":\s*"value3"\n'
+        r'\s*},\n'
+        r'\s*"key2":\s*{\n'
+        r'\s*"0":\s*0.1,\n\s*"1":\s*2,\n\s*"2":\s*"Test",\n'
+        r'\s*"3":\s*0.1,\n\s*"4":\s*2,\n\s*"5":\s*"Test",\n'
+        r'\s*"6":\s*0.1,\n\s*"7":\s*2,\n\s*"8":\s*"Test"\n'
+        r'\s*},\n'
+        r'\s*"channel":\s*{\n'
+        r'\s*"0":\s*"test_channel",\n\s*"1":\s*"test_channel",\n\s*"2":\s*"test_channel",\n'
+        r'\s*"3":\s*"test_channel",\n\s*"4":\s*"test_channel",\n\s*"5":\s*"test_channel",\n'
+        r'\s*"6":\s*"test_channel",\n\s*"7":\s*"test_channel",\n\s*"8":\s*"test_channel"\n'
+        r'\s*},\n'
+        r'\s*"taskmanager_id":\s*{\n'
+        r'\s*"0":\s*1,\n\s*"1":\s*1,\n\s*"2":\s*1,\n'
+        r'\s*"3":\s*1,\n\s*"4":\s*1,\n\s*"5":\s*1,\n'
+        r'\s*"6":\s*1,\n\s*"7":\s*1,\n\s*"8":\s*1\n'
+        r'\s*},\n'
+        r'\s*"generation_id":\s*{\n'
+        r'\s*"0":\s*1,\n\s*"1":\s*1,\n\s*"2":\s*1,\n'
+        r'\s*"3":\s*2,\n\s*"4":\s*2,\n\s*"5":\s*2,\n'
+        r'\s*"6":\s*3,\n\s*"7":\s*3,\n\s*"8":\s*3\n'
+        r'\s*}\n'
+        r'}\n',
+        output
+    )
+
+def test_query_tool_since(deserver):
+    # Test taskmanager start time
+    current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    output = deserver.de_query_tool_run_cli('foo', f'--since="{current_time}"')
+    assert output == DEFAULT_OUTPUT
+
+def test_query_tool_invalid_product(deserver):
+    # Test invalid product output
+    output = deserver.de_query_tool_run_cli('not_foo')
+    assert output == "Product not_foo: Not produced by any module\n"


### PR DESCRIPTION
This addresses issue #111 requested by @StevenCTimm.

The new **de-query-tool** fetches all generations of a product from one or more recent task managers.
I made some changes to the PostgreSQL datasoruce to make it possible to query data products by name.