### PR TITLE
List why we aren't checking

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,7 +11,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import sphinx_rtd_theme  # noqa
+import sphinx_rtd_theme  # noqa: F401
 import sys
 import time
 


### PR DESCRIPTION
One of the linters noted we didn't say which error code to ignore (in this instance, unused-import).