### PR TITLE
Drop unnecessary timeout

### DIFF
--- a/src/decisionengine/framework/tests/test_source_proxy.py
+++ b/src/decisionengine/framework/tests/test_source_proxy.py
@@ -25,7 +25,6 @@ deserver = DEServer(
 )  # pylint: disable=invalid-name
 
 
-@pytest.mark.timeout(20)
 @pytest.mark.usefixtures("deserver")
 def test_working_source_proxy(deserver):
     # The following 'block-while' call be unnecessary once the
@@ -42,7 +41,6 @@ def test_working_source_proxy(deserver):
 _fail_channel_config_dir = os.path.join(TEST_CONFIG_PATH, 'test-failing-source-proxy')  # noqa: F405
 deserver_fail = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=_fail_channel_config_dir)  # pylint: disable=invalid-name
 
-@pytest.mark.timeout(20)
 @pytest.mark.usefixtures("deserver_fail")
 def test_stop_failing_source_proxy(deserver_fail):
     # The following 'block-while' call be unnecessary once the


### PR DESCRIPTION
Now that the fixtures have a more deterministic startup, we don't need these timeout checks to avoid unexpected deadlocks.