### PR TITLE
Add missing `config` attrib test

### DIFF
--- a/src/decisionengine/framework/dataspace/datasources/tests/test_datasource_api.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/test_datasource_api.py
@@ -28,6 +28,12 @@ def test_create_tables(datasource):  # noqa: F811
 
 
 @pytest.mark.usefixtures("datasource")
+def test_has_config(datasource):  # noqa: F811
+    """This should have a `config` dict we can pass to jsonnet"""
+    assert isinstance(datasource.config, dict)
+
+
+@pytest.mark.usefixtures("datasource")
 def test_get_taskmanager_exists(datasource):  # noqa: F811
     """Can I get a taskmanager by name or name and uuid"""
     # should return the 'newest' instance


### PR DESCRIPTION
For reaching into the fixtures to see how they are configured and test to make sure the `config` is what it should be.