### PR TITLE
Correctly test datablock construction paths

### DIFF
--- a/src/decisionengine/framework/dataspace/datablock.py
+++ b/src/decisionengine/framework/dataspace/datablock.py
@@ -212,15 +212,18 @@ class DataBlock:
             self.taskmanager_id = taskmanager_id
         else:
             self.taskmanager_id = ('%s' % uuid.uuid1()).upper()
+
         if sequence_id:
             self.sequence_id = sequence_id
         else:
-            self.sequence_id = self.store_taskmanager(name, taskmanager_id)
+            self.sequence_id = self.store_taskmanager(name, self.taskmanager_id)
+
         if generation_id:
             self.generation_id = generation_id
         else:
             self.generation_id = self.dataspace.get_last_generation_id(
                 name, taskmanager_id)
+
         self._keys = []
         self.lock = threading.Lock()
 

--- a/src/decisionengine/framework/dataspace/datasources/postgresql.py
+++ b/src/decisionengine/framework/dataspace/datasources/postgresql.py
@@ -55,9 +55,10 @@ WHERE foo.taskmanager_id=%s
 """
 
 SELECT_LAST_GENERATION_ID_BY_NAME = """
-SELECT max(generation_id)
-FROM dataproduct
-WHERE taskmanager_id = (select  max(sequence_id) from taskmanager where name = %s)
+SELECT max(dp.generation_id) as generation_id
+FROM dataproduct dp
+JOIN taskmanager tm ON dp.taskmanager_id=tm.sequence_id
+WHERE tm.name=%s
 """
 
 SELECT_LAST_GENERATION_ID_BY_NAME_AND_ID = """

--- a/src/decisionengine/framework/dataspace/tests/test_datablock.py
+++ b/src/decisionengine/framework/dataspace/tests/test_datablock.py
@@ -16,15 +16,16 @@ from decisionengine.framework.dataspace import datablock
 def test_DataBlock_constructor(dataspace):  # noqa: F811
     my_tm = dataspace.get_taskmanagers()[0]  # fetch one of our loaded examples
 
+    dblock = datablock.DataBlock(dataspace, my_tm["name"])
+    assert dblock.generation_id == 1
+
     dblock = datablock.DataBlock(dataspace, my_tm["name"], my_tm["taskmanager_id"])
     assert dblock.generation_id == 1
 
     dblock = datablock.DataBlock(dataspace, my_tm["name"], generation_id=1)
     assert dblock.generation_id == 1
 
-    dblock = datablock.DataBlock(
-        dataspace, my_tm["name"], my_tm["taskmanager_id"], sequence_id=1
-    )
+    dblock = datablock.DataBlock(dataspace, my_tm["name"], sequence_id=1)
     assert dblock.generation_id == 1
 
 


### PR DESCRIPTION
The previous constructor tests didn't actually test the range of "no optional arguments" as expected.