### PR TITLE
Help define the fixture interlocking

### DIFF
--- a/src/decisionengine/framework/dataspace/datasources/tests/test_datasource_api.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/test_datasource_api.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import NoResultFound
 
 from decisionengine.framework.dataspace.datasources.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DATABASES_TO_TEST,
     datasource,

--- a/src/decisionengine/framework/dataspace/datasources/tests/test_datasource_api.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/test_datasource_api.py
@@ -12,6 +12,8 @@ from sqlalchemy.exc import NoResultFound
 from decisionengine.framework.dataspace.datasources.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     PG_PROG,
     DATABASES_TO_TEST,
     datasource,

--- a/src/decisionengine/framework/dataspace/tests/fixtures.py
+++ b/src/decisionengine/framework/dataspace/tests/fixtures.py
@@ -69,6 +69,11 @@ def dataspace(request):
             "module"
         ] = "decisionengine.framework.dataspace.datasources.postgresql"
         config["dataspace"]["datasource"]["name"] = "Postgresql"
+    elif "SQLALCHEMY" in request.param:
+        config["dataspace"]["datasource"][
+            "module"
+        ] = "decisionengine.framework.dataspace.datasources.sqlalchemy_ds"
+        config["dataspace"]["datasource"]["name"] = "SQLAlchemyDS"
 
     my_ds = ds.DataSpace(config)
     load_sample_data_into_datasource(my_ds)

--- a/src/decisionengine/framework/dataspace/tests/test_datablock.py
+++ b/src/decisionengine/framework/dataspace/tests/test_datablock.py
@@ -4,6 +4,7 @@ import pytest
 
 from decisionengine.framework.dataspace.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DATABASES_TO_TEST,
     dataspace,

--- a/src/decisionengine/framework/dataspace/tests/test_datablock.py
+++ b/src/decisionengine/framework/dataspace/tests/test_datablock.py
@@ -5,6 +5,8 @@ import pytest
 from decisionengine.framework.dataspace.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     PG_PROG,
     DATABASES_TO_TEST,
     dataspace,

--- a/src/decisionengine/framework/dataspace/tests/test_dataspace.py
+++ b/src/decisionengine/framework/dataspace/tests/test_dataspace.py
@@ -8,6 +8,8 @@ from decisionengine.framework.dataspace import dataspace as ds
 from decisionengine.framework.dataspace.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     PG_PROG,
     DATABASES_TO_TEST,
     dataspace,

--- a/src/decisionengine/framework/dataspace/tests/test_dataspace.py
+++ b/src/decisionengine/framework/dataspace/tests/test_dataspace.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import NoResultFound
 from decisionengine.framework.dataspace import dataspace as ds
 from decisionengine.framework.dataspace.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DATABASES_TO_TEST,
     dataspace,

--- a/src/decisionengine/framework/tests/test_client_errors.py
+++ b/src/decisionengine/framework/tests/test_client_errors.py
@@ -5,6 +5,7 @@ import pytest
 
 from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DEServer,
     TEST_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_client_errors.py
+++ b/src/decisionengine/framework/tests/test_client_errors.py
@@ -7,6 +7,8 @@ from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     DEServer,
     TEST_CONFIG_PATH,
     TEST_CHANNEL_CONFIG_PATH

--- a/src/decisionengine/framework/tests/test_client_server.py
+++ b/src/decisionengine/framework/tests/test_client_server.py
@@ -10,6 +10,8 @@ from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     DEServer,
     TEST_CONFIG_PATH,
     TEST_CHANNEL_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_client_server.py
+++ b/src/decisionengine/framework/tests/test_client_server.py
@@ -8,6 +8,7 @@ import pytest
 
 from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DEServer,
     TEST_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_defaults.py
+++ b/src/decisionengine/framework/tests/test_defaults.py
@@ -9,6 +9,8 @@ from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     DEServer,
     TEST_CONFIG_PATH,
     TEST_CHANNEL_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_defaults.py
+++ b/src/decisionengine/framework/tests/test_defaults.py
@@ -7,6 +7,7 @@ import pytest
 
 from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DEServer,
     TEST_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_error_on_acquire.py
+++ b/src/decisionengine/framework/tests/test_error_on_acquire.py
@@ -4,6 +4,7 @@ import pytest
 
 from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DEServer,
     TEST_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_error_on_acquire.py
+++ b/src/decisionengine/framework/tests/test_error_on_acquire.py
@@ -6,6 +6,8 @@ from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     DEServer,
     TEST_CONFIG_PATH,
 )

--- a/src/decisionengine/framework/tests/test_query_tool_server.py
+++ b/src/decisionengine/framework/tests/test_query_tool_server.py
@@ -10,6 +10,8 @@ from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     DEServer,
     TEST_CONFIG_PATH,
     TEST_CHANNEL_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_query_tool_server.py
+++ b/src/decisionengine/framework/tests/test_query_tool_server.py
@@ -8,6 +8,7 @@ import datetime
 
 from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DEServer,
     TEST_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_reaper.py
+++ b/src/decisionengine/framework/tests/test_reaper.py
@@ -5,6 +5,7 @@ import pytest
 
 from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DEServer,
     TEST_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_reaper.py
+++ b/src/decisionengine/framework/tests/test_reaper.py
@@ -7,6 +7,8 @@ from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     DEServer,
     TEST_CONFIG_PATH,
     TEST_CHANNEL_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_sample_config.py
+++ b/src/decisionengine/framework/tests/test_sample_config.py
@@ -5,6 +5,7 @@ import pytest
 
 from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DEServer,
     TEST_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_sample_config.py
+++ b/src/decisionengine/framework/tests/test_sample_config.py
@@ -7,6 +7,8 @@ from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     DEServer,
     TEST_CONFIG_PATH,
     TEST_CHANNEL_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_source_proxy.py
+++ b/src/decisionengine/framework/tests/test_source_proxy.py
@@ -13,6 +13,8 @@ from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     DEServer,
     TEST_CONFIG_PATH,
 )

--- a/src/decisionengine/framework/tests/test_source_proxy.py
+++ b/src/decisionengine/framework/tests/test_source_proxy.py
@@ -11,6 +11,7 @@ from decisionengine.framework.dataspace.datasources.tests.fixtures import (  # n
 )
 from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DEServer,
     TEST_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_start_with_bad_channels.py
+++ b/src/decisionengine/framework/tests/test_start_with_bad_channels.py
@@ -10,6 +10,8 @@ from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
     PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_IN_MEMORY_SQLITE,
     DEServer,
     TEST_CONFIG_PATH,
     TEST_CHANNEL_CONFIG_PATH,

--- a/src/decisionengine/framework/tests/test_start_with_bad_channels.py
+++ b/src/decisionengine/framework/tests/test_start_with_bad_channels.py
@@ -8,6 +8,7 @@ from logging import ERROR
 
 from decisionengine.framework.tests.fixtures import (  # noqa: F401
     PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
     PG_PROG,
     DEServer,
     TEST_CONFIG_PATH,


### PR DESCRIPTION
SQLAlchemy is going to add another 100 or so tests.  Having the tests rigged up in a way that makes running them in easier parallel should help give us the option of running them via xdist (and in parallel), but the interlocking needs to be something that pytest can map out.

This patch avoids making namespace conflicts via the postgresql fixtures (in the actual database server it spins up) via reuse of the connection fixture.