### PR TITLE
Simplify use of our PG fixtures

### DIFF
--- a/src/decisionengine/framework/dataspace/datasources/tests/fixtures.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/fixtures.py
@@ -8,17 +8,26 @@ import pytest
 
 from pytest_postgresql import factories
 
-DE_DB_HOST = "127.0.0.1"
-DE_DB_USER = "postgres"
-DE_DB_PASS = None
-DE_DB_NAME = "decisionengine"
-DE_SCHEMA = [
-    os.path.dirname(os.path.abspath(__file__)) + "/../postgresql.sql",
+__all__ = [
+    "DATABASES_TO_TEST",
+    "PG_PROG",
+    "PG_DE_DB_WITH_SCHEMA",
+    "mock_data_block",
 ]
 
 # DE_DB_PORT assigned at random
-PG_PROG = factories.postgresql_proc(user=DE_DB_USER, password=DE_DB_PASS, host=DE_DB_HOST, port=None)
-DE_DB = factories.postgresql("PG_PROG", dbname=DE_DB_NAME, load=DE_SCHEMA)
+PG_PROG = factories.postgresql_proc(
+    user="postgres", password=None, host="127.0.0.1", port=None
+)
+PG_DE_DB_WITH_SCHEMA = factories.postgresql(
+    "PG_PROG",
+    dbname="decisionengine",
+    load=[
+        os.path.dirname(os.path.abspath(__file__)) + "/../postgresql.sql",
+    ],
+)
+
+DATABASES_TO_TEST = ("PG_DE_DB_WITH_SCHEMA",)
 
 
 @pytest.fixture

--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -1,22 +1,25 @@
 '''pytest defaults'''
-import random
-import string
 import threading
 
-import psycopg2
 import pytest
-from pytest_postgresql.janitor import DatabaseJanitor
 
 import decisionengine.framework.engine.de_client as de_client
 import decisionengine.framework.engine.de_query_tool as de_query_tool
 
-from decisionengine.framework.dataspace.datasources.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA, PG_PROG, DE_DB
-from decisionengine.framework.engine.DecisionEngine import _get_de_conf_manager, _create_de_server, parse_program_options
+from decisionengine.framework.dataspace.datasources.tests.fixtures import (
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DATABASES_TO_TEST,
+)
+from decisionengine.framework.engine.DecisionEngine import (
+    _get_de_conf_manager,
+    _create_de_server,
+    parse_program_options,
+)
 from decisionengine.framework.util.sockets import get_random_port
 from decisionengine.framework.taskmanager.TaskManager import State
 
-__all__ = ['DE_DB_HOST', 'DE_DB_USER', 'DE_DB_PASS', 'DE_DB_NAME', 'DE_SCHEMA',
-           'PG_PROG', 'DE_DB', 'DE_HOST', 'DEServer']
+__all__ = ["DATABASES_TO_TEST", "PG_DE_DB_WITH_SCHEMA", "PG_PROG", "DEServer"]
 
 # Not all test hosts are IPv6, generally IPv4 works fine some test
 # hosts use IPv6 for localhost by default, even when not configured!
@@ -27,12 +30,22 @@ DE_HOST = '127.0.0.1'
 class DETestWorker(threading.Thread):
     '''A DE Server process with our test config'''
 
-    def __init__(self, conf_path, channel_conf_path, server_address, db_info, conf_override=None, channel_conf_override=None):
+    def __init__(
+        self,
+        conf_path,
+        channel_conf_path,
+        server_address,
+        db_info,
+        conf_override=None,
+        channel_conf_override=None,
+    ):
         '''format of args should match what you set in conf_mamanger'''
         super().__init__(name='DETestWorker')
         self.server_address = server_address
 
-        global_config, channel_config_loader = _get_de_conf_manager(conf_path, channel_conf_path, parse_program_options([]))
+        global_config, channel_config_loader = _get_de_conf_manager(
+            conf_path, channel_conf_path, parse_program_options([])
+        )
 
         # Override global configuration for testing
         global_config['shutdown_timeout'] = 1
@@ -40,7 +53,9 @@ class DETestWorker(threading.Thread):
         global_config['dataspace']['datasource']['config'] = db_info
 
         self.de_server = _create_de_server(global_config, channel_config_loader)
-        self.reaper_start_delay_seconds = global_config['dataspace'].get('reaper_start_delay_seconds', 1818)
+        self.reaper_start_delay_seconds = global_config['dataspace'].get(
+            "reaper_start_delay_seconds", 1818
+        )
 
     def run(self):
         self.de_server.reaper_start(delay=self.reaper_start_delay_seconds)
@@ -52,9 +67,15 @@ class DETestWorker(threading.Thread):
         Run the DE Client CLI with these args
         The DE Server host/port are automatically set for you
         '''
-        return de_client.main(["--host", self.server_address[0],
-                               "--port", str(self.server_address[1]),
-                               *args])
+        return de_client.main(
+            [
+                "--host",
+                self.server_address[0],
+                "--port",
+                str(self.server_address[1]),
+                *args,
+            ]
+        )
 
     def de_query_tool_run_cli(self, *args):
         """
@@ -64,83 +85,87 @@ class DETestWorker(threading.Thread):
         Returns:
             str: Query result
         """
-        return de_query_tool.main(["--host", self.server_address[0],
-                                   "--port", str(self.server_address[1]),
-                                   *args])
+        return de_query_tool.main(
+            [
+                "--host",
+                self.server_address[0],
+                "--port",
+                str(self.server_address[1]),
+                *args,
+            ]
+        )
 
 
 # pylint: disable=invalid-name
-def DEServer(conf_path=None, conf_override=None,
-             channel_conf_path=None, channel_conf_override=None,
-             host=DE_HOST, port=None,
-             pg_prog_name='PG_PROG', pg_db_conn_name='DE_DB'):
+def DEServer(
+    conf_path=None,
+    conf_override=None,
+    channel_conf_path=None,
+    channel_conf_override=None,
+    host=DE_HOST,
+    port=None,
+):
     '''A DE Server using a private database'''
 
-    @pytest.fixture(scope='function')
+    @pytest.fixture(params=DATABASES_TO_TEST)
     def de_server_factory(request):
         '''
-        actually make the fixture
+        This parameterized fixture will mock up various datasources.
+
+        Add datasource objects to DATABASES_TO_TEST once they've got
+        our basic schema loaded.  Pytest should take it from there and
+        automatically run it throught all the below tests
         '''
         if port:
             host_port = (host, port)
         else:
             host_port = (host, get_random_port())
 
+        conn_fixture = request.getfixturevalue(request.param)
+
         db_info = {}
+        try:
+            # SQL Alchemy
+            db_info['url'] = conn_fixture.url
+        except AttributeError:
+            try:
+                # psycopg2
+                db_info['host'] = conn_fixture.info.host
+                db_info['port'] = conn_fixture.info.port
+                db_info['user'] = conn_fixture.info.user
+                db_info['password'] = conn_fixture.info.password
+                db_info['database'] = conn_fixture.info.dbname
+            except AttributeError:
+                # psycopg2cffi
+                for element in conn_fixture.dsn.split():
+                    (key, value) = element.split('=')
+                    if value != "''" and value != '""':
+                        db_info[key] = value
 
-        proc_fixture = request.getfixturevalue(pg_prog_name)
-        db_info['host'] = proc_fixture.host
-        db_info['port'] = proc_fixture.port
-        db_info['user'] = proc_fixture.user
-        db_info['password'] = proc_fixture.password
+        server_proc = DETestWorker(
+            conf_path,
+            channel_conf_path,
+            host_port,
+            db_info,
+            conf_override,
+            channel_conf_override,
+        )
+        server_proc.start()
+        # The following block only works if there are
+        # active workers; if it is called before any workers
+        # exist, then it will return and not block as requested.
+        # so long as your config contains at least one worker,
+        # this will work as you'd expect.
+        server_proc.de_server.block_while(State.BOOT)
 
-        # used to find the version of postgres
-        conn_fixture = request.getfixturevalue(pg_db_conn_name)
+        if not server_proc.is_alive():
+            raise RuntimeError('Could not start PrivateDEServer fixture')
 
-        # pseudo random database name for testing
-        db_info['database'] = DE_DB_NAME + '_test_' + ''.join(random.choices(string.ascii_uppercase + string.digits, k=5))
+        yield server_proc
 
-        # Due to the multi-threaded/connection pooled nature
-        # of the DE Server, it is cleaner to build out an
-        # unscoped database.  The one created by the `DE_DB`
-        # fixture is private to a single socket/connection
-        # and cannot be shared cleanly.
-        #
-        # And even if we could share it, then we wouldn't
-        # be testing the production data path or pooling
-        # with those tricks
+        if server_proc.is_alive():
+            server_proc.de_server.rpc_stop()
 
-        # DatabaseJanitor will create and drop the tablespace for us
-        with DatabaseJanitor(user=db_info['user'], password=db_info['password'],
-                             host=db_info['host'], port=db_info['port'],
-                             dbname=db_info['database'],
-                             version=conn_fixture.server_version):
-            # if you swap this for the `DE_DB` fixture, it will
-            # block and changes will not be visable to the connection
-            # fired up within the DE Server thread.
-            with psycopg2.connect(**db_info) as connection:
-                for filename in DE_SCHEMA:  # noqa: F405
-                    with open(filename, 'r') as _fd, \
-                         connection.cursor() as cur:
-                        cur.execute(_fd.read())
-
-            server_proc = DETestWorker(conf_path, channel_conf_path, host_port, db_info, conf_override, channel_conf_override)
-            server_proc.start()
-            # The following block only works if there are
-            # active workers; if it is called before any workers
-            # exist, then it will return and not block as requested.
-            # so long as your config contains at least one worker,
-            # this will work as you'd expect.
-            server_proc.de_server.block_while(State.BOOT)
-
-            if not server_proc.is_alive():
-                raise RuntimeError('Could not start PrivateDEServer fixture')
-
-            yield server_proc
-
-            if server_proc.is_alive():
-                server_proc.de_server.rpc_stop()
-
-            server_proc.join()
+        server_proc.join()
 
     return de_server_factory

--- a/src/decisionengine/framework/tests/fixtures.py
+++ b/src/decisionengine/framework/tests/fixtures.py
@@ -1,15 +1,26 @@
-'''defaults for pytest'''
+"""defaults for pytest"""
 import os
 
 # load DE Server fixtures
 # even though we are only using DEServer
 # we need to import all of these to instantiate the other fixtures
 # so that DEServer gets setup correctly
-from decisionengine.framework.engine.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA, PG_PROG, DE_DB, DE_HOST, DEServer
+from decisionengine.framework.engine.tests.fixtures import (
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DEServer,
+)
 
 # set path to test config
-TEST_CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "etc/decisionengine")
-TEST_CHANNEL_CONFIG_PATH = os.path.join(TEST_CONFIG_PATH, 'config.d')
+TEST_CONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "etc/decisionengine"
+)
+TEST_CHANNEL_CONFIG_PATH = os.path.join(TEST_CONFIG_PATH, "config.d")
 
-__all__ = ['DE_DB_HOST', 'DE_DB_USER', 'DE_DB_PASS', 'DE_DB_NAME', 'DE_SCHEMA',
-           'PG_PROG', 'DE_DB', 'DE_HOST', 'DEServer', 'TEST_CONFIG_PATH', 'TEST_CHANNEL_CONFIG_PATH']
+__all__ = [
+    "PG_DE_DB_WITH_SCHEMA",
+    "PG_PROG",
+    "DEServer",
+    "TEST_CONFIG_PATH",
+    "TEST_CHANNEL_CONFIG_PATH",
+]

--- a/src/decisionengine/framework/tests/test_client_errors.py
+++ b/src/decisionengine/framework/tests/test_client_errors.py
@@ -3,10 +3,18 @@
 
 import pytest
 
-from decisionengine.framework.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA  # noqa: F401
-from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH  # noqa: F401
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DEServer,
+    TEST_CONFIG_PATH,
+    TEST_CHANNEL_CONFIG_PATH
+)
 
-deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH) # pylint: disable=invalid-name
+deserver = DEServer(
+    conf_path=TEST_CONFIG_PATH,
+    channel_conf_path=TEST_CHANNEL_CONFIG_PATH
+) # pylint: disable=invalid-name
 
 @pytest.mark.usefixtures("deserver")
 def test_client_cannot_wait_on_bad_state(deserver):

--- a/src/decisionengine/framework/tests/test_client_server.py
+++ b/src/decisionengine/framework/tests/test_client_server.py
@@ -6,10 +6,18 @@ import sys
 
 import pytest
 
-from decisionengine.framework.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA # noqa: F401
-from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH # noqa: F401
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DEServer,
+    TEST_CONFIG_PATH,
+    TEST_CHANNEL_CONFIG_PATH,
+)
 
-deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH) # pylint: disable=invalid-name
+deserver = DEServer(
+    conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH
+)  # pylint: disable=invalid-name
+
 
 @pytest.mark.usefixtures("deserver")
 def test_client_status_msg_to_stdout(deserver):

--- a/src/decisionengine/framework/tests/test_defaults.py
+++ b/src/decisionengine/framework/tests/test_defaults.py
@@ -1,29 +1,39 @@
-'''Fixture based DE Server tests of the sample config'''
+"""Fixture based DE Server tests of the sample config"""
 # pylint: disable=redefined-outer-name
 
 import json
 
 import pytest
 
-from decisionengine.framework.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA  # noqa: F401
-from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH  # noqa: F401
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DEServer,
+    TEST_CONFIG_PATH,
+    TEST_CHANNEL_CONFIG_PATH,
+)
 
-deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH) # pylint: disable=invalid-name
+deserver = DEServer(
+    conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH
+)  # pylint: disable=invalid-name
+
 
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_de_server_show_channel_logger_level(deserver):
-    '''Verify unknown channel has NOTSET'''
-    output = deserver.de_client_run_cli('--get-channel-loglevel=UNITTEST')
-    assert output == 'NOTSET'
+    """Verify unknown channel has NOTSET"""
+    output = deserver.de_client_run_cli("--get-channel-loglevel=UNITTEST")
+    assert output == "NOTSET"
+
 
 @pytest.mark.usefixtures("deserver")
 def test_global_channel_log_level_in_config(deserver):
-    '''Verify global_channel_log_level setting exists'''
-    output = deserver.de_client_run_cli('--show-de-config')
-    assert 'global_channel_log_level' in output
+    """Verify global_channel_log_level setting exists"""
+    output = deserver.de_client_run_cli("--show-de-config")
+    assert "global_channel_log_level" in output
+
 
 @pytest.mark.usefixtures("deserver")
 def test_client_de_config_is_json(deserver):
-    '''Verify config can be fetched in json format'''
-    output = deserver.de_client_run_cli('--show-de-config')
+    """Verify config can be fetched in json format"""
+    output = deserver.de_client_run_cli("--show-de-config")
     assert json.loads(output)

--- a/src/decisionengine/framework/tests/test_query_tool_server.py
+++ b/src/decisionengine/framework/tests/test_query_tool_server.py
@@ -6,10 +6,17 @@ import re
 
 from datetime import datetime
 
-from decisionengine.framework.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA # noqa: F401
-from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH # noqa: F401
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DEServer,
+    TEST_CONFIG_PATH,
+    TEST_CHANNEL_CONFIG_PATH,
+)
 
-deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH) # pylint: disable=invalid-name
+deserver = DEServer(
+    conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH
+)  # pylint: disable=invalid-name
 
 DEFAULT_OUTPUT = (
     "Product foo:  Found in channel test_channel\n"

--- a/src/decisionengine/framework/tests/test_reaper.py
+++ b/src/decisionengine/framework/tests/test_reaper.py
@@ -3,10 +3,18 @@
 
 import pytest
 
-from decisionengine.framework.tests.fixtures import DE_DB_HOST, DE_DB_USER, DE_DB_PASS, DE_DB_NAME, DE_SCHEMA  # noqa: F401
-from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH  # noqa: F401
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DEServer,
+    TEST_CONFIG_PATH,
+    TEST_CHANNEL_CONFIG_PATH,
+)
 
-deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH) # pylint: disable=invalid-name
+deserver = DEServer(
+    conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH
+)  # pylint: disable=invalid-name
+
 
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_de_server_reaper_status(deserver):

--- a/src/decisionengine/framework/tests/test_sample_config.py
+++ b/src/decisionengine/framework/tests/test_sample_config.py
@@ -3,9 +3,17 @@
 
 import pytest
 
-from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH  # noqa: F401
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DEServer,
+    TEST_CONFIG_PATH,
+    TEST_CHANNEL_CONFIG_PATH,
+)
 
-deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH)  # pylint: disable=invalid-name
+deserver = DEServer(
+    conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH
+)  # pylint: disable=invalid-name
 
 
 @pytest.mark.usefixtures("deserver")

--- a/src/decisionengine/framework/tests/test_source_proxy.py
+++ b/src/decisionengine/framework/tests/test_source_proxy.py
@@ -6,11 +6,21 @@ import re
 
 import pytest
 
-from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block  # noqa: F401
-from decisionengine.framework.tests.fixtures import DE_DB, DEServer, PG_PROG, TEST_CONFIG_PATH  # noqa: F401
+from decisionengine.framework.dataspace.datasources.tests.fixtures import (  # noqa: F401
+    mock_data_block,
+)
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DEServer,
+    TEST_CONFIG_PATH,
+)
 
-_channel_config_dir = os.path.join(TEST_CONFIG_PATH, 'test-source-proxy')  # noqa: F405
-deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=_channel_config_dir)  # pylint: disable=invalid-name
+_channel_config_dir = os.path.join(TEST_CONFIG_PATH, "test-source-proxy")  # noqa: F405
+deserver = DEServer(
+    conf_path=TEST_CONFIG_PATH, channel_conf_path=_channel_config_dir
+)  # pylint: disable=invalid-name
+
 
 @pytest.mark.usefixtures("deserver")
 def test_working_source_proxy(deserver):

--- a/src/decisionengine/framework/tests/test_start_with_bad_channels.py
+++ b/src/decisionengine/framework/tests/test_start_with_bad_channels.py
@@ -6,10 +6,18 @@ import pytest
 import re
 from logging import ERROR
 
-from decisionengine.framework.tests.fixtures import DE_DB, DE_HOST, PG_PROG, DEServer, TEST_CONFIG_PATH, TEST_CHANNEL_CONFIG_PATH  # noqa: F401
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DEServer,
+    TEST_CONFIG_PATH,
+    TEST_CHANNEL_CONFIG_PATH,
+)
 
-_channel_config_dir = os.path.join(TEST_CONFIG_PATH, 'test-bad-channel')  # noqa: F405
-deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=_channel_config_dir)  # pylint: disable=invalid-name
+_channel_config_dir = os.path.join(TEST_CONFIG_PATH, "test-bad-channel")  # noqa: F405
+deserver = DEServer(
+    conf_path=TEST_CONFIG_PATH, channel_conf_path=_channel_config_dir
+)  # pylint: disable=invalid-name
 
 
 def _missing_produces(name):


### PR DESCRIPTION
We had a few unnecessary includes and slightly ambiguous names (which DB engine is `DE_DB`?).  These are now cleaned up and simplified (since our bugfixes landed upstream) for our testing.