### PR TITLE
Restore product-name translation required for some source-proxy cases

### DIFF
--- a/src/decisionengine/framework/modules/SourceProxy.py
+++ b/src/decisionengine/framework/modules/SourceProxy.py
@@ -11,6 +11,7 @@ import decisionengine.framework.dataspace.datablock as datablock
 import decisionengine.framework.dataspace.dataspace as dataspace
 from decisionengine.framework.modules import Source
 from decisionengine.framework.modules.Source import Parameter
+from decisionengine.framework.modules.translate_product_name import translate_all
 
 RETRIES = 10
 RETRY_TO = 60
@@ -27,7 +28,7 @@ class SourceProxy(Source.Source):
             raise RuntimeError(
                 'SourceProxy misconfigured. Must have {} defined'.format(must_have))
         self.source_channel = config['channel_name']
-        self.data_keys = config['Dataproducts']
+        self.data_keys = translate_all(config['Dataproducts'])
         self.retries = config.get('retries', RETRIES)
         self.retry_to = config.get('retry_timeout', RETRY_TO)
         self.logger = logging.getLogger()
@@ -35,7 +36,7 @@ class SourceProxy(Source.Source):
         # Hack - it is possible for a subclass to declare @produces,
         #        in which case, we do not want to override that.
         if not self._produces:
-            self._produces = {k: Any for k in self.data_keys}
+            self._produces = {new_name: Any for new_name in self.data_keys.values()}
 
     def post_create(self, global_config):
         self.dataspace = dataspace.DataSpace(global_config)
@@ -85,18 +86,12 @@ class SourceProxy(Source.Source):
         filled_keys = []
         for _ in range(self.retries):
             if len(filled_keys) != len(self.data_keys):
-                for k in self.data_keys:
-                    if isinstance(k, tuple) or isinstance(k, list):
-                        k_in = k[0]
-                        k_out = k[1]
-                    else:
-                        k_in = k
-                        k_out = k
+                for k_in, k_out in self.data_keys.items():
                     if k_in not in filled_keys:
                         try:
                             rc[k_out] = pd.DataFrame(
                                 self._get_data(data_block, k_in))
-                            filled_keys.append(k)
+                            filled_keys.append(k_in)
                         except KeyError as ke:
                             self.logger.debug("KEYERROR %s", ke)
             if len(filled_keys) == len(self.data_keys):

--- a/src/decisionengine/framework/modules/tests/test_translate_product_name.py
+++ b/src/decisionengine/framework/modules/tests/test_translate_product_name.py
@@ -1,0 +1,24 @@
+from decisionengine.framework.modules.translate_product_name import translate, translate_all
+
+import pytest
+
+def test_translate_none():
+    with pytest.raises(RuntimeError, match="does not match the supported pattern"):
+        translate("")
+    assert translate("old") == ("old", None)
+
+def test_translate_simple():
+    assert translate("old -> new") == ('old', 'new')
+
+def test_translate_with_underscores():
+    assert translate("old_v0 -> new_v1") == ('old_v0', 'new_v1')
+
+def test_translate_illegal_characters():
+    with pytest.raises(RuntimeError, match="does not match the supported pattern"):
+        translate("old-v0 -> new-v1")
+    with pytest.raises(RuntimeError, match="does not match the supported pattern"):
+        translate("old-<3=->=new-<3")
+
+def test_translate_all():
+    specs = ["old", "old1 -> new1"]
+    assert translate_all(specs) == {"old": "old", "old1": "new1"}

--- a/src/decisionengine/framework/modules/translate_product_name.py
+++ b/src/decisionengine/framework/modules/translate_product_name.py
@@ -1,0 +1,39 @@
+# The functionality provided here supports the translation of one
+# string to another using the syntax 'old -> new', subject to the
+# following constraints:
+#
+#   - The 'old' and 'new' strings may contain the following
+#     characters: a-z, A-Z, 0-9, and _ (underscore).
+#
+#   - If '->' is provided, it must be surrounded by at least one space
+#     on either side.
+#
+# The behavior is the following:
+#
+#   - translate("old") == ("old", None)
+#   - translate("old -> new") == ("old", "new")
+#   - translate_all(["old", "old1 -> new1"]) == {"old": "old", "old1": "new1"}
+
+import re
+
+
+def translate(spec):
+    """Break apart the string 'old -> new' into a tuple ('old', 'new')"""
+    match = re.fullmatch(R'(\w+)(\s+\->\s+(\w+))?', spec)
+    if match is None:
+        raise RuntimeError(f"The specification '{spec}' does not match the supported pattern "
+                           '"old_name[ -> new_name]",\n'
+                           "where the product names can consist of the characters a-z, a-Z, 0-9, "
+                           "and an underscore '_'.\nIf an optional new name is specified, the '->' "
+                           "token must be surrounded by at least\none space on either side.")
+    return match.group(1, 3)
+
+
+def translate_all(specs):
+    result = {}
+    for entry in specs:
+        old, new = translate(entry)
+        if new is None:
+            new = old
+        result[old] = new
+    return result


### PR DESCRIPTION
This commit restores the ability for source proxies to specify an optional translation from an input product name to an output one.  This was unintentionally removed when implementing the `@produces`/`@consumes` system.

In order to effect product name translation, use the following pattern in your source-proxy configurations:

```jsonnet
Dataproducts: [
  "product1",
  "product2",
  "old_name -> new_name"
]
```

The `SourceProxy` class looks for the string pattern "old -> new", where the product names "old" and "new" may contain any of the following characters: a-z, A-Z, 0-9, and _ (underscore).  When specified, the `->` must be surrounded by at least one whitespace character on either side.