### PR TITLE
Add self.config so I can introspect the fixtures later

### DIFF
--- a/src/decisionengine/framework/dataspace/dataspace.py
+++ b/src/decisionengine/framework/dataspace/dataspace.py
@@ -85,6 +85,8 @@ class DataSpace():
             self.logger.exception("Error in initializing DataSpace!")
             raise DataSpaceConfigurationError('Invalid dataspace configuration')
 
+        self.config = config
+
         # Connect to the datasource/database
         self.datasource = DataSourceLoader().create_datasource(self._db_driver_module,
                                                                self._db_driver_name,

--- a/src/decisionengine/framework/dataspace/tests/test_dataspace.py
+++ b/src/decisionengine/framework/dataspace/tests/test_dataspace.py
@@ -17,6 +17,12 @@ from decisionengine.framework.dataspace.tests.fixtures import (  # noqa: F401
 from decisionengine.framework.dataspace.datablock import Header, Metadata
 
 
+@pytest.mark.usefixtures("dataspace")
+def test_has_config(dataspace):  # noqa: F811
+    """verify our config entry exists"""
+    assert isinstance(dataspace.config, dict)
+
+
 def test_dataspace_config_finds_bad():
     with pytest.raises(ds.DataSpaceConfigurationError) as e:
         ds.DataSpace({})


### PR DESCRIPTION
For more aggressive testing I need to be able to ask a fixture how it is configured.