### PR TITLE
Add another sync method to try and make tests less spotty

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -19,6 +19,8 @@ import json
 import socketserver
 import xmlrpc.server
 
+from threading import Event
+
 from decisionengine.framework.config import ChannelConfigHandler, ValidConfig, policies
 from decisionengine.framework.dataspace.maintain import Reaper
 from decisionengine.framework.engine.Workers import Worker, Workers
@@ -59,6 +61,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
         self.global_config = global_config
         self.dataspace = dataspace.DataSpace(self.global_config)
         self.reaper = Reaper(self.global_config)
+        self.startup_complete = Event()
         self.logger.info("DecisionEngine started on {}".format(server_address))
 
     def get_logger(self):
@@ -550,6 +553,7 @@ def _start_de_server(server):
     try:
         server.reaper_start(delay=server.global_config['dataspace'].get('reaper_start_delay_seconds', 1818))
         server.start_channels()
+        server.startup_complete.set()
         server.serve_forever()
     except Exception as __e:  # pragma: no cover
         msg = f"""Server Address: {server.global_config.get('server_address')}

--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -150,11 +150,18 @@ def DEServer(
         )
         logger.debug("Starting DE Fixture")
         server_proc.start()
+
+        # Ensure the channels have started
+        logger.debug(f"DE Fixture: Waiting on startup state is_set={server_proc.de_server.startup_complete.is_set()}")
+        server_proc.de_server.startup_complete.wait(timeout=3)
+        logger.debug(f"DE Fixture: startup state is_set={server_proc.de_server.startup_complete.is_set()}")
+
         # The following block only works if there are
         # active workers; if it is called before any workers
         # exist, then it will return and not block as requested.
         # so long as your config contains at least one worker,
         # this will work as you'd expect.
+        logger.debug("DE Fixture: Waiting on channels to start")
         server_proc.de_server.block_while(State.BOOT)
 
         if not server_proc.is_alive():

--- a/src/decisionengine/framework/tests/test_query_tool_server.py
+++ b/src/decisionengine/framework/tests/test_query_tool_server.py
@@ -101,11 +101,10 @@ def test_query_tool_json(deserver):
 
 @pytest.mark.usefixtures("deserver")
 def test_query_tool_since(deserver):
-    # Test taskmanager start time was very recent
-    just_a_moment_ago = datetime.datetime.now() - datetime.timedelta(seconds=1)
+    recently = datetime.datetime.now() - datetime.timedelta(minutes=3)
     # give the channel a moment to complete setup
     deserver.de_client_run_cli('--block-while', 'BOOT'),
-    output = deserver.de_query_tool_run_cli('foo', f'--since="{just_a_moment_ago.strftime("%Y-%m-%d %H:%M:%S")}"')
+    output = deserver.de_query_tool_run_cli('foo', f'--since="{recently.strftime("%Y-%m-%d %H:%M:%S")}"')
     assert output == DEFAULT_OUTPUT
 
 @pytest.mark.usefixtures("deserver")

--- a/src/decisionengine/framework/tests/test_start_with_bad_channels.py
+++ b/src/decisionengine/framework/tests/test_start_with_bad_channels.py
@@ -42,7 +42,9 @@ def test_client_can_get_products_no_channels(deserver, caplog):
     output = deserver.de_client_run_cli('--print-products')
     assert 'No channels are currently active.' in output
 
-    error_msgs = [entry.message for entry in caplog.records if entry.levelno == ERROR]
+    error_msgs = []
+    for when in ("setup", "call"):  # log may show up in either pytest 'when'
+        error_msgs.extend([entry.message for entry in caplog.get_records(when) if entry.levelno == ERROR])
     assert len(error_msgs) == 5
 
     # Find missing product erro


### PR DESCRIPTION
This should make the unit tests less spotty on thread startups.

This should go a long way to fixing #367 