### PR TITLE
Drop pointless lines

### DIFF
--- a/src/decisionengine/framework/dataspace/datablock.py
+++ b/src/decisionengine/framework/dataspace/datablock.py
@@ -445,7 +445,6 @@ class DataBlock:
         Check if the dataproduct for a given key or any key is expired
         """
         self.logger.info('datablock is checking for expired dataproducts')
-        pass
 
     def mark_expired(self, expiration_time):
         """
@@ -453,4 +452,3 @@ class DataBlock:
         and mark it as expired if expiration_time <= current time
         """
         self.logger.info('datablock is marking expired dataproducts')
-        pass

--- a/src/decisionengine/framework/dataspace/datasources/postgresql.py
+++ b/src/decisionengine/framework/dataspace/datasources/postgresql.py
@@ -183,7 +183,6 @@ class Postgresql(ds.DataSource):
                 SELECT_TASKMANAGERS += " AND "
             else:
                 SELECT_TASKMANAGERS += " WHERE "
-                have_where = True
             SELECT_TASKMANAGERS += " tm.datestamp <=  '" + end_time + "'"
         try:
             return self._select_dictresult(SELECT_TASKMANAGERS +


### PR DESCRIPTION
These two `pass` instances don't actually accomplish anything since the logger lines make the syntax valid.