### PR TITLE
Set names for the various parallel code

### DIFF
--- a/src/decisionengine/framework/engine/Workers.py
+++ b/src/decisionengine/framework/engine/Workers.py
@@ -26,7 +26,7 @@ class Worker(multiprocessing.Process):
     '''
 
     def __init__(self, task_manager, logger_config):
-        super().__init__()
+        super().__init__(name=f'DEWorker-{task_manager.name}')
         self.task_manager = task_manager
         self.task_manager_id = task_manager.id
         self.logger_config = logger_config

--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -28,7 +28,7 @@ class DETestWorker(threading.Thread):
 
     def __init__(self, conf_path, channel_conf_path, server_address, db_info, conf_override=None, channel_conf_override=None):
         '''format of args should match what you set in conf_mamanger'''
-        super().__init__()
+        super().__init__(name='DETestWorker')
         self.server_address = server_address
 
         global_config, channel_config_loader = _get_de_conf_manager(conf_path, channel_conf_path, parse_program_options([]))

--- a/src/decisionengine/framework/taskmanager/tests/test_processing_state.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_processing_state.py
@@ -12,7 +12,7 @@ from decisionengine.framework.taskmanager.ProcessingState import INACTIVE_CONDIT
 
 class Worker(multiprocessing.Process):
     def __init__(self, state):
-        super().__init__()
+        super().__init__(name='TestWorker')
         self._state = state
 
     def run(self):

--- a/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
@@ -27,7 +27,7 @@ def task_manager_for(name):
 class RunChannel:
     def __init__(self, name):
         self._tm = task_manager_for(name)
-        self._thread = threading.Thread(target=self._tm.run)
+        self._thread = threading.Thread(name=name, target=self._tm.run)
 
     def __enter__(self):
         self._thread.start()


### PR DESCRIPTION
When the threads/workers develop oddities it can be handy for each one to have a name.  This should help track down which one is sad and hopefully lead us to why.

This code shouldn't run any differently, but should be easier to debug when things get confused.