### PR TITLE
Add set_to_shutdown method to facilitate running publisher shutdown methods

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -353,6 +353,9 @@ class DecisionEngine(socketserver.ThreadingMixIn,
 
     def stop_worker(self, worker, timeout):
         if worker.is_alive():
+            self.logger.debug("Trying to shutdown worker")
+            worker.task_manager.set_to_shutdown()
+            self.logger.debug("Trying to take worker offline")
             worker.task_manager.take_offline(None)
             worker.join(timeout)
         if worker.exitcode is None:

--- a/src/decisionengine/framework/modules/Publisher.py
+++ b/src/decisionengine/framework/modules/Publisher.py
@@ -13,7 +13,7 @@ class Publisher(Module):
         super().__init__(set_of_parameters)
 
     def publish(self, data_block=None):
-        print("Called Publisher.publish")
+        pass
 
     def shutdown(self):
-        print("Called Publisher.shutdown")
+        pass

--- a/src/decisionengine/framework/taskmanager/TaskManager.py
+++ b/src/decisionengine/framework/taskmanager/TaskManager.py
@@ -270,6 +270,14 @@ class TaskManager:
         with self.loglevel.get_lock():
             return self.loglevel.value
 
+    def set_to_shutdown(self):
+        self.state.set(State.SHUTTINGDOWN)
+        logging.getLogger("decision_engine").debug('Shutting down. Will call '
+            'shutdown on all publishers')
+        for publisher_worker in self.channel.publishers.values():
+            publisher_worker.worker.shutdown()
+        self.state.set(State.SHUTDOWN)
+
     def take_offline(self, current_data_block):
         """
         offline and stop task manager

--- a/src/decisionengine/framework/taskmanager/TaskManager.py
+++ b/src/decisionengine/framework/taskmanager/TaskManager.py
@@ -273,7 +273,7 @@ class TaskManager:
     def set_to_shutdown(self):
         self.state.set(State.SHUTTINGDOWN)
         logging.getLogger("decision_engine").debug('Shutting down. Will call '
-            'shutdown on all publishers')
+                                                   'shutdown on all publishers')
         for publisher_worker in self.channel.publishers.values():
             publisher_worker.worker.shutdown()
         self.state.set(State.SHUTDOWN)

--- a/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
@@ -2,21 +2,37 @@
   sources: {
     source1: {
       module: "decisionengine.framework.tests.SourceNOP",
-      name: "SourceNOP",
       parameters: {},
       schedule: 1,
-     }
-   },
-
-   transforms: {
-     transform1: {
-       module: "decisionengine.framework.tests.TransformNOP",
-       name : "TransformNOP",
-       parameters: {},
-       schedule: 1
-     }
-   },
-
-  logicengines: {},
-  publishers: {}
+    }
+  },
+  transforms: {
+    transform1: {
+      module: "decisionengine.framework.tests.TransformNOP",
+      parameters: {},
+      schedule: 1
+    }
+  },
+  logicengines: {
+    le1: {
+      module: "decisionengine.framework.logicengine.LogicEngine",
+      parameters: {
+        facts: {
+          pass_all: "True"
+        },
+        rules: {
+          r1: {
+            expression: 'pass_all',
+            actions: ['publisher1']
+          }
+        }
+      }
+    }
+  },
+  publishers: {
+    publisher1: {
+      module: "decisionengine.framework.tests.PublisherNOP",
+      parameters: {}
+    }
+  }
 }

--- a/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
@@ -2,6 +2,7 @@ import threading
 import os
 
 import pytest
+from unittest.mock import patch
 
 import decisionengine.framework.config.policies as policies
 from decisionengine.framework.config.ValidConfig import ValidConfig
@@ -43,6 +44,17 @@ class RunChannel:
 def test_task_manager_construction(mock_data_block):  # noqa: F811
     task_manager = task_manager_for('test_channel')
     assert task_manager.state.has_value(State.BOOT)
+
+
+@pytest.mark.usefixtures("mock_data_block")
+def test_set_to_shutdown(mock_data_block):  # noqa: F811
+    with RunChannel('test_channel') as task_manager:
+        task_manager.state.wait_until(State.STEADY)
+        m = 'decisionengine.framework.tests.PublisherNOP.PublisherNOP.shutdown'
+        with patch(m) as mocked_shutdown:
+            task_manager.set_to_shutdown()
+            mocked_shutdown.assert_called()
+        assert task_manager.state.has_value(State.SHUTDOWN)
 
 
 @pytest.mark.usefixtures("mock_data_block")


### PR DESCRIPTION
These are mostly the same changes as #334, but rebased on the current master, along with a unit test config file change to take advantage of the new produces/consumes code.