### PR TITLE
Sometimes these tests get stuck

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version:

--- a/src/decisionengine/framework/tests/test_source_proxy.py
+++ b/src/decisionengine/framework/tests/test_source_proxy.py
@@ -22,6 +22,7 @@ deserver = DEServer(
 )  # pylint: disable=invalid-name
 
 
+@pytest.mark.timeout(20)
 @pytest.mark.usefixtures("deserver")
 def test_working_source_proxy(deserver):
     # The following 'block-while' call be unnecessary once the
@@ -38,6 +39,7 @@ def test_working_source_proxy(deserver):
 _fail_channel_config_dir = os.path.join(TEST_CONFIG_PATH, 'test-failing-source-proxy')  # noqa: F405
 deserver_fail = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=_fail_channel_config_dir)  # pylint: disable=invalid-name
 
+@pytest.mark.timeout(20)
 @pytest.mark.usefixtures("deserver_fail")
 def test_stop_failing_source_proxy(deserver_fail):
     # The following 'block-while' call be unnecessary once the


### PR DESCRIPTION
Sometimes the source_proxy tests gets stuck.  While I figure out why, we can add a rational timeout to ensure it doesn't get too frustrating.