### PR TITLE
Ensure fixtures are cleaned up between invocations

### DIFF
--- a/src/decisionengine/framework/dataspace/datasources/tests/fixtures.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/fixtures.py
@@ -1,5 +1,6 @@
 """pytest fixtures/constants"""
 import datetime
+import gc
 import logging
 import os
 import threading
@@ -78,7 +79,10 @@ def datasource(request):
 
     load_sample_data_into_datasource(my_ds)
 
-    return my_ds
+    yield my_ds
+
+    del my_ds
+    gc.collect()
 
 
 @pytest.fixture

--- a/src/decisionengine/framework/dataspace/tests/fixtures.py
+++ b/src/decisionengine/framework/dataspace/tests/fixtures.py
@@ -1,3 +1,4 @@
+import gc
 import pytest
 
 from decisionengine.framework.dataspace import dataspace as ds
@@ -65,4 +66,7 @@ def dataspace(request):
     my_ds = ds.DataSpace(config)
     load_sample_data_into_datasource(my_ds)
 
-    return my_ds
+    yield my_ds
+
+    del my_ds
+    gc.collect()

--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -1,4 +1,5 @@
 '''pytest defaults'''
+import gc
 import logging
 import threading
 
@@ -174,5 +175,8 @@ def DEServer(
         server_proc.de_server.rpc_stop()
 
         server_proc.join()
+
+        del server_proc
+        gc.collect()
 
     return de_server_factory


### PR DESCRIPTION
The more strict `Singleton` code seems to benefit from explicit cleanups with pytest under python 3.10 and pypy.