### PR TITLE
Begin prepwork for PEP517

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ runtime_require = ["jsonnet >= 0.17.0", "tabulate >= 0.8.7",
 
 devel_req = ["setuptools >= 51.2", "setuptools-scm >= 6.0.1",
              "setuptools-scm[toml] >= 6.0.1", "toml >= 0.10.2",
+             "packaging >= 20.4",
              "mock >= 4.0.3", "pytest >= 6.2.2", "pytest-cov >= 2.11.1",
              "pytest-flake8 >= 1.0.7", "pytest-postgresql >= 3.0.0",
              "pytest-timeout >= 1.4.2",


### PR DESCRIPTION
The `packaging` module will be required for fully platform agnostic builds.  We aren't currently doing those, but having the module available for developers to test with will simplify that adoption long term.