### PR TITLE
Add option to set taskmanager datestamp

### DIFF
--- a/src/decisionengine/framework/dataspace/datasource.py
+++ b/src/decisionengine/framework/dataspace/datasource.py
@@ -260,13 +260,15 @@ class DataSource(object, metaclass=abc.ABCMeta):  # pragma: no cover
         return
 
     @abc.abstractmethod
-    def store_taskmanager(self, taskmanager_name, taskmanager_id):
+    def store_taskmanager(self, taskmanager_name, taskmanager_id, datestamp=None):
         """
         Store TaskManager
         :type taskmanager_name: :obj:`string`
         :arg taskmanager_name: name of taskmanager to retrieve
         :type taskmanager_id: :obj:`string`
         :arg taskmanager_id: id of taskmanager to retrieve
+        :type datestamp: :obj:`datetime`
+        :arg datestamp: datetime of created object, defaults to 'now'
         """
         self.logger.info('datasource is storing a taskmanager')
         return

--- a/src/decisionengine/framework/dataspace/datasources/postgresql.py
+++ b/src/decisionengine/framework/dataspace/datasources/postgresql.py
@@ -132,7 +132,11 @@ class Postgresql(ds.DataSource):
     def create_tables(self):
         return True
 
-    def store_taskmanager(self, name, taskmanager_id):
+    def store_taskmanager(self, name, taskmanager_id, datestamp=None):
+        if datestamp:
+            return self._update_returning_result("INSERT INTO taskmanager (name, taskmanager_id, datestamp) values (%s, %s, %s)",
+                                                 (name, taskmanager_id, datestamp)).get('sequence_id')
+
         return self._update_returning_result("INSERT INTO taskmanager (name, taskmanager_id) values (%s, %s)",
                                              (name, taskmanager_id)).get('sequence_id')
 

--- a/src/decisionengine/framework/dataspace/datasources/tests/test_postgresql.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/test_postgresql.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import pytest
 
@@ -92,6 +93,8 @@ def test_create_tables(datasource):
 
 def test_store_taskmanager(datasource, taskmanager):
     result = datasource.store_taskmanager(taskmanager["name"], taskmanager["taskmanager_id"])
+    assert result > 0
+    result = datasource.store_taskmanager(taskmanager["name"], taskmanager["taskmanager_id"], datetime.datetime(2016, 3, 14))
     assert result > 0
 
 def test_get_taskmanager(datasource, taskmanager, data):


### PR DESCRIPTION
In order to easily test the reaper's ability to remove old entries, I need a clear way to set a taskmanager as having an old date.

I'm not sure this will get much use, but without it I have to break the database abstraction to build tests.  I'd rather not as it will further co-mingle the code in unpleasant ways.