### PR TITLE
Set the logs to DEBUG for testing

### DIFF
--- a/src/decisionengine/framework/tests/etc/decisionengine/decision_engine.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/decision_engine.jsonnet
@@ -6,8 +6,8 @@
     'rotation_time_unit':'D',
     'rotation_time_interval':1,
     'file_rotate_by':"size",
-    'log_level': "INFO",
-    'global_channel_log_level':"WARNING",
+    'log_level': "DEBUG",
+    'global_channel_log_level':"DEBUG",
   },
 
   'server_address' : ["localhost",8888],


### PR DESCRIPTION
During `pytest` it is helpful to have full debugging logs enabled so folks can more easily see why specific tests failed.