### PR TITLE
Sometimes pypy times out on the cleanup.

### DIFF
--- a/src/decisionengine/framework/tests/test_sample_config.py
+++ b/src/decisionengine/framework/tests/test_sample_config.py
@@ -31,7 +31,7 @@ def test_client_can_get_de_server_status(deserver):
     output = deserver.de_client_run_cli('--status')
     assert 'state = STEADY' in output
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(35)
 @pytest.mark.usefixtures("deserver")
 def test_client_wait_timeout_works(deserver):
     '''Verify channel enters stable state and timeout works too'''


### PR DESCRIPTION
This makes the timeout match the rest of the tests in this file.