### PR TITLE
moved logging of LogicEngine from decisionengine logger to channel loggers

### DIFF
--- a/src/decisionengine/framework/logicengine/LogicEngine.py
+++ b/src/decisionengine/framework/logicengine/LogicEngine.py
@@ -5,12 +5,11 @@ from itertools import chain
 from decisionengine.framework.logicengine.RuleEngine import RuleEngine
 from decisionengine.framework.logicengine.BooleanExpression import BooleanExpression
 from decisionengine.framework.modules.Module import Module
-from decisionengine.framework.modules.de_logger import LOGGERNAME
 
 class LogicEngine(Module):
-    def __init__(self, cfg):
+    def __init__(self, cfg, channel_name):
         super().__init__(cfg)
-        self.logger = structlog.getLogger(LOGGERNAME)
+        self.logger = structlog.getLogger(f"{channel_name}")
         self.logger = self.logger.bind(module=__name__.split(".")[-1])
         self.facts = {name: BooleanExpression(expr) for name, expr in cfg["facts"].items()}
         self.rule_engine = RuleEngine(cfg["facts"].keys(), cfg["rules"])

--- a/src/decisionengine/framework/logicengine/tests/test_cascaded_rules.py
+++ b/src/decisionengine/framework/logicengine/tests/test_cascaded_rules.py
@@ -10,8 +10,9 @@ def myengine():
     rules["r2"] = {"expression": "f2", "actions": ["a2"], "facts": ["f3"]}
     rules["r3"] = {"expression": "f3", "facts": ["f4"]}
     rules["r4"] = {"expression": "f4", "actions": ["a4"], "false_actions": ["fa4"]}
+    channelname = "testing"
 
-    yield LogicEngine({"facts": facts, "rules": rules})
+    yield LogicEngine({"facts": facts, "rules": rules}, channelname)
 
 def test_rule_that_fires(myengine):
     db = {"val": 20}

--- a/src/decisionengine/framework/logicengine/tests/test_construction.py
+++ b/src/decisionengine/framework/logicengine/tests/test_construction.py
@@ -12,26 +12,29 @@ def test_wrong_configuration():
     """LogicEngine construction requires rules and facts;
     if we don't supply them it is an error."""
     with pytest.raises(KeyError):
-        LogicEngine({})
+        LogicEngine({}, "test")
 
 def test_trivial_configuration():
     """Logic engine constructed with trivial rules and facts."""
     cfg = {"rules": {}, "facts": {}}
-    le = LogicEngine(cfg)
+    channelname = "test"
+    le = LogicEngine(cfg, channelname)
     assert le.produces() == ["actions", "newfacts"]
     assert le.consumes() == []
 
 def test_configuration_with_fact_using_function():
     facts = {"f1": "len(vals) == 10"}
     rules = {"r1": {"expression": "f1", "actions": ["launch"]}}
-    le = LogicEngine({"rules": rules, "facts": facts})
+    channelname = "test"
+    le = LogicEngine({"rules": rules, "facts": facts}, channelname)
     assert le.produces() == ["actions", "newfacts"]
     assert le.consumes() == ["vals"]
 
 def test_configuration_with_numy_facts():
     facts = {"f1": "vals.sum() > blob.available"}
     rules = {"r1": {"expression": "f1", "actions": ["launch"]}}
-    le = LogicEngine({"rules": rules, "facts": facts})
+    channelname = "test"
+    le = LogicEngine({"rules": rules, "facts": facts}, channelname)
     assert le.produces() == ["actions", "newfacts"]
     assert set(le.consumes()) == {"vals", "blob"}
     #cfg = { "rules": {}, "facts": {} }

--- a/src/decisionengine/framework/logicengine/tests/test_duplicate_fact_names.py
+++ b/src/decisionengine/framework/logicengine/tests/test_duplicate_fact_names.py
@@ -8,7 +8,8 @@ def test_duplicate_fact_names():
                           "facts": ["should_publish"]}
     rules["publish_2"] = {"expression": "(should_publish)",
                           "facts": ["should_publish"]}
-    le = LogicEngine({"facts": facts, "rules": rules})
+    channelname = "test"
+    le = LogicEngine({"facts": facts, "rules": rules}, channelname)
     ef = le.evaluate_facts({})
     assert ef["should_publish"]
     result = le.evaluate({})

--- a/src/decisionengine/framework/logicengine/tests/test_fail_on_error.py
+++ b/src/decisionengine/framework/logicengine/tests/test_fail_on_error.py
@@ -5,7 +5,8 @@ import pytest
 def logic_engine_with_fact(fact):
     facts = {"f1": fact}
     rules = {"r1": {"expression": "f1"}}
-    return LogicEngine({"facts": facts, "rules": rules})
+    channelname = "test"
+    return LogicEngine({"facts": facts, "rules": rules}, channelname)
 
 def test_true_literal_fact():
     engine = logic_engine_with_fact("fail_on_error(True)")

--- a/src/decisionengine/framework/logicengine/tests/test_pandas_fact.py
+++ b/src/decisionengine/framework/logicengine/tests/test_pandas_fact.py
@@ -7,7 +7,8 @@ import pandas as pd
 def myengine():
     facts = {"f1": "y > 10", "f2": "vals.one.sum() > 10"}
     rules = {"r1": {"expression": "f1 and f2", "actions": ["a1", "a2"]}}
-    yield LogicEngine({"facts": facts, "rules": rules})
+    channelname = "test"
+    yield LogicEngine({"facts": facts, "rules": rules}, channelname)
 
 def mydata(y):
     """Return a 'datablock' surrogate carrying a Pandas DataFrame, and a

--- a/src/decisionengine/framework/logicengine/tests/test_rule_with_negated_fact.py
+++ b/src/decisionengine/framework/logicengine/tests/test_rule_with_negated_fact.py
@@ -8,7 +8,8 @@ def myengine():
     rules = {}
     rules["r1"] = {"expression": "not f1", "actions": ["a1"]}
     rules["r2"] = {"expression": "not (f1)", "actions": ["a2"]}
-    yield LogicEngine({"facts": facts, "rules": rules})
+    channelname = "test"
+    yield LogicEngine({"facts": facts, "rules": rules}, channelname)
 
 
 def test_rule_that_fires(myengine):

--- a/src/decisionengine/framework/logicengine/tests/test_simple_configuration.py
+++ b/src/decisionengine/framework/logicengine/tests/test_simple_configuration.py
@@ -6,7 +6,8 @@ import pandas as pd
 def myengine():
     facts = {"f1": "val > 10"}
     rules = {"r1": {"expression": "f1", "actions": ["a1", "a2"]}}
-    yield LogicEngine({"facts": facts, "rules": rules})
+    channelname = "test"
+    yield LogicEngine({"facts": facts, "rules": rules}, channelname)
 
 
 def test_rule_that_fires(myengine):

--- a/src/decisionengine/framework/taskmanager/TaskManager.py
+++ b/src/decisionengine/framework/taskmanager/TaskManager.py
@@ -51,7 +51,7 @@ def _find_only_one_subclass(module, base_class):
     return subclasses[0]
 
 
-def _create_module_instance(config_dict, base_class):
+def _create_module_instance(config_dict, base_class, channel_name):
     """
     Create instance of dynamically loaded module
     """
@@ -65,7 +65,11 @@ def _create_module_instance(config_dict, base_class):
             class_name = _find_only_one_subclass(my_module, base_class)
 
     class_type = getattr(my_module, class_name)
-    return class_type(config_dict["parameters"])
+    #here we add the channel name to the LogicEngine class to get the correct logger
+    if class_name == "LogicEngine":
+        return class_type(config_dict["parameters"], channel_name)
+    else:
+        return class_type(config_dict["parameters"])
 
 
 class Worker:
@@ -74,12 +78,12 @@ class Worker:
     execution
     """
 
-    def __init__(self, conf_dict, base_class):
+    def __init__(self, conf_dict, base_class, channel_name):
         """
         :type conf_dict: :obj:`dict`
         :arg conf_dict: configuration dictionary describing the worker
         """
-        self.worker = _create_module_instance(conf_dict, base_class)
+        self.worker = _create_module_instance(conf_dict, base_class, channel_name)
         self.module = conf_dict["module"]
         self.name = self.worker.__class__.__name__
         self.schedule = conf_dict.get("schedule", _DEFAULT_SCHEDULE)
@@ -92,8 +96,8 @@ class Worker:
         )
 
 
-def _make_workers_for(configs, base_class):
-    return {name: Worker(e, base_class) for name, e in configs.items()}
+def _make_workers_for(configs, base_class, channel_name):
+    return {name: Worker(e, base_class, channel_name) for name, e in configs.items()}
 
 
 class Channel:
@@ -102,21 +106,21 @@ class Channel:
     Instantiates workers according to channel configuration
     """
 
-    def __init__(self, channel_dict):
+    def __init__(self, channel_dict, channel_name):
         """
         :type channel_dict: :obj:`dict`
         :arg channel_dict: channel configuration
         """
 
         delogger.debug("Creating channel source")
-        self.sources = _make_workers_for(channel_dict["sources"], Source)
+        self.sources = _make_workers_for(channel_dict["sources"], Source, channel_name)
         delogger.debug("Creating channel logicengine")
-        self.le_s = _make_workers_for(channel_dict["logicengines"], LogicEngine)
+        self.le_s = _make_workers_for(channel_dict["logicengines"], LogicEngine, channel_name)
         delogger.debug("Creating channel publisher")
-        self.publishers = _make_workers_for(channel_dict["publishers"], Publisher)
+        self.publishers = _make_workers_for(channel_dict["publishers"], Publisher, channel_name)
 
         delogger.debug("Creating channel transform")
-        transforms = _make_workers_for(channel_dict["transforms"], Transform)
+        transforms = _make_workers_for(channel_dict["transforms"], Transform, channel_name)
         self.transforms = ensure_no_circularities(self.sources, transforms, self.publishers)
         self.task_manager = channel_dict.get("task_manager", {})
 
@@ -143,7 +147,7 @@ class TaskManager:
         self.name = name
         self.logger = structlog.getLogger(f"{self.name}")
         self.logger = self.logger.bind(module=__name__.split(".")[-1])
-        self.channel = Channel(channel_dict)
+        self.channel = Channel(channel_dict, name)
         self.state = ProcessingState()
         self.loglevel = multiprocessing.Value("i", logging.WARNING)
         self.lock = threading.Lock()

--- a/src/decisionengine/framework/taskmanager/tests/test_module_inference.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_module_inference.py
@@ -7,17 +7,20 @@ import pytest
 def test_no_module():
     config = {'module': 'decisionengine.framework.taskmanager.tests.NoSource',
               'parameters': {}}
+    channelname = "test"
     with pytest.raises(RuntimeError, match="Could not find a decision-engine 'Source'"):
-        _create_module_instance(config, Source)
+        _create_module_instance(config, Source, channelname)
 
 def test_too_many_modules():
     config = {'module': 'decisionengine.framework.taskmanager.tests.TwoSources',
               'parameters': {}}
+    channelname = "test"
     with pytest.raises(RuntimeError, match="Found more than one decision-engine 'Source'"):
-        _create_module_instance(config, Source)
+        _create_module_instance(config, Source, channelname)
 
 def test_select_one_of_two_modules():
     config = {'module': 'decisionengine.framework.taskmanager.tests.TwoSources',
               'name': 'Source2',
               'parameters': {}}
-    _create_module_instance(config, Source)
+    channelname = "test"
+    _create_module_instance(config, Source, channelname)


### PR DESCRIPTION
These changes address Issue #456. If we want the Sources, Transforms, etc to log to the channel loggers, a different set of changes needs to be made.