### PR TITLE
Put postgresql datasource schema into RPM

### DIFF
--- a/package/rpm/install_section
+++ b/package/rpm/install_section
@@ -28,3 +28,7 @@ echo "%dir %attr(0750,decisionengine,decisionengine) %{_sysconfdir}/decisionengi
 mkdir -p %{buildroot}/%{_sysconfdir}/sysconfig
 touch %{buildroot}/%{_sysconfdir}/sysconfig/decisionengine
 echo "%attr(0640,root,decisionengine) %config(noreplace) %{_sysconfdir}/sysconfig/decisionengine" >> INSTALLED_FILES
+
+mkdir -p %{buildroot}/%{_defaultdocdir}/%{name}/datasources/
+install -m 0644 src/decisionengine/framework/dataspace/datasources/postgresql.sql %{buildroot}/%{_defaultdocdir}/%{name}/datasources/postgresql.sql
+echo "%doc %{_defaultdocdir}/%{name}" >> INSTALLED_FILES


### PR DESCRIPTION
This should fix #379 and put the schema in the doc section of the RPM.