### PR TITLE
Datablock use db keys

### DIFF
--- a/src/decisionengine/framework/dataspace/datablock.py
+++ b/src/decisionengine/framework/dataspace/datablock.py
@@ -226,7 +226,6 @@ class DataBlock:
             self.generation_id = self.dataspace.get_last_generation_id(
                 name, taskmanager_id)
 
-        self._keys = []
         self.lock = threading.Lock()
 
     def __str__(self):
@@ -244,6 +243,14 @@ class DataBlock:
 
     def __contains__(self, key):
         return key in self.keys()
+
+    @property
+    def _keys(self):
+        return tuple(self.dataspace.get_datablock(self.sequence_id, self.generation_id).keys())
+
+    @_keys.setter
+    def _keys(self, value):  # pragma: no cover
+        raise ValueError("You may not redefine the known keys for a datablock")
 
     def keys(self):
         return self._keys
@@ -306,7 +313,6 @@ class DataBlock:
         """
         self.dataspace.insert(self.sequence_id, self.generation_id,
                               key, value, header, metadata)
-        self._keys.append(key)
 
     def _update(self, key, value, header, metadata):
         """
@@ -439,7 +445,6 @@ class DataBlock:
 
         dup_datablock = copy.copy(self)
         self.generation_id += 1
-        dup_datablock._keys = copy.deepcopy(self._keys)
         self.dataspace.duplicate_datablock(self.sequence_id,
                                            dup_datablock.generation_id,
                                            self.generation_id)

--- a/src/decisionengine/framework/dataspace/tests/test_datablock.py
+++ b/src/decisionengine/framework/dataspace/tests/test_datablock.py
@@ -42,9 +42,9 @@ def test_DataBlock_to_str(dataspace):  # noqa: F811
             my_tm["name"], my_tm["taskmanager_id"]
         ),
         "sequence_id": len(dataspace.get_dataproducts(my_tm["sequence_id"])) + 1,
-        "keys": [
+        "keys": (
             "example_test_key",
-        ],
+        ),
         "dataproducts": {"example_test_key": "example_test_value"},
     }
 


### PR DESCRIPTION
This should keep the "known" keys from drifting away from the known state in the database.

Switched the `_insert` and `_update` methods to `__` so python will really try to protect those methods from unwise callers. Since they don't hold our write locks, they really should be considered private methods.

Fixes: #458 
Fixes: #455 