### PR TITLE
Move sys stderr test to its own space since it doesn't test server

### DIFF
--- a/src/decisionengine/framework/tests/test_client_server.py
+++ b/src/decisionengine/framework/tests/test_client_server.py
@@ -1,9 +1,6 @@
 '''Fixture based DE Server for the de-client tests'''
 # pylint: disable=redefined-outer-name
 
-import io
-import sys
-
 import pytest
 
 from decisionengine.framework.tests.fixtures import (  # noqa: F401
@@ -18,19 +15,6 @@ deserver = DEServer(
     conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH
 )  # pylint: disable=invalid-name
 
-
-@pytest.mark.usefixtures("deserver")
-def test_client_status_msg_to_stdout(deserver):
-    """Make sure the actuall client console call goes to stdout"""
-    import decisionengine.framework.engine.de_client as de_client
-
-    myoutput = io.StringIO()
-    sys.stdout = myoutput
-    de_client.console_scripts_main(['--host', deserver.server_address[0],
-                                    '--port', str(deserver.server_address[1]),
-                                    '--status'])
-    sys.stdout = sys.__stdout__
-    assert 'channel: test_channel' in myoutput.getvalue()
 
 @pytest.mark.usefixtures("deserver")
 def test_client_print_product(deserver):

--- a/src/decisionengine/framework/tests/test_client_stderr.py
+++ b/src/decisionengine/framework/tests/test_client_stderr.py
@@ -1,0 +1,33 @@
+'''Fixture based DE Server for the de-client tests'''
+# pylint: disable=redefined-outer-name
+
+import io
+import sys
+
+import pytest
+
+import decisionengine.framework.engine.de_client as de_client
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    PG_DE_DB_WITH_SCHEMA,
+    PG_PROG,
+    DEServer,
+    TEST_CONFIG_PATH,
+    TEST_CHANNEL_CONFIG_PATH,
+)
+
+deserver = DEServer(
+    conf_path=TEST_CONFIG_PATH, channel_conf_path=TEST_CHANNEL_CONFIG_PATH
+)  # pylint: disable=invalid-name
+
+
+@pytest.mark.usefixtures("deserver")
+def test_client_status_msg_to_stdout(deserver):
+    """Make sure the actuall client console call goes to stdout"""
+
+    myoutput = io.StringIO()
+    sys.stdout = myoutput
+    de_client.console_scripts_main(['--host', deserver.server_address[0],
+                                    '--port', str(deserver.server_address[1]),
+                                    '--status'])
+    sys.stdout = sys.__stdout__
+    assert 'channel: test_channel' in myoutput.getvalue()


### PR DESCRIPTION
As I'm chasing odd behavior blocking SQLAlchemy, this test seemed a bit out of place.

It is really just testing the client behavior, but it needs a working server to ensure we get past the error checking.