### PR TITLE
Add in Jenkinsfile pipeline configuration a timeout at stage level

### DIFF
--- a/.Jenkins/workflows/Jenkinsfile
+++ b/.Jenkins/workflows/Jenkinsfile
@@ -10,6 +10,9 @@ pipeline {
                             customWorkspace "${WORKSPACE}/${STAGE_NAME}"
                         }
                     }
+                    options {
+                        timeout(time: "${STAGE_TIMEOUT}", activity: false, unit: 'MINUTES')
+                    }
                     steps {
                         script {
                             // DOCKER_IMAGE is defined through Jenkins project
@@ -61,6 +64,9 @@ pipeline {
                             customWorkspace "${WORKSPACE}/${STAGE_NAME}"
                         }
                     }
+                    options {
+                        timeout(time: "${STAGE_TIMEOUT}", activity: false, unit: 'MINUTES')
+                    }
                     steps {
                         script {
                             // DOCKER_IMAGE is defined through Jenkins project
@@ -102,6 +108,9 @@ pipeline {
                             customWorkspace "${WORKSPACE}/${STAGE_NAME}"
                         }
                     }
+                    options {
+                        timeout(time: "${STAGE_TIMEOUT}", activity: false, unit: 'MINUTES')
+                    }
                     steps {
                         script {
                             // DOCKER_IMAGE is defined through Jenkins project
@@ -142,6 +151,9 @@ pipeline {
                             label 'docker'
                             customWorkspace "${WORKSPACE}/${STAGE_NAME}"
                         }
+                    }
+                    options {
+                        timeout(time: "${STAGE_TIMEOUT}", activity: false, unit: 'MINUTES')
                     }
                     steps {
                         script {


### PR DESCRIPTION
This PR adds a timeout in the Jenkinsfile pipeline configuration.
The timeout value in minutes is provided through Jenkins as build parameter.
The default value is set to 60 minutes.
This PR needs to be merged to both master and 1.6 branch.