### PR TITLE
Setup PYTHONPATH for subprocess automatically

### DIFF
--- a/src/decisionengine/framework/tests/ModuleProgramOptions.py
+++ b/src/decisionengine/framework/tests/ModuleProgramOptions.py
@@ -1,15 +1,26 @@
+import os
 import re
 import subprocess
 import sys
 import tempfile
 
+import decisionengine
+
 def _run_as_main(name, *program_options):
+    import_path = os.path.dirname(os.path.dirname(decisionengine.__file__))
+    myenv = os.environ.copy()
+    if 'PYTHONPATH' not in myenv:
+        myenv['PYTHONPATH'] = import_path
+    else:
+        myenv['PYTHONPATH'] = f"{myenv['PYTHONPATH']}:{import_path}"
     rc = subprocess.run([sys.executable,
                          '-m',
                          'decisionengine.framework.tests.' + name,
                          *program_options],
+                        shell=True,
                         stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE)
+                        stderr=subprocess.PIPE,
+                        env=myenv)
     return rc.returncode, rc.stdout.decode().strip(), rc.stderr.decode().strip()
 
 def _normalize(string):


### PR DESCRIPTION
These tests depend on being able to run `import decisionengine` but may not have the right `PYTHONPATH` setup.  Folks should `export PYTHONPATH` or install the module, but this one bites me every so often...