### PR TITLE
Added metrics API module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 # pull in runtime requirements
 runtime_require = ["DBUtils >= 2.0",
                    "jsonnet >= 0.17.0",
+                   "prometheus-client >= 0.10.0",
                    "tabulate >= 0.8.7",
                    "toposort >= 1.6",
                    "sqlalchemy >= 1.4.20",
@@ -31,7 +32,6 @@ runtime_require = ["DBUtils >= 2.0",
                    "pandas == 1.1.5; python_version <= '3.6'",
                    "pandas >= 1.1.5; python_version >= '3.7' and platform_python_implementation == 'CPython'",
                    "pandas == 1.2.5; platform_python_implementation == 'PyPy'",  # For pypy3.7, try again on pypy3.8
-                   "prometheus-client >= 0.10.0",
                    "psycopg2-binary >= 2.8.6; platform_python_implementation == 'CPython'",  # noqa: E501
                    "psycopg2cffi >= 2.9.0; platform_python_implementation == 'PyPy'"]  # noqa: E501
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ runtime_require = ["DBUtils >= 2.0",
                    "pandas == 1.1.5; python_version <= '3.6'",
                    "pandas >= 1.1.5; python_version >= '3.7' and platform_python_implementation == 'CPython'",
                    "pandas == 1.2.5; platform_python_implementation == 'PyPy'",  # For pypy3.7, try again on pypy3.8
+                   "prometheus-client >= 0.10.0",
                    "psycopg2-binary >= 2.8.6; platform_python_implementation == 'CPython'",  # noqa: E501
                    "psycopg2cffi >= 2.9.0; platform_python_implementation == 'PyPy'"]  # noqa: E501
 

--- a/src/decisionengine/framework/util/metrics.py
+++ b/src/decisionengine/framework/util/metrics.py
@@ -1,0 +1,34 @@
+import prometheus_client
+
+
+class Gauge(prometheus_client.Gauge):
+    """Override prometheus client Gauge so that muliproccess_mode 'liveall" is
+    the default as opposed to 'all'"""
+
+    _DEFAULT_MULTIPROC_MODE = "liveall"
+
+    def __init__(self, *args, **kwargs):
+        if self.__determine_multiprocess_mode_existence(*args, **kwargs):
+            super().__init__(*args, **kwargs)
+        else:
+            super().__init__(multiprocess_mode=self._DEFAULT_MULTIPROC_MODE, *args, **kwargs)
+
+    def __determine_multiprocess_mode_existence(self, *args, **kwargs):
+        if "multiprocess_mode" in kwargs:
+            return True
+        for arg in args:
+            if isinstance(arg, str) and arg in self._MULTIPROC_MODES:
+                return True
+        return False
+
+
+class Counter(prometheus_client.Counter):
+    pass
+
+
+class Histogram(prometheus_client.Histogram):
+    pass
+
+
+class Summary(prometheus_client.Summary):
+    pass

--- a/src/decisionengine/framework/util/tests/test_metrics.py
+++ b/src/decisionengine/framework/util/tests/test_metrics.py
@@ -1,0 +1,140 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def env_setup(tmp_path, monkeypatch):
+    """Make sure we have a directory set for PROMETHEUS_MULTIPROC_DIR so that
+    metric instantiation gives us multiprocess metrics"""
+    d = tmp_path
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(d))
+    yield
+    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR")
+
+
+# Put these metrics declarations in fixtures because we need the env_setup
+# fixture to be set before importing any of the metrics
+@pytest.fixture()
+def Gauge():
+    from decisionengine.framework.util.metrics import Gauge
+
+    pytest.gauge_default_multiproc_mode = Gauge._DEFAULT_MULTIPROC_MODE
+
+    def _gauge(*args, **kwargs):
+        return Gauge(*args, **kwargs)
+
+    yield _gauge
+
+
+@pytest.fixture()
+def Counter():
+    from decisionengine.framework.util.metrics import Counter
+
+    def _counter(*args, **kwargs):
+        return Counter(*args, **kwargs)
+
+    yield _counter
+
+
+@pytest.fixture
+def OtherMetric():
+    from decisionengine.framework.util.metrics import Histogram, Summary
+
+    def _decider(metric_type):
+        if metric_type == "histogram":
+
+            def _histogram(*args, **kwargs):
+                return Histogram(*args, **kwargs)
+
+            return _histogram
+        elif metric_type == "summary":
+
+            def _summary(*args, **kwargs):
+                return Summary(*args, **kwargs)
+
+            return _summary
+
+    yield _decider
+
+
+@pytest.mark.parametrize(
+    "test_params",
+    [
+        {
+            "metric_args": ["test_gauge_default_multiproc_par", "test_gauge_default_multiproc_par"],
+            "wanted_multiprocess_mode": "liveall",
+        },
+        {
+            "metric_args": ["test_gauge_multiproc_override_par", "test_gauge_multiproc_override_par"],
+            "metric_kwargs": {"multiprocess_mode": "all"},
+            "wanted_multiprocess_mode": "all",
+        },
+        {
+            "metric_args": ["test_gauge_multiproc_override_with_arg", "test_gauge_multiproc_override_with_arg", "all"],
+            "wanted_multiprocess_mode": "all",
+        },
+    ],
+)
+@pytest.mark.usefixtures("Gauge")
+def test_gauge_set_multiproc_mode(Gauge, test_params):
+    """
+    Test setting the gauge multiproc mode
+
+    test_params is a list of dicts that support three keys:
+        'metric_args': list of arguments to pass to Gauge
+        'metric_kwargs': dict of keyword arguments to pass to Gauge
+        'wanted_multiprocess_mode': Intended multiprocess mode of Gauge after
+            instantiation
+    """
+    g = Gauge(*test_params["metric_args"], **test_params.get("metric_kwargs", {}))
+    assert g._multiprocess_mode == test_params.get("wanted_multiprocess_mode", pytest.gauge_default_multiproc_mode)
+
+
+@pytest.mark.usefixtures("Gauge")
+def test_gauge_multiproc_override_invalid(Gauge):
+    """Test overriding the default gauge multiproc mode with something
+    invalid"""
+    new_multiprocess_mode = "foo"
+    with pytest.raises(ValueError, match="Invalid multiprocess mode"):
+        _ = Gauge(
+            "test_gauge_multiproc_override_invalid",
+            "test_gauge_multiproc_override_invalid",
+            multiprocess_mode=new_multiprocess_mode,
+        )
+
+
+@pytest.mark.usefixtures("Gauge")
+def test_gauge_set_value(Gauge):
+    """Test setting a gauge value"""
+    g = Gauge("test_gauge_set_value", "test_gauge_set_value")
+    g.set(42)
+    assert g._value.get() == 42
+
+
+@pytest.mark.usefixtures("Gauge")
+def test_gauge_set_invalid_value(Gauge):
+    """Try to set a gauge to an invalid value"""
+    g = Gauge(
+        "test_gauge_set_invalid_value",
+        "test_gauge_set_invalid_value",
+    )
+    with pytest.raises(ValueError):
+        g.set("badstring")
+
+
+@pytest.mark.usefixtures("Counter")
+def test_counter_inc_value(Counter):
+    """Increment the counter"""
+    c = Counter("test_counter_inc_value", "test_counter_inc_value")
+    c.inc()
+    assert c._value.get() == 1
+
+
+@pytest.mark.parametrize("other_metric_arg", ["histogram", "summary"])
+@pytest.mark.usefixtures("OtherMetric")
+def test_other_metric_observe_value(OtherMetric, other_metric_arg):
+    """Observe a histogram or summary value and make sure it is stored properly"""
+    _m = OtherMetric(other_metric_arg)
+    test_metric_string = f"test_{other_metric_arg}_observe_value"
+    m = _m(test_metric_string, test_metric_string)
+    m.observe(42)
+    assert m._sum.get() == 42


### PR DESCRIPTION
This is simply adding the metrics API to the repository so that any custom implementations of the four prometheus metrics (Counter, Gauge, Histogram, Summary) can be imported from within the framework. At Marco's request, I overrode the "Gauge" metric so that we're placed in the correct "multiprocess" mode by default.