### PR TITLE
Don't do debug logs for flake8, they aren't helpful

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,7 +189,7 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}/src
         run: |
-          pytest -m flake8 --flake8
+          pytest -m flake8 --flake8 --log-level=error
 
   run_pylint:
     name: Run pylint against code tree


### PR DESCRIPTION
We don't need to do detailed debugging of `flake8` inside of github actions.  Just report errors.