### PR TITLE
Setup pytest so we get colors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,7 @@ jobs:
         env:
           PYTEST_TIMEOUT: 90
           PYTHONPATH: ${{ github.workspace }}/src
+        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         run: |
           pytest --cov-report term --cov-report xml --cov=decisionengine --no-cov-on-fail
 


### PR DESCRIPTION
Having colors in the pytest output is handy to make the bigger dumps of things more readable.

The output from `pytest` should be in color now ;)