### PR TITLE
Add more state management to tasks so we know where they are

### DIFF
--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -178,10 +178,15 @@ def DEServer(
         # this will work as you'd expect.
         logger.debug("DE Fixture: Waiting on channels to start, timeout=3")
         server_proc.de_server.block_while(State.BOOT, timeout=3)
+        logger.debug("DE Fixture: Waiting on channel to stop being IDLE, timeout=2")
+        server_proc.de_server.block_while(State.IDLE, timeout=2)
+        logger.debug("DE Fixture: Waiting on channel run one cycle, timeout=2")
+        server_proc.de_server.block_while(State.ACTIVE, timeout=2)
 
         if not server_proc.is_alive():
             raise RuntimeError('Could not start PrivateDEServer fixture')
 
+        logger.debug("DE Fixture: Private DE Test Server should be running now")
         yield server_proc
 
         # does not error out even if the server is stopped


### PR DESCRIPTION
For debugging it is nice to know when a channels sources have run.  Also it might be nice for the client/monitoring to be able to tell if a channel is waiting on sources.