### PR TITLE
Unused loop vars should start with `_`

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -244,7 +244,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
                           "publishers"):
                     txt += "\t{}:\n".format(i)
                     modules = channel_config.get(i, {})
-                    for mod_name, mod_config in modules.items():
+                    for mod_name in modules.keys():
                         txt += "\t\t{}\n".format(mod_name)
                         products = produces.get(mod_name, [])
                         for product in products:
@@ -279,7 +279,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
                           "publishers"):
                     txt += "\t{}:\n".format(i)
                     modules = channel_config.get(i, {})
-                    for mod_name, mod_config in modules.items():
+                    for mod_name in modules.keys():
                         txt += "\t\t{}\n".format(mod_name)
                         txt += "\t\t\tconsumes : {}\n".format(consumes.get(mod_name, []))
                         txt += "\t\t\tproduces : {}\n".format(produces.get(mod_name, []))

--- a/src/decisionengine/framework/engine/Workers.py
+++ b/src/decisionengine/framework/engine/Workers.py
@@ -142,7 +142,7 @@ class Workers:
 
     def _update_channel_states(self):
         with self._lock:
-            for channel, process in self._workers.items():
+            for process in self._workers.values():
                 if process.is_alive():
                     continue
                 if process.task_manager.state.inactive():

--- a/src/decisionengine/framework/modules/Module.py
+++ b/src/decisionengine/framework/modules/Module.py
@@ -93,5 +93,5 @@ def verify_products(producer, data):
 
     err_msg = "\nThe following products have the wrong types:\n"
     for name, a_type, b_type in mismatched_types:
-        err_msg += f" - '{name}' (expected '{a_name}', got '{b_name}')\n"
+        err_msg += f" - '{name}' (expected '{a_type}', got '{b_type}')\n"
     raise RuntimeError(err_msg)

--- a/src/decisionengine/framework/util/tests/test_singleton.py
+++ b/src/decisionengine/framework/util/tests/test_singleton.py
@@ -102,7 +102,7 @@ def test_single_instance_threading_lock():
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
         threads = []
-        for i in range(15):
+        for _i in range(15):
             threads.append(executor.submit(make_class, barrier))
 
         for future in concurrent.futures.as_completed(threads):


### PR DESCRIPTION
By convention, unused loop variables should start with `_` to denote this.

I'm a bit unsure on the changes to `DecisionEngine.py` but they "look" right....