### PR TITLE
Have client provide a hint when you ask for no behavior

### DIFF
--- a/src/decisionengine/framework/engine/de_client.py
+++ b/src/decisionengine/framework/engine/de_client.py
@@ -204,6 +204,8 @@ def execute_command_from_args(argsparsed, de_socket):
     if argsparsed.reaper_status:
         return de_socket.reaper_status()
 
+    return 'No command specified, try --help'
+
 
 def main(args_to_parse=None):
     '''If you pass a list of args, they will be used instead of sys.argv'''

--- a/src/decisionengine/framework/engine/tests/test_client_only.py
+++ b/src/decisionengine/framework/engine/tests/test_client_only.py
@@ -25,6 +25,12 @@ def test_client_with_no_server():
         "An error occurred while trying to access a DE server at 'http://localhost:8888'\n" + \
         "Please ensure that the host and port names correspond to a running DE instance."
 
+def test_client_with_no_command_says_use_help():
+    # --verbose doesn't do anything without an action item
+    msg = de_client.main(['--verbose'])
+    if "-h" not in msg:
+        raise ValueError(msg)
+
 def test_client_with_no_server_verbose():
     msg = de_client.main(['--status', '--verbose'])
     if "Connection refused" not in msg \


### PR DESCRIPTION
Running `de-client` with no arguments should return "something" so users know it works even if the server is broken.