### PR TITLE
Add missing break statement

### DIFF
--- a/src/decisionengine/framework/engine/de_client.py
+++ b/src/decisionengine/framework/engine/de_client.py
@@ -164,8 +164,8 @@ def execute_command_from_args(argsparsed, de_socket):
         if argsparsed.force:
             timeout = 0
         elif argsparsed.timeout:
-            timeout = argsparsed.timeout
-        return de_socket.kill_chaannel(argsparsed.kill_channel, timeout)
+            timeout = int(argsparsed.timeout)
+        return de_socket.kill_channel(argsparsed.kill_channel, timeout)
     if argsparsed.start_channel:
         return de_socket.start_channel(argsparsed.start_channel)
     if argsparsed.stop_channels:

--- a/src/decisionengine/framework/taskmanager/TaskManager.py
+++ b/src/decisionengine/framework/taskmanager/TaskManager.py
@@ -384,6 +384,7 @@ class TaskManager:
             except Exception:
                 logging.getLogger().exception(f'Exception running source {src.name} ')
                 self.take_offline(self.data_block_t0)
+                break
             if src.schedule > 0:
                 s = src.stop_running.wait(src.schedule)
                 if s:

--- a/src/decisionengine/framework/tests/ErrorOnAcquire.py
+++ b/src/decisionengine/framework/tests/ErrorOnAcquire.py
@@ -1,0 +1,13 @@
+from decisionengine.framework.modules import Source
+
+@Source.produces(_placeholder=None)
+class ErrorOnAcquire(Source.Source):
+
+    def __init__(self, config):
+        super().__init__(config)
+
+    def acquire(self):
+        raise RuntimeError("Test error-handling")
+
+
+Source.describe(ErrorOnAcquire)

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-error-on-acquire/error_on_acquire.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-error-on-acquire/error_on_acquire.jsonnet
@@ -1,0 +1,17 @@
+# The ErrorOnAcquire source raises an exception as part of the acquire
+# method.  We then specify a ridiculous schedule of 10k seconds, to
+# test that the task manager does not wait 10k seconds before taking
+# the channel offline.
+
+{
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.ErrorOnAcquire",
+      parameters: {},
+      schedule: 10000
+    }
+  },
+  transforms: {},
+  logicengines: {},
+  publishers: {}
+}

--- a/src/decisionengine/framework/tests/test_error_on_acquire.py
+++ b/src/decisionengine/framework/tests/test_error_on_acquire.py
@@ -1,0 +1,25 @@
+import os
+
+import pytest
+
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DEServer,
+    TEST_CONFIG_PATH,
+)
+
+_channel_config_dir = os.path.join(TEST_CONFIG_PATH, "test-error-on-acquire")  # noqa: F405
+deserver = DEServer(
+    conf_path=TEST_CONFIG_PATH, channel_conf_path=_channel_config_dir
+)  # pylint: disable=invalid-name
+
+
+@pytest.mark.usefixtures("deserver")
+def test_source_only_channel(deserver):
+    # The following 'block-while' call will be unnecessary once the
+    # deserver fixture can reliably block when no workers have yet
+    # been constructed.
+    deserver.de_client_run_cli("--block-while", "BOOT")
+    output = deserver.de_client_run_cli('--stop-channel', 'error_on_acquire')
+    assert "Channel error_on_acquire stopped cleanly." == output

--- a/src/decisionengine/framework/tests/test_sample_config.py
+++ b/src/decisionengine/framework/tests/test_sample_config.py
@@ -15,6 +15,11 @@ deserver = DEServer(
     conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH
 )  # pylint: disable=invalid-name
 
+_STOPPED_CHANNEL_OPTS = [
+    'Channel test_channel stopped cleanly.',
+    'Channel test_channel has been killed due to shutdown timeout (1 second).',
+    'Channel test_channel has been killed.'
+]
 
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_de_server_status(deserver):
@@ -120,8 +125,9 @@ def test_client_can_kill_one_channel(deserver):
     assert 'test_channel' in output
     assert 'state = STEADY' in output
     output = deserver.de_client_run_cli('--kill-channel', 'test_channel')
+    assert output in _STOPPED_CHANNEL_OPTS
     output = deserver.de_client_run_cli('--status')
-    assert 'No channels are currently active.' not in output
+    assert 'No channels are currently active.' in output
 
 
 @pytest.mark.timeout(35)
@@ -133,8 +139,9 @@ def test_client_can_kill_one_channel_force(deserver):
     assert 'test_channel' in output
     assert 'state = STEADY' in output
     output = deserver.de_client_run_cli('--kill-channel', 'test_channel', '--force')
+    assert output in _STOPPED_CHANNEL_OPTS
     output = deserver.de_client_run_cli('--status')
-    assert 'No channels are currently active.' not in output
+    assert 'No channels are currently active.' in output
 
 
 @pytest.mark.timeout(35)
@@ -146,8 +153,9 @@ def test_client_can_kill_one_channel_timeout(deserver):
     assert 'test_channel' in output
     assert 'state = STEADY' in output
     output = deserver.de_client_run_cli('--kill-channel', 'test_channel', '--timeout', '5')
+    assert output in _STOPPED_CHANNEL_OPTS
     output = deserver.de_client_run_cli('--status')
-    assert 'No channels are currently active.' not in output
+    assert 'No channels are currently active.' in output
 
 
 @pytest.mark.usefixtures("deserver")


### PR DESCRIPTION
Under the condition where a source's `acquire` method raises an exception *during its first execution*, the task-manager needs to end the source loop.  Unfortunately, the source loop was calling `take_offline` but then waiting the number of seconds as configured by the source's `schedule` parameter before ending its loop.

This PR fixes that error, and it fixes a typo in the `de-client` (including adjusting the tests appropriately).