### PR TITLE
One of these tests seems to be spotty, break them out to find which one

### DIFF
--- a/src/decisionengine/framework/tests/test_client_server.py
+++ b/src/decisionengine/framework/tests/test_client_server.py
@@ -45,9 +45,20 @@ def test_client_print_product(deserver):
         "|  1 | value2 | 2      |\n" \
         "|  2 | value3 | Test   |\n" \
         "+----+--------+--------+"
+
+@pytest.mark.usefixtures("deserver")
+def test_client_print_product_not_real(deserver):
     output = deserver.de_client_run_cli('--print-product', 'NO_SUCH_PRODUCT')
+
+    # Check individual elements
+    assert "Product NO_SUCH_PRODUCT:" in output
+    assert "Not produced by any module" in output
+
+    # Check for specific output
     assert output == "Product NO_SUCH_PRODUCT: Not produced by any module"
 
+@pytest.mark.usefixtures("deserver")
+def test_client_print_product_types(deserver):
     # Test --types
     output = deserver.de_client_run_cli('--print-product', 'foo', '--types')
     assert output == \
@@ -60,6 +71,8 @@ def test_client_print_product(deserver):
         "|  2 | value3 | str         | Test   | str         |\n" \
         "+----+--------+-------------+--------+-------------+"
 
+@pytest.mark.usefixtures("deserver")
+def test_client_print_product_columns(deserver):
     # Test specific columns only
     output = deserver.de_client_run_cli('--print-product', 'foo', '--columns', 'key1')
     assert output == \
@@ -83,6 +96,9 @@ def test_client_print_product(deserver):
         "|  2 | value3 | Test   |\n" \
         "+----+--------+--------+"
 
+@pytest.mark.usefixtures("deserver")
+def test_client_print_product_query(deserver):
+    # Test specific columns only
     # Test query
     output = deserver.de_client_run_cli('--print-product', 'foo', '--query', 'key2 == 2')
     assert output == \
@@ -93,6 +109,8 @@ def test_client_print_product(deserver):
         "|  1 | value2 |      2 |\n" \
         "+----+--------+--------+"
 
+@pytest.mark.usefixtures("deserver")
+def test_client_print_product_columns_query(deserver):
     # Test query and column names
     output = deserver.de_client_run_cli('--print-product', 'foo', '--query', 'key2 == 2', '--columns', 'key2')
     assert output == \
@@ -113,6 +131,8 @@ def test_client_print_product(deserver):
         "+----+--------+--------+"
 
 
+@pytest.mark.usefixtures("deserver")
+def test_client_print_product_vertical(deserver):
     # Test --format vertical
     output = deserver.de_client_run_cli('--print-product', 'foo', '--format', 'vertical')
     assert output == \
@@ -144,7 +164,9 @@ def test_client_print_product(deserver):
         "| key2      |\n" \
         "+-----------+"
 
-# Test --format json
+@pytest.mark.usefixtures("deserver")
+def test_client_print_product_json(deserver):
+    # Test --format json
     output = deserver.de_client_run_cli('--print-product', 'foo', '--format', 'json')
     assert output == \
         'Product foo:  Found in channel test_channel\n' \


### PR DESCRIPTION
One of these tests seems to break randomly on github actions (but not locally).

I've broken them into smaller units to hopefully isolate which one is spotty ~and figure out why.~

Spotty test now fixed.

This will have to be a different investigation: 
```
deserver = <DETestWorker(DETestWorker, started 140171908544064)>

        assert 'No channels are currently active.' not in output
    
    
    @pytest.mark.timeout(35)
    @pytest.mark.usefixtures("deserver")
    def test_client_can_kill_one_channel_force(deserver):
        '''Verify client can kill a single channel with force'''
        deserver.de_client_run_cli('--start-channel', 'test_channel')
>       deserver.de_client_run_cli('--block-while', 'BOOT'),
E       assert 'state = STEADY' in "channel: test_channel , id = 7BF1AFD6-8B21-42C8-8DBD-F6EE3F77A6BA, state = OFFLINE    \n\tsources:\n\t\tsource1\n\t\t...publisher1\n\t\t\tconsumes : ['bar']\n\t\t\tproduces : []\n\nreaper:\n\tstate: State.IDLE\n\tretention_interval: 370\n"

deserver   = <DETestWorker(DETestWorker, started 140171908544064)>
output     = "channel: test_channel , id = 7BF1AFD6-8B21-42C8-8DBD-F6EE3F77A6BA, state = OFFLINE    \n\tsources:\n\t\tsource1\n\t\t...publisher1\n\t\t\tconsumes : ['bar']\n\t\t\tproduces : []\n\nreaper:\n\tstate: State.IDLE\n\tretention_interval: 370\n"

tests/test_sample_config.py:139: AssertionError
```

Seems the 'block' is called too soon...

```
DEBUG    root:dataspace.py:81 Initializing a dataspace
DEBUG    root:datasource.py:27 Initializing a datasource
DEBUG    root:postgresql.py:130 Initializing a Postgresql datasource
DEBUG    root:maintain.py:27 Initializing a reaper
DEBUG    root:maintain.py:71 Reaper setting retention_interval to 370.
DEBUG    root:maintain.py:85 Reaper setting seconds_between_runs to 86400.
DEBUG    root:datasource.py:27 Initializing a datasource
DEBUG    root:postgresql.py:130 Initializing a Postgresql datasource
INFO     decision_engine:DecisionEngine.py:62 DecisionEngine started on ('127.0.0.1', 50935)
INFO     decision_engine:DecisionEngine.py:86 No active channels.
DEBUG    root:maintain.py:106 Reaper thread started.
DEBUG    root:maintain.py:116 Reaper waiting 1818 seconds or for a stop.
DEBUG    root:dataspace.py:81 Initializing a dataspace
DEBUG    root:datasource.py:27 Initializing a datasource
DEBUG    root:postgresql.py:130 Initializing a Postgresql datasource
DEBUG    root:datablock.py:207 Initializing a datablock
DEBUG    root:FactLookup.py:59 Registered the following facts:
{'pass_all': ['']}
DEBUG    root:FactLookup.py:87 Calculated the following order for evaluating rules:
['r1']
INFO     decision_engine:DecisionEngine.py:292 Channel test_channel started

```