### PR TITLE
Fix name of ABC args

### DIFF
--- a/src/decisionengine/framework/dataspace/datasource.py
+++ b/src/decisionengine/framework/dataspace/datasource.py
@@ -238,13 +238,13 @@ class DataSource(object, metaclass=abc.ABCMeta):  # pragma: no cover
         return
 
     @abc.abstractmethod
-    def get_last_generation_id(self, name, taskmanager_id=None):
+    def get_last_generation_id(self, taskmanager_name, taskmanager_id=None):
         """
         Return last generation id for current task manager
         or taskmanager w/ task_manager_id.
 
-        :type name: :obj:`string`
-        :arg name: task manager name
+        :type taskmanager_name: :obj:`string`
+        :arg taskmanager_name: task manager name
         :type taskmanager_id: :obj:`string`
         :arg taskmanager_id: task manager id
         """

--- a/src/decisionengine/framework/dataspace/datasources/tests/fixtures.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/fixtures.py
@@ -1,27 +1,29 @@
-'''pytest fixtures/constants'''
+"""pytest fixtures/constants"""
 import os
 import threading
 from collections import UserDict
 
 import mock
 import pytest
+
 from pytest_postgresql import factories
 
-DE_DB_HOST = '127.0.0.1'
-DE_DB_USER = 'postgres'
+DE_DB_HOST = "127.0.0.1"
+DE_DB_USER = "postgres"
 DE_DB_PASS = None
-DE_DB_NAME = 'decisionengine'
-DE_SCHEMA = [os.path.dirname(os.path.abspath(__file__)) + "/../postgresql.sql", ]
+DE_DB_NAME = "decisionengine"
+DE_SCHEMA = [
+    os.path.dirname(os.path.abspath(__file__)) + "/../postgresql.sql",
+]
 
 # DE_DB_PORT assigned at random
-PG_PROG = factories.postgresql_proc(user=DE_DB_USER, password=DE_DB_PASS,
-                                    host=DE_DB_HOST, port=None)
-DE_DB = factories.postgresql('PG_PROG', dbname=DE_DB_NAME, load=DE_SCHEMA)
+PG_PROG = factories.postgresql_proc(user=DE_DB_USER, password=DE_DB_PASS, host=DE_DB_HOST, port=None)
+DE_DB = factories.postgresql("PG_PROG", dbname=DE_DB_NAME, load=DE_SCHEMA)
 
 
 @pytest.fixture
 def mock_data_block():
-    '''
+    """
     This fixture replaces the standard datablock implementation.
 
     The current DataBlock implementation does not own any data
@@ -34,14 +36,18 @@ def mock_data_block():
     avoiding the need for a datasource backend.  It is anticipated
     that a future design of the DataBlock will own the data products,
     thus making this mock class unnecessary.
-    '''
+    """
 
     class MockDataBlock(UserDict):
-        def __init__(self, products={}):
+        def __init__(self, products=None):
+            super().__init__()
             self.lock = threading.Lock()
             self.taskmanager_id = None
             self.generation_id = 1
-            self.data = products
+            if products:
+                self.data = products
+            else:
+                self.data = {}
 
         def duplicate(self):
             return MockDataBlock(self.data)
@@ -49,6 +55,6 @@ def mock_data_block():
         def put(self, key, product, header, metadata=None):
             self.data[key] = product
 
-    with mock.patch('decisionengine.framework.dataspace.datablock.DataBlock') as mock_data_block:
-        mock_data_block.return_value = MockDataBlock()
+    with mock.patch("decisionengine.framework.dataspace.datablock.DataBlock") as my_mock_data_block:
+        my_mock_data_block.return_value = MockDataBlock()
         yield


### PR DESCRIPTION
The class in use has `taskmanager_name` as the keyword argument.  Make the `ABC` match so our interfaces are in line with (a) usage and (b) documentation.