### PR TITLE
Since we are opening an IPv4 socket, just use 127.0.0.1 to check

### DIFF
--- a/src/decisionengine/framework/util/sockets.py
+++ b/src/decisionengine/framework/util/sockets.py
@@ -4,7 +4,7 @@ import logging
 def get_random_port():
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(('', 0))
+            s.bind(('127.0.0.1', 0))
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             return s.getsockname()[1]
 


### PR DESCRIPTION
Ports really shouldn't be randomly opened on all interfaces just for us to locate a temporary port we can allocate.  Just use localhost since we are in an IPv4 context.