### PR TITLE
Setup blank DB for SQLAlchemy tests and prep fixtures

### DIFF
--- a/src/decisionengine/framework/dataspace/tests/fixtures.py
+++ b/src/decisionengine/framework/dataspace/tests/fixtures.py
@@ -4,16 +4,22 @@ from decisionengine.framework.dataspace import dataspace as ds
 
 from decisionengine.framework.dataspace.datasources.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DATABASES_TO_TEST,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     datasource,
     load_sample_data_into_datasource,
 )
 
 __all__ = [
     "PG_DE_DB_WITH_SCHEMA",
+    "PG_DE_DB_WITHOUT_SCHEMA",
     "PG_PROG",
     "DATABASES_TO_TEST",
+    "SQLALCHEMY_PG_WITH_SCHEMA",
+    "SQLALCHEMY_IN_MEMORY_SQLITE",
     "datasource",
     "dataspace",
     "load_sample_data_into_datasource",
@@ -36,6 +42,7 @@ def dataspace(request):
     try:
         # SQL Alchemy
         db_info["url"] = conn_fixture["url"]
+        db_info["echo"] = True  # put into extra chatty mode for tests
     except TypeError:
         try:
             # psycopg2

--- a/src/decisionengine/framework/tests/fixtures.py
+++ b/src/decisionengine/framework/tests/fixtures.py
@@ -7,7 +7,10 @@ import os
 # so that DEServer gets setup correctly
 from decisionengine.framework.engine.tests.fixtures import (
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     DEServer,
 )
 
@@ -19,7 +22,10 @@ TEST_CHANNEL_CONFIG_PATH = os.path.join(TEST_CONFIG_PATH, "config.d")
 
 __all__ = [
     "PG_DE_DB_WITH_SCHEMA",
+    "PG_DE_DB_WITHOUT_SCHEMA",
     "PG_PROG",
+    "SQLALCHEMY_PG_WITH_SCHEMA",
+    "SQLALCHEMY_IN_MEMORY_SQLITE",
     "DEServer",
     "TEST_CONFIG_PATH",
     "TEST_CHANNEL_CONFIG_PATH",

--- a/src/decisionengine/framework/tests/test_client_server.py
+++ b/src/decisionengine/framework/tests/test_client_server.py
@@ -35,7 +35,7 @@ def test_client_status_msg_to_stdout(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_print_product(deserver):
     # Test default options
-    output = deserver.de_client_run_cli('--print-product', 'foo')
+    output = deserver.de_client_run_cli('--print-product', 'foo', '--verbose')
     assert output == \
         "Product foo:  Found in channel test_channel\n" \
         "+----+--------+--------+\n" \


### PR DESCRIPTION
I'm unwinding my giant SQLAlchemy patches into smaller bits.

This patch lays the foundation with a blank DB (so SQLAlchemy can load its own schema) and seeds the various fixture code.