### PR TITLE
Add timeout option to block-while

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -75,24 +75,24 @@ class DecisionEngine(socketserver.ThreadingMixIn,
             raise Exception(f'method "{method}" is not supported')
         return func(*params)
 
-    def block_until(self, state):
+    def block_until(self, state, timeout=None):
         with self.workers.unguarded_access() as workers:
             if not workers:
                 self.logger.info('No active channels to wait on.')
                 return 'No active channels.'
             for tm in workers.values():
                 if tm.is_alive():
-                    tm.wait_until(state)
+                    tm.wait_until(state, timeout)
         return f'No channels in {state} state.'
 
-    def block_while(self, state):
+    def block_while(self, state, timeout=None):
         with self.workers.unguarded_access() as workers:
             if not workers:
                 self.logger.info('No active channels to wait on.')
                 return 'No active channels.'
             for tm in workers.values():
                 if tm.is_alive():
-                    tm.wait_while(state)
+                    tm.wait_while(state, timeout)
         return f'No channels in {state} state.'
 
     def _dataframe_to_table(self, df):
@@ -115,13 +115,13 @@ class DecisionEngine(socketserver.ThreadingMixIn,
     def _dataframe_to_csv(self, df):
         return "{}\n".format(df.to_csv())
 
-    def rpc_block_while(self, state_str):
+    def rpc_block_while(self, state_str, timeout=None):
         allowed_state = None
         try:
             allowed_state = ProcessingState.State[state_str]
         except Exception:
             return f'{state_str} is not a valid channel state.'
-        return self.block_while(allowed_state)
+        return self.block_while(allowed_state, timeout)
 
     def rpc_show_config(self, channel):
         """

--- a/src/decisionengine/framework/engine/Workers.py
+++ b/src/decisionengine/framework/engine/Workers.py
@@ -31,11 +31,11 @@ class Worker(multiprocessing.Process):
         self.task_manager_id = task_manager.id
         self.logger_config = logger_config
 
-    def wait_until(self, state):
-        return self.task_manager.state.wait_until(state)
+    def wait_until(self, state, timeout=None):
+        return self.task_manager.state.wait_until(state, timeout)
 
-    def wait_while(self, state):
-        return self.task_manager.state.wait_while(state)
+    def wait_while(self, state, timeout=None):
+        return self.task_manager.state.wait_while(state, timeout)
 
     def get_state_name(self):
         return self.task_manager.get_state_name()

--- a/src/decisionengine/framework/engine/de_client.py
+++ b/src/decisionengine/framework/engine/de_client.py
@@ -70,8 +70,9 @@ def create_parser():
         help="May be used with --kill-channel to immediately kill the channel process")
     kill_options.add_argument(
         '--timeout',
+        default=None,
         metavar="<seconds>",
-        help="May be specified with --kill-channel to override the DE server's configured timeout window.")
+        help="May be specified with --kill-channel to override the DE server's configured timeout window or max time to wait for --block-while.")
     channels.add_argument(
         "--show-config",
         action='store_true',
@@ -148,7 +149,7 @@ def execute_command_from_args(argsparsed, de_socket):
     if argsparsed.print_engine_loglevel:
         return de_socket.get_log_level()
     if argsparsed.block_while:
-        return de_socket.block_while(argsparsed.block_while)
+        return de_socket.block_while(argsparsed.block_while, argsparsed.timeout)
 
     # Channel-specific options
     if argsparsed.stop_channel:
@@ -157,8 +158,8 @@ def execute_command_from_args(argsparsed, de_socket):
         if not argsparsed.kill_channel:
             return "The --force (-f) option may be used only with --kill-channel."
     if argsparsed.timeout:
-        if not argsparsed.kill_channel:
-            return "The --timeout option may be used only with --kill-channel."
+        if not argsparsed.kill_channel and not argsparsed.block_while:
+            return "The --timeout option may be used only with --kill-channel or --block-while."
     if argsparsed.kill_channel:
         timeout = None  # Use server-configured timeout
         if argsparsed.force:

--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -161,8 +161,8 @@ def DEServer(
         # exist, then it will return and not block as requested.
         # so long as your config contains at least one worker,
         # this will work as you'd expect.
-        logger.debug("DE Fixture: Waiting on channels to start")
-        server_proc.de_server.block_while(State.BOOT)
+        logger.debug("DE Fixture: Waiting on channels to start, timeout=3")
+        server_proc.de_server.block_while(State.BOOT, timeout=3)
 
         if not server_proc.is_alive():
             raise RuntimeError('Could not start PrivateDEServer fixture')

--- a/src/decisionengine/framework/engine/tests/test_client_only.py
+++ b/src/decisionengine/framework/engine/tests/test_client_only.py
@@ -42,7 +42,7 @@ def test_exclusive_options():
     assert de_client.main(['--force']) == \
         "The --force (-f) option may be used only with --kill-channel."
     assert de_client.main(['--timeout', '2']) == \
-        "The --timeout option may be used only with --kill-channel."
+        "The --timeout option may be used only with --kill-channel or --block-while."
 
 def test_client_err_returned_as_rc():
     """no de server is running, so --status should error"""

--- a/src/decisionengine/framework/tests/test_sample_config.py
+++ b/src/decisionengine/framework/tests/test_sample_config.py
@@ -28,6 +28,15 @@ def test_client_can_get_de_server_status(deserver):
     output = deserver.de_client_run_cli('--status')
     assert 'state = STEADY' in output
 
+@pytest.mark.timeout(10)
+@pytest.mark.usefixtures("deserver")
+def test_client_wait_timeout_works(deserver):
+    '''Verify channel enters stable state and timeout works too'''
+    deserver.de_client_run_cli('--block-while', 'BOOT')
+    deserver.de_client_run_cli('--block-while', 'STABLE', '--timeout', '3')
+    output = deserver.de_client_run_cli('--status')
+    assert 'state = STEADY' in output
+
 
 @pytest.mark.usefixtures("deserver")
 def test_client_can_stop_server(deserver):


### PR DESCRIPTION
This should permit us to timeout `block-while` waits if we need to.

The `_until` functions aren't actually exported or in use but I agree with the author that they seem like they might be useful later on.