### PR TITLE
Update PyPy to 3.7 for testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
             ${{ runner.os }}-pip-
-            ${{ runner.os }}-
 
       - name: Note Python version/implementation/cache
         run: |
@@ -108,7 +107,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-
             ${{ runner.os }}-pip-
-            ${{ runner.os }}-
 
       - name: Note Python version/implementation/cache
         run: |
@@ -166,7 +164,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-
             ${{ runner.os }}-pip-
-            ${{ runner.os }}-
 
       - name: Note Python version/implementation
         run: |
@@ -217,7 +214,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-
             ${{ runner.os }}-pip-
-            ${{ runner.os }}-
 
       - name: Note Python version/implementation
         run: |
@@ -254,7 +250,6 @@ jobs:
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pre-commit-
-            ${{ runner.os }}-
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,13 +12,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     strategy:
       matrix:
         python-version:
           - '3.6'
           - '3.9'
-          - 'pypy-3.6'
+          - 'pypy-3.7'
 
     name: Python ${{ matrix.python-version }} unit tests
     steps:
@@ -38,9 +37,9 @@ jobs:
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-${{ matrix.python-version }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
 
@@ -71,6 +70,7 @@ jobs:
         run: python3 setup.py bdist_wheel
 
       - name: Run Unit Tests on Python ${{ matrix.python-version }}
+        timeout-minutes: 20
         env:
           PYTEST_TIMEOUT: 90
           PYTHONPATH: ${{ github.workspace }}/src


### PR DESCRIPTION
PyPy 3.6 reached end of life.  Mostly PyPy is here to expose any ambiguities in our implementation.  With 3.7 as the latest PyPy this new version should continue the tradition.

I had to move the timeout to the test specific location so PyPy had enough time to build the initial pip cache and run the tests.