### PR TITLE
Test datablock fixtures

### DIFF
--- a/src/decisionengine/framework/dataspace/datablock.py
+++ b/src/decisionengine/framework/dataspace/datablock.py
@@ -226,7 +226,7 @@ class DataBlock:
 
     def __str__(self):
         value = {
-            'taskamanger_id': self.taskmanager_id,
+            'taskmanager_id': self.taskmanager_id,
             'generation_id': self.generation_id,
             'sequence_id': self.sequence_id,
             'keys': self._keys,

--- a/src/decisionengine/framework/dataspace/tests/test_datablock.py
+++ b/src/decisionengine/framework/dataspace/tests/test_datablock.py
@@ -1,324 +1,293 @@
 import ast
-import os
-import pickle
+
 import pytest
-import pytest_postgresql # noqa: F401
-import unittest
-import zlib
 
-from decisionengine.framework.dataspace import dataspace, datablock
+from decisionengine.framework.dataspace.tests.fixtures import (  # noqa: F401
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DATABASES_TO_TEST,
+    dataspace,
+)
 
-@pytest.fixture()
-def datasource(request, postgresql, data):
-    with postgresql.cursor() as cursor:
-        cwd = os.path.split(os.path.abspath(__file__))[0]
-        # Load decision engine schema
-        cursor.execute(open(cwd + "/../datasources/postgresql.sql", "r").read())
-        # Load test data
-        for table, rows in data.items():
-            for row in rows:
-                keys = ",".join(row.keys())
-                values = ("%s," * len(row.values()))[:-1]
-                query = f"INSERT INTO {table} ({keys}) VALUES({values})"
-                cursor.execute(query, list(row.values()))
-    postgresql.commit()
+from decisionengine.framework.dataspace import datablock
 
-    return postgresql
 
-@pytest.fixture()
-def data():
-    return {
-        "taskmanager": [
-            {
-                "taskmanager_id": "1",
-                "name": "taskmanager1"
-            }
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_constructor(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
+    assert dblock.generation_id == 1
+
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], generation_id=1)
+    assert dblock.generation_id == 1
+
+    dblock = datablock.DataBlock(
+        dataspace, my_tm["name"], my_tm["taskmanager_id"], sequence_id=1
+    )
+    assert dblock.generation_id == 1
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_to_str(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+
+    expected = {
+        "taskmanager_id": my_tm["taskmanager_id"],
+        "generation_id": dataspace.get_last_generation_id(
+            my_tm["name"], my_tm["taskmanager_id"]
+        ),
+        "sequence_id": len(dataspace.get_dataproducts(my_tm["sequence_id"])) + 1,
+        "keys": [
+            "example_test_key",
         ],
-        "dataproduct": [
-            {
-                "taskmanager_id": "1",
-                "generation_id": "1",
-                "key": "test_key1",
-                "value": "test_value1"
-            }
-        ]
+        "dataproducts": {"example_test_key": "example_test_value"},
     }
 
-@pytest.fixture()
-def dspace(datasource):
-    dsn_parameters = dict(s.split("=") for s in datasource.dsn.split())
-    global_config = {
-        'dataspace': {
-            'reaper_start_delay_seconds': 1818,
-            'retention_interval_in_days': 365,
-            'datasource': {
-                'module': 'decisionengine.framework.dataspace.datasources.postgresql',
-                'name': 'Postgresql',
-                'config': {
-                    'user': dsn_parameters["user"],
-                    'blocking': True,
-                    'host': dsn_parameters["host"],
-                    'port': dsn_parameters["port"],
-                    'database': dsn_parameters["dbname"],
-                    'maxconnections': 100,
-                    'maxcached': 10,
-                },
-            },
-        }
-    }
-    return dataspace.DataSpace(global_config)
+    header = datablock.Header(my_tm["taskmanager_id"])
 
-@pytest.fixture()
-def dblock(dspace, data):
-    return datablock.DataBlock(dspace, data["taskmanager"][0]["name"], data["taskmanager"][0]["taskmanager_id"])
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
+    dblock.put("example_test_key", "example_test_value", header)
 
-# Wrapper to embed pytest fixtures in a TestCase class
-@pytest.fixture()
-def fixtures(request, data, dspace, dblock):
-    request.cls.data = data
-    request.cls.dataspace = dspace
-    request.cls.datablock = dblock
-
-@pytest.mark.usefixtures("fixtures")
-class TestDatablock(unittest.TestCase):
-
-    def setUp(self):
-        self.obj = {'a': {'b': 'c'}}
-
-    def tearDown(self):
-        pass
-
-    def test_zdumps(self):
-        zbytes = datablock.zdumps(self.obj)
-        value = pickle.loads(zlib.decompress(zbytes))
-
-        self.assertEqual(value, self.obj)
-
-    def test_zloads(self):
-        zbytes = zlib.compress(pickle.dumps(self.obj))
-        value = datablock.zloads(zbytes)
-        self.assertEqual(value, self.obj)
-
-        zbytes = pickle.dumps(self.obj)
-        value = datablock.zloads(zbytes.decode("latin1"))
-        self.assertEqual(value, self.obj)
-
-        zbytes = pickle.dumps(self.obj)
-        value = datablock.zloads(zbytes)
-        self.assertEqual(value, self.obj)
-
-    def test_compress(self):
-        zbytes = datablock.compress({'pickled': True,
-                                     'value': pickle.dumps(self.obj,
-                                                           protocol=pickle.HIGHEST_PROTOCOL)})
-        value = ast.literal_eval(datablock.decompress(zbytes))
-        value = datablock.zloads(value.get('value'))
-        self.assertEqual(value, self.obj)
-
-        zbytes = datablock.compress({'pickled': True,
-                                     'value': zlib.compress(pickle.dumps(self.obj,
-                                                                         protocol=pickle.HIGHEST_PROTOCOL), 9)})
-        value = ast.literal_eval(datablock.decompress(zbytes))
-        value = datablock.zloads(value.get('value'))
-        self.assertEqual(value, self.obj)
-
-        value = str(self.obj).encode("latin1")
-        value = ast.literal_eval(datablock.decompress(value))
-        self.assertEqual(value, self.obj)
-
-    def test_DataBlock_constructor(self):
-        dblock = datablock.DataBlock(self.dataspace, self.data["taskmanager"][0]["name"],
-                                     self.data["taskmanager"][0]["taskmanager_id"])
-        self.assertEqual(str(dblock.generation_id), self.data["dataproduct"][0]["generation_id"])
-
-        dblock = datablock.DataBlock(self.dataspace, self.data["taskmanager"][0]["name"],
-                                     generation_id=self.data["dataproduct"][0]["generation_id"])
-        self.assertEqual(str(dblock.generation_id), self.data["dataproduct"][0]["generation_id"])
-
-        dblock = datablock.DataBlock(self.dataspace, self.data["taskmanager"][0]["name"],
-                                     taskmanager_id=self.data["taskmanager"][0]["taskmanager_id"],
-                                     sequence_id=1)
-        self.assertEqual(str(dblock.generation_id), self.data["dataproduct"][0]["generation_id"])
-
-    def test_DataBlock_to_str(self):
-        dataproduct = self.data["dataproduct"][0]
-        header = datablock.Header(dataproduct["taskmanager_id"])
-        self.datablock.put(dataproduct["key"], dataproduct["value"], header)
-
-        result = str(self.datablock)
-        self.assertEqual(
-            result,
-            "{'taskamanger_id': '1', 'generation_id': 1, 'sequence_id': 2, "
-            "'keys': ['%s'], 'dataproducts': {'%s': '%s'}}"
-            % (dataproduct["key"], dataproduct["key"], dataproduct["value"])
-        )
-
-    def test_DataBlock_key_management(self):
-        dataproduct = self.data["dataproduct"][0]
-        header = datablock.Header(dataproduct["taskmanager_id"])
-
-        self.datablock.put(dataproduct["key"], dataproduct["value"], header)
-
-        self.assertIn(dataproduct["key"], self.datablock.keys())
-        self.assertIn(dataproduct["key"], self.datablock)
-
-        self.assertEqual(self.datablock.get(dataproduct["key"]), dataproduct["value"])
-
-        # Test product-retriever interface
-        retriever = datablock.ProductRetriever(dataproduct["key"], None, None)
-        assert retriever(self.datablock) == dataproduct["value"]
-        assert str(retriever) == "Product retriever for {'name': 'test_key1', 'type': None, 'creator': None}"
-
-        # FIXME: The following behavior should be disallowed for data-integrity reasons!
-        #        i.e. replacing a product name with a different value.
-        newDict = {"subKey": "newValue"}
-        self.datablock.put(dataproduct["key"], newDict, header)
-        self.assertEqual(self.datablock[dataproduct["key"]], newDict)
-
-        with self.assertRaises(KeyError):
-            self.datablock["invalidKey"]
-
-    def test_DataBlock_get_header(self):
-        dataproduct = self.data["dataproduct"][0]
-        header = datablock.Header(dataproduct["taskmanager_id"])
-        self.datablock.put(dataproduct["key"], dataproduct["value"], header)
-
-        self.assertEqual(header, self.datablock.get_header(dataproduct["key"]))
-
-    def test_DataBlock_get_metadata(self):
-        dataproduct = self.data["dataproduct"][0]
-        header = datablock.Header(dataproduct["taskmanager_id"])
-        metadata = datablock.Metadata(dataproduct["taskmanager_id"], generation_id=int(dataproduct["generation_id"]))
-        self.datablock.put(dataproduct["key"], dataproduct["value"], header, metadata)
-
-        self.assertEqual(metadata, self.datablock.get_metadata(dataproduct["key"]))
-
-    def test_DataBlock_get_taskmanager(self):
-        taskmanager = self.data["taskmanager"][0]
-        dataproduct = self.data["dataproduct"][0]
-        header = datablock.Header(dataproduct["taskmanager_id"])
-        self.datablock.put(dataproduct["key"], dataproduct["value"], header)
-
-        tid = self.datablock.get_taskmanager(taskmanager["name"])["taskmanager_id"]
-        self.assertEqual(taskmanager["taskmanager_id"], tid)
-
-    def test_DataBlock_get_taskmanagers(self):
-        taskmanager = self.data["taskmanager"][0]
-        dataproduct = self.data["dataproduct"][0]
-        header = datablock.Header(dataproduct["taskmanager_id"])
-        self.datablock.put(dataproduct["key"], dataproduct["value"], header)
-        tms = self.dataspace.get_taskmanagers()
-        self.assertEqual(taskmanager["taskmanager_id"], tms[0]["taskmanager_id"])
-
-    def test_DataBlock_is_expired(self):
-        """This test just validates the method/function exists.
-           The stub within our default code should be replaced
-           by a class inheriting from it.
-           That class should have more rational return types.
-        """
-        assert self.datablock.is_expired() is None
-
-    def test_DataBlock_is_expired_with_key(self):
-        """This test just validates the method/function exists.
-           The stub within our default code should be replaced
-           by a class inheriting from it.
-           That class should have more rational return types.
-        """
-        dataproduct = self.data["dataproduct"][0]
-        assert self.datablock.is_expired(key=dataproduct["key"]) is None
+    result = ast.literal_eval(str(dblock))
+    assert result == expected
 
 
-    def test_DataBlock_mark_expired(self):
-        # mark_expired is just a stub in this case
-        # failure in a real implementation should raise an exception
-        assert self.datablock.mark_expired(1) is None
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_key_management(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
 
-    def test_DataBlock_get_dataproducts(self):
-        dataproduct = self.data["dataproduct"][0]
-        header = datablock.Header(dataproduct["taskmanager_id"])
-        self.datablock.put(dataproduct["key"], dataproduct["value"], header)
-        products = self.datablock.get_dataproducts()
-        self.assertEqual(dataproduct["value"], products[0]["value"])
+    dblock.put("example_test_key", "example_test_value", header)
 
-    def test_DataBlock_duplicate(self):
-        dataproduct = self.data["dataproduct"][0]
-        header = datablock.Header(dataproduct["taskmanager_id"])
-        metadata = datablock.Metadata(dataproduct["taskmanager_id"], generation_id=int(dataproduct["generation_id"]))
-        self.datablock.put(dataproduct["key"], dataproduct["value"], header, metadata)
+    assert "example_test_key" in dblock.keys()
+    assert "example_test_key" in dblock
 
-        dblock = self.datablock.duplicate()
+    assert dblock.get("example_test_key") == "example_test_value"
 
-        self.assertEqual(dblock.taskmanager_id, self.datablock.taskmanager_id)
-        self.assertEqual(dblock.generation_id + 1, self.datablock.generation_id)
-        self.assertEqual(dblock.sequence_id, self.datablock.sequence_id)
-        self.assertEqual(dblock._keys, self.datablock._keys)
-        for key in self.datablock._keys:
-            self.assertEqual(dblock[key], self.datablock[key])
+    # Test product-retriever interface
+    retriever = datablock.ProductRetriever("example_test_key", None, None)
+    assert retriever(dblock) == "example_test_value"
+    assert (
+        str(retriever)
+        == "Product retriever for {'name': 'example_test_key', 'type': None, 'creator': None}"
+    )
 
-    def test_Metadata_constructor(self):
-        dataproduct = self.data["dataproduct"][0]
-
-        metadata = datablock.Metadata(dataproduct["taskmanager_id"])
-        self.assertEqual(metadata.data["taskmanager_id"], dataproduct["taskmanager_id"])
-
-        genTime = 1.0
-        missCount = 3
-        state = "START_BACKUP"
-        metadata = datablock.Metadata(dataproduct["taskmanager_id"],
-                                      state=state,
-                                      generation_id=int(dataproduct["generation_id"]),
-                                      generation_time=genTime,
-                                      missed_update_count=missCount)
-        self.assertEqual(metadata.data["taskmanager_id"], dataproduct["taskmanager_id"])
-        self.assertEqual(metadata.data["state"], state)
-        self.assertEqual(metadata.data["generation_id"], int(dataproduct["generation_id"]))
-        self.assertEqual(metadata.data["generation_time"], genTime)
-        self.assertEqual(metadata.data["missed_update_count"], missCount)
-
-        with self.assertRaises(datablock.InvalidMetadataError):
-            metadata = datablock.Metadata(dataproduct["taskmanager_id"], "INVALID_STATE")
-
-    def test_Metadata_set_state(self):
-        dataproduct = self.data["dataproduct"][0]
-        metadata = datablock.Metadata(dataproduct["taskmanager_id"])
-
-        state = "START_BACKUP"
-        metadata.set_state(state)
-        self.assertEqual(metadata.data["state"], state)
-
-        with self.assertRaises(datablock.InvalidMetadataError):
-            metadata.set_state("INVALID_STATE")
-
-    def test_Header_constructor(self):
-        dataproduct = self.data["dataproduct"][0]
-
-        header = datablock.Header(dataproduct["taskmanager_id"])
-        self.assertEqual(header.data["taskmanager_id"], dataproduct["taskmanager_id"])
-
-        createTime = 1.0
-        expirationTime = 3.0
-        scheduleTime = 5.0
-        creator = "creator"
-        schema = 1
-        header = datablock.Header(dataproduct["taskmanager_id"],
-                                  create_time=createTime,
-                                  expiration_time=expirationTime,
-                                  scheduled_create_time=scheduleTime,
-                                  creator=creator,
-                                  schema_id=schema)
-        self.assertEqual(header.data["taskmanager_id"], dataproduct["taskmanager_id"])
-        self.assertEqual(header.data["create_time"], createTime)
-        self.assertEqual(header.data["expiration_time"], expirationTime)
-        self.assertEqual(header.data["scheduled_create_time"], scheduleTime)
-        self.assertEqual(header.data["creator"], creator)
-        self.assertEqual(header.data["schema_id"], schema)
-
-    def test_Header_is_valid(self):
-        dataproduct = self.data["dataproduct"][0]
-        header = datablock.Header(dataproduct["taskmanager_id"])
-
-        self.assertEqual(header.is_valid(), True)
+    # FIXME: The following behavior should be disallowed for data-integrity reasons!
+    #        i.e. replacing a product name with a different value.
+    newDict = {"subKey": "newValue"}
+    dblock.put("example_test_key", newDict, header)
+    assert dblock["example_test_key"] == newDict
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_no_key_by_name(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
+
+    dblock.put("example_test_key", "example_test_value", header)
+
+    with pytest.raises(KeyError):
+        dblock["no_such_key_exists"]
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_get_header(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
+
+    dblock.put("example_test_key", "example_test_value", header)
+
+    assert header == dblock.get_header("example_test_key")
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_get_metadata(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+    metadata = datablock.Metadata(
+        my_tm["taskmanager_id"],
+        generation_id=dataspace.get_last_generation_id(
+            my_tm["name"], my_tm["taskmanager_id"]
+        ),
+    )
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
+
+    dblock.put("example_test_key", "example_test_value", header, metadata)
+
+    assert metadata == dblock.get_metadata("example_test_key")
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_get_taskmanager(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
+
+    dblock.put("example_test_key", "example_test_value", header)
+
+    assert (
+        dblock.get_taskmanager(my_tm["name"])["taskmanager_id"]
+        == my_tm["taskmanager_id"]
+    )
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_is_expired(dataspace):  # noqa: F811
+    """This test just validates the method/function exists.
+    The stub within our default code should be replaced
+    by a class inheriting from it.
+    That class should have more rational return types.
+    """
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
+
+    dblock.put("example_test_key", "example_test_value", header)
+
+    assert dblock.is_expired() is None
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_is_expired_with_key(dataspace):  # noqa: F811
+    """This test just validates the method/function exists.
+    The stub within our default code should be replaced
+    by a class inheriting from it.
+    That class should have more rational return types.
+    """
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
+
+    dblock.put("example_test_key", "example_test_value", header)
+
+    assert dblock.is_expired(key="example_test_key") is None
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_mark_expired(dataspace):  # noqa: F811
+    # mark_expired is just a stub in this case
+    # failure in a real implementation should raise an exception
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
+
+    dblock.put("example_test_key", "example_test_value", header)
+
+    assert dblock.mark_expired(1) is None
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_get_dataproducts(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
+
+    dblock.put("example_test_key", "example_test_value", header)
+
+    products = dblock.get_dataproducts()
+    assert len(products) == 1
+    assert products[0]["key"] == "example_test_key"
+    assert products[0]["value"] == "example_test_value"
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_DataBlock_duplicate(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
+
+    dblock.put("example_test_key", "example_test_value", header)
+
+    dblock_2 = dblock.duplicate()
+
+    assert dblock.taskmanager_id == dblock_2.taskmanager_id
+    assert dblock.generation_id == dblock_2.generation_id + 1
+    assert dblock.sequence_id == dblock_2.sequence_id
+    assert dblock._keys == dblock_2._keys
+
+    for key in dblock._keys:
+        assert dblock[key] == dblock_2[key]
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_Metadata_constructor(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    metadata = datablock.Metadata(my_tm["taskmanager_id"])
+
+    assert metadata.data["taskmanager_id"] == my_tm["taskmanager_id"]
+
+    genTime = 1.0
+    missCount = 3
+    state = "START_BACKUP"
+
+    metadata = datablock.Metadata(
+        my_tm["taskmanager_id"],
+        state=state,
+        generation_id=dataspace.get_last_generation_id(
+            my_tm["name"], my_tm["taskmanager_id"]
+        ),
+        generation_time=genTime,
+        missed_update_count=missCount,
+    )
+
+    assert metadata.data["taskmanager_id"] == my_tm["taskmanager_id"]
+    assert metadata.data["state"] == state
+    assert metadata.data["generation_id"] == dataspace.get_last_generation_id(
+        my_tm["name"], my_tm["taskmanager_id"]
+    )
+    assert metadata.data["generation_time"] == genTime
+    assert metadata.data["missed_update_count"] == missCount
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_Metadata_set_state(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    metadata = datablock.Metadata(my_tm["taskmanager_id"])
+
+    state = "START_BACKUP"
+    metadata.set_state(state)
+
+    assert metadata.data["state"] == state
+
+    with pytest.raises(datablock.InvalidMetadataError):
+        metadata.set_state("INVALID_STATE")
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_Header_constructor(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+
+    assert header.data["taskmanager_id"] == my_tm["taskmanager_id"]
+
+    createTime = 1.0
+    expirationTime = 3.0
+    scheduleTime = 5.0
+    creator = "creator"
+    schema = 1
+    header = datablock.Header(
+        my_tm["taskmanager_id"],
+        create_time=createTime,
+        expiration_time=expirationTime,
+        scheduled_create_time=scheduleTime,
+        creator=creator,
+        schema_id=schema,
+    )
+    assert header.data["taskmanager_id"] == my_tm["taskmanager_id"]
+    assert header.data["create_time"] == createTime
+    assert header.data["expiration_time"] == expirationTime
+    assert header.data["scheduled_create_time"] == scheduleTime
+    assert header.data["creator"] == creator
+    assert header.data["schema_id"] == schema
+
+
+@pytest.mark.usefixtures("dataspace")
+def test_Header_is_valid(dataspace):  # noqa: F811
+    my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
+    header = datablock.Header(my_tm["taskmanager_id"])
+
+    assert header.is_valid() is True

--- a/src/decisionengine/framework/dataspace/tests/test_datablock_zlib.py
+++ b/src/decisionengine/framework/dataspace/tests/test_datablock_zlib.py
@@ -1,0 +1,54 @@
+import ast
+import pickle
+import zlib
+
+from decisionengine.framework.dataspace import datablock
+
+
+def test_zdumps():
+    zbytes = datablock.zdumps({"a": {"b": "c"}})
+    value = pickle.loads(zlib.decompress(zbytes))
+
+    assert value == {"a": {"b": "c"}}
+
+
+def test_zloads():
+    zbytes = zlib.compress(pickle.dumps({"a": {"b": "c"}}))
+    value = datablock.zloads(zbytes)
+    assert value == {"a": {"b": "c"}}
+
+    zbytes = pickle.dumps({"a": {"b": "c"}})
+    value = datablock.zloads(zbytes.decode("latin1"))
+    assert value == {"a": {"b": "c"}}
+
+    zbytes = pickle.dumps({"a": {"b": "c"}})
+    value = datablock.zloads(zbytes)
+    assert value == {"a": {"b": "c"}}
+
+
+def test_compress():
+    zbytes = datablock.compress(
+        {
+            "pickled": True,
+            "value": pickle.dumps({"a": {"b": "c"}}, protocol=pickle.HIGHEST_PROTOCOL),
+        }
+    )
+    value = ast.literal_eval(datablock.decompress(zbytes))
+    value = datablock.zloads(value.get("value"))
+    assert value == {"a": {"b": "c"}}
+
+    zbytes = datablock.compress(
+        {
+            "pickled": True,
+            "value": zlib.compress(
+                pickle.dumps({"a": {"b": "c"}}, protocol=pickle.HIGHEST_PROTOCOL), 9
+            ),
+        }
+    )
+    value = ast.literal_eval(datablock.decompress(zbytes))
+    value = datablock.zloads(value.get("value"))
+    assert value == {"a": {"b": "c"}}
+
+    value = str({"a": {"b": "c"}}).encode("latin1")
+    value = ast.literal_eval(datablock.decompress(value))
+    assert value == {"a": {"b": "c"}}


### PR DESCRIPTION
The datablock fixtures are not using our existing database mockup fixtures.  Switching to those will simplify the transition to SQLAlchemy.  It is a bit frustrating to pass parameterized fixtures into `unittest.TestCase` objects.  So I've reworked these as raw tests.

Requires #382 