### PR TITLE
Log as workers are started

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -305,7 +305,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
             try:
                 self.start_channel(name, config)
             except Exception as e:
-                self.logger.error(f"Channel {name} failed to start : {e}")
+                self.logger.exception(f"Channel {name} failed to start : {e}")
 
     def rpc_start_channel(self, channel_name):
         with self.workers.access() as workers:

--- a/src/decisionengine/framework/engine/Workers.py
+++ b/src/decisionengine/framework/engine/Workers.py
@@ -70,6 +70,7 @@ class Worker(multiprocessing.Process):
 
         file_handler.setFormatter(FORMATTER)
         logger.addHandler(file_handler)
+        logger.debug(f"Starting {self.name}")
 
         channel_log_level = self.logger_config.get("global_channel_log_level", "WARNING")
         self.task_manager.set_loglevel_value(channel_log_level)

--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -1,4 +1,5 @@
 '''pytest defaults'''
+import logging
 import threading
 
 import pytest
@@ -112,6 +113,7 @@ def DEServer(
         our basic schema loaded.  Pytest should take it from there and
         automatically run it throught all the below tests
         '''
+        logger = logging.getLogger()
         if port:
             host_port = (host, port)
         else:
@@ -137,7 +139,7 @@ def DEServer(
                     (key, value) = element.split('=')
                     if value != "''" and value != '""':
                         db_info[key] = value
-
+        logger.debug(f"DE Fixture has db_info: {db_info}")
         server_proc = DETestWorker(
             conf_path,
             channel_conf_path,
@@ -146,6 +148,7 @@ def DEServer(
             conf_override,
             channel_conf_override,
         )
+        logger.debug("Starting DE Fixture")
         server_proc.start()
         # The following block only works if there are
         # active workers; if it is called before any workers


### PR DESCRIPTION
This adds a trivial log message when workers are started to help trace their flow if needed.  Currently needed for troubleshooting some sync issues.