### PR TITLE
Added set_to_shutdown method to TaskManager and accompanying test

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -362,6 +362,9 @@ class DecisionEngine(socketserver.ThreadingMixIn,
 
     def stop_worker(self, worker, timeout):
         if worker.is_alive():
+            self.logger.debug("Trying to shutdown worker")
+            worker.task_manager.set_to_shutdown()
+            self.logger.debug("Trying to take worker offline")
             worker.task_manager.take_offline(None)
             worker.join(timeout)
         if worker.exitcode is None:

--- a/src/decisionengine/framework/modules/Publisher.py
+++ b/src/decisionengine/framework/modules/Publisher.py
@@ -6,10 +6,10 @@ class Publisher(Module.Module):
         super().__init__(set_of_parameters)
 
     def consumes(self, name_list):
-        print("Called Publisher.consumes")
+        pass
 
     def publish(self, data_block=None):
-        print("Called Publisher.publish")
+        pass
 
     def shutdown(self):
-        print("Called Publisher.shutdown")
+        pass

--- a/src/decisionengine/framework/taskmanager/TaskManager.py
+++ b/src/decisionengine/framework/taskmanager/TaskManager.py
@@ -220,6 +220,16 @@ class TaskManager:
         with self.loglevel.get_lock():
             return self.loglevel.value
 
+    def set_to_shutdown(self):
+        self.state.set(State.SHUTTINGDOWN)
+        # The following logging statement is not properly logged.  This will
+        # be worked on in a future issue
+        logging.getLogger().debug('Shutting down.  Will call shutdown on all '
+                                  + 'publishers')
+        for publisher_worker in self.channel.publishers.values():
+            publisher_worker.worker.shutdown()
+        self.state.set(State.SHUTDOWN)
+
     def take_offline(self, current_data_block):
         """
         offline and stop task manager

--- a/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
@@ -16,7 +16,34 @@
        schedule: 1
      }
    },
-
-  logicengines: {},
-  publishers: {}
+  logicengines: {
+    "logicengine1": {
+      "module": "decisionengine.framework.logicengine.LogicEngine",
+      "name": "LogicEngine",
+      "parameters": {
+        "rules": {
+          "publish_nersc_fom": {
+            "expression": "(foo)",
+            "actions": [
+              "PublisherNOP"
+            ],
+            "facts": [
+              "foo"
+            ]
+          }
+        },
+        "facts": {
+          "foo": "(True)"
+        }
+      }
+    }
+  },
+  publishers: {
+    PublisherNOP: {
+      module: "decisionengine.framework.tests.PublisherNOP",
+      name : "PublisherNOP",
+      parameters: {},
+      schedule: 1
+    }
+  },
 }

--- a/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
@@ -2,6 +2,7 @@ import threading
 import os
 
 import pytest
+from unittest.mock import patch
 
 import decisionengine.framework.config.policies as policies
 from decisionengine.framework.config.ValidConfig import ValidConfig
@@ -43,6 +44,17 @@ class RunChannel:
 def test_task_manager_construction(mock_data_block):  # noqa: F811
     task_manager = task_manager_for('test_channel')
     assert task_manager.state.has_value(State.BOOT)
+
+
+@pytest.mark.usefixtures("mock_data_block")
+def test_set_to_shutdown(mock_data_block):  # noqa: F811
+    with RunChannel('test_channel') as task_manager:
+        task_manager.state.wait_until(State.STEADY)
+        m = 'decisionengine.framework.tests.PublisherNOP.PublisherNOP.shutdown'
+        with patch(m) as mocked_shutdown:
+            task_manager.set_to_shutdown()
+            mocked_shutdown.assert_called()
+        assert task_manager.state.has_value(State.SHUTDOWN)
 
 
 @pytest.mark.usefixtures("mock_data_block")

--- a/src/decisionengine/framework/tests/PublisherNOP.py
+++ b/src/decisionengine/framework/tests/PublisherNOP.py
@@ -1,6 +1,6 @@
 from decisionengine.framework.modules import Publisher
 
-CONSUMES = ["bar"]
+CONSUMES = ["foo"]
 
 
 class PublisherNOP(Publisher.Publisher):


### PR DESCRIPTION
This is the same set of code changes (_not_ commits) as #334, but on Marco's request, I've created a separate PR for the merge into 1.6.

I made sure the unit test passed, but in interest of full disclosure, I did _not_ test this code with a dummy channel like I did #334.