### PR TITLE
Fix path error

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,7 @@
 [run]
 concurrency = multiprocessing
 branch = True
-source = framework
+source = src
 omit = */tests/*
 
 [report]


### PR DESCRIPTION
The coverage default path got left out of the setuptools migration somehow.