### PR TITLE
Add more details to channel startup logs

### DIFF
--- a/src/decisionengine/framework/config/ChannelConfigHandler.py
+++ b/src/decisionengine/framework/config/ChannelConfigHandler.py
@@ -120,6 +120,8 @@ class ChannelConfigHandler():
             self.channels = {}
             self.logger.info("All channel configurations have been removed and are being reloaded.")
 
+        self.logger.info(f"Loading channel configs from:{self.channel_config_dir}")
+
         files = fs.files_with_extensions(self.channel_config_dir, '.conf', '.jsonnet')
         for channel_name, full_path in files:
             # Load only the channels that are not already in memory

--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -300,6 +300,8 @@ class DecisionEngine(socketserver.ThreadingMixIn,
         if not self.channel_config_loader.get_channels():
             self.logger.info("No channel configurations available in " +
                              f"{self.channel_config_loader.channel_config_dir}")
+        else:
+            self.logger.debug(f"Found channels: {self.channel_config_loader.get_channels().items()}")
 
         for name, config in self.channel_config_loader.get_channels().items():
             try:


### PR DESCRIPTION
As i try to figure out why some of the channel tests fail under some conditions, it is helpful to have the channel config information logged with each test.