### PR TITLE
ExecStopPre is not supported on all systemd instances

### DIFF
--- a/package/systemd/decisionengine.service
+++ b/package/systemd/decisionengine.service
@@ -9,7 +9,7 @@ EnvironmentFile = -/etc/sysconfig/decisionengine
 User = decisionengine
 Group = decisionengine
 ExecStart = /usr/bin/decisionengine
-ExecStopPre =- /usr/bin/echo "Running /usr/bin/de-client --stop" >&2
+ExecStop = /usr/bin/echo "Running /usr/bin/de-client --stop" >&2
 ExecStop = /usr/bin/de-client --stop
 
 [Install]


### PR DESCRIPTION
The extra specificity wasn't actually required for for the secondary command.  It is just for notification and logging.  Switching to the more widely supported `ExecStop` achieves the same goal and has wider compatibility.