### PR TITLE
Increase wait for overloaded test workers, update log messages

### DIFF
--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -167,9 +167,9 @@ def DEServer(
         server_proc.start()
 
         # Ensure the channels have started
-        logger.debug(f"DE Fixture: Waiting on startup state is_set={server_proc.de_server.startup_complete.is_set()}")
-        server_proc.de_server.startup_complete.wait(timeout=3)
-        logger.debug(f"DE Fixture: startup state is_set={server_proc.de_server.startup_complete.is_set()}")
+        logger.debug(f"DE Fixture: Wait on startup state: is_set={server_proc.de_server.startup_complete.is_set()}")
+        server_proc.de_server.startup_complete.wait()
+        logger.debug(f"DE Fixture: Done waiting for startup state: is_set={server_proc.de_server.startup_complete.is_set()}")
 
         # The following block only works if there are
         # active workers; if it is called before any workers


### PR DESCRIPTION
This should help fix the test errors Lisa was seeing due to timeout on `test_client_can_get_de_server_status`.

 https://github.com/HEPCloud/decisionengine/pull/424/checks?check_run_id=2954255157

We could go higher if folks thought that would help.  The timeout is needed to keep things from getting stuck too long, but how long is too long?