### PR TITLE
Make sure our sqlite tests have ForeignKeyConditional support

### DIFF
--- a/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/utils.py
+++ b/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/utils.py
@@ -43,8 +43,13 @@ def add_engine_pidguard(engine):
     def connect(dbapi_connection, connection_record):
         """
         Based on
+        https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#foreign-key-support
         https://docs.sqlalchemy.org/en/14/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork
         """
+        if 'sqlite' in str(type(dbapi_connection)):
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.close()
         connection_record.info["pid"] = os.getpid()
 
     @sqlalchemy.event.listens_for(engine, "checkout")

--- a/src/decisionengine/framework/dataspace/datasources/tests/test_datasource_api.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/test_datasource_api.py
@@ -408,7 +408,7 @@ def test_update(datasource):  # noqa: F811
 
 @pytest.mark.usefixtures("datasource")
 def test_update_bad(datasource):  # noqa: F811
-    """Do updates fail to work as expected"""
+    """Do updates fail to work on bogus taskmanager as expected"""
     metadata_row = datasource.get_metadata(
         taskmanager_id=1,
         generation_id=1,
@@ -419,7 +419,7 @@ def test_update_bad(datasource):  # noqa: F811
         generation_id=1,
         key="my_test_key",
     )
-    with pytest.raises((KeyError, NoResultFound)):
+    with pytest.raises(Exception):
         datasource.update(
             taskmanager_id=100,
             generation_id=1,

--- a/src/decisionengine/framework/dataspace/tests/test_dataspace.py
+++ b/src/decisionengine/framework/dataspace/tests/test_dataspace.py
@@ -404,7 +404,7 @@ def test_update(dataspace):  # noqa: F811
 
 @pytest.mark.usefixtures("dataspace")
 def test_update_bad(dataspace):  # noqa: F811
-    """Do updates fail to work as expected"""
+    """Do updates fail to work on bogus taskmanager as expected"""
     metadata_row = dataspace.get_metadata(
         taskmanager_id=1,
         generation_id=1,
@@ -415,7 +415,7 @@ def test_update_bad(dataspace):  # noqa: F811
         generation_id=1,
         key="my_test_key",
     )
-    with pytest.raises((KeyError, NoResultFound)):
+    with pytest.raises(Exception):
         dataspace.update(
             taskmanager_id=100,
             generation_id=1,


### PR DESCRIPTION
This should ensure our foreign key constraints are correctly checked in sqlite.  The database will now raise the relevant constraint error during tests so we just catch `Exception` rather than the specific DBAPI error.