### PR TITLE
Add line length for autoformater

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ flake8-max-line-length = "120"
 flake8-ignore = "E501 E303 E302 E261 E265 W503 W504"
 flake8-show-source = "True"
 flake8-statistics = "True"
+
+[tool.black]
+line-length = 120


### PR DESCRIPTION
I often run my patches through the `black` autoformater and am adding this setting to try and avoid pointless whitespace changes down the road.