### PR TITLE
Drop `_keys` in favor of DB backed `keys`

### DIFF
--- a/src/decisionengine/framework/dataspace/datablock.py
+++ b/src/decisionengine/framework/dataspace/datablock.py
@@ -246,18 +246,10 @@ class DataBlock:
     def __contains__(self, key):
         return key in self.keys()
 
-    @property
-    def _keys(self):
-        self.logger.debug("datablock waiting for internal read lock in '_keys'")
+    def keys(self):
+        self.logger.debug("datablock waiting for internal read lock in 'keys'")
         with self.__internal_data_read_lock:
             return tuple(self.dataspace.get_datablock(self.sequence_id, self.generation_id).keys())
-
-    @_keys.setter
-    def _keys(self, value):  # pragma: no cover
-        raise ValueError("You may not redefine the known keys for a datablock")
-
-    def keys(self):
-        return self._keys
 
     def store_taskmanager(self, taskmanager_name, taskmanager_id):
         """

--- a/src/decisionengine/framework/dataspace/tests/test_datablock.py
+++ b/src/decisionengine/framework/dataspace/tests/test_datablock.py
@@ -233,9 +233,9 @@ def test_DataBlock_duplicate(dataspace):  # noqa: F811
     assert dblock.taskmanager_id == dblock_2.taskmanager_id
     assert dblock.generation_id == dblock_2.generation_id + 1
     assert dblock.sequence_id == dblock_2.sequence_id
-    assert dblock._keys == dblock_2._keys
+    assert dblock.keys() == dblock_2.keys()
 
-    for key in dblock._keys:
+    for key in dblock.keys():
         assert dblock[key] == dblock_2[key]
 
 


### PR DESCRIPTION
Marco noted the `_keys` interface wasn't necessary any longer since we've moved to the DB backed methods.