### PR TITLE
Combine nested `with` blocks

### DIFF
--- a/src/decisionengine/framework/dataspace/datasources/tests/fixtures.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/fixtures.py
@@ -58,9 +58,11 @@ def PG_DE_DB_WITH_SCHEMA(PG_DE_DB_WITHOUT_SCHEMA):
     so pytest knows the limitations on parallel usage of this
     database scope.
     """
-    with open(os.path.dirname(os.path.abspath(__file__)) + "/../postgresql.sql", 'r') as _fd:
-        with PG_DE_DB_WITHOUT_SCHEMA.cursor() as cursor:
-            cursor.execute(_fd.read())
+    with open(
+        os.path.dirname(os.path.abspath(__file__)) + "/../postgresql.sql"
+    ) as _fd, PG_DE_DB_WITHOUT_SCHEMA.cursor() as cursor:
+        cursor.execute(_fd.read())
+
     PG_DE_DB_WITHOUT_SCHEMA.commit()
     yield PG_DE_DB_WITHOUT_SCHEMA
 

--- a/src/decisionengine/framework/modules/tests/test_de_logger.py
+++ b/src/decisionengine/framework/modules/tests/test_de_logger.py
@@ -27,15 +27,14 @@ def log_setup():
 @pytest.mark.usefixtures("log_setup")
 @pytest.mark.skip(reason="test failing under structlog config, needs re-working")
 def test_by_nonsense_is_err(log_setup):
-    with pytest.raises(ValueError) as err:
-        with tempfile.NamedTemporaryFile() as log:
-            de_logger.set_logging(
-                log_level="INFO",
-                max_backup_count=6,
-                file_rotate_by="nonsense",
-                max_file_size=1000000,
-                log_file_name=log.name,
-            )
+    with pytest.raises(ValueError) as err, tempfile.NamedTemporaryFile() as log:
+        de_logger.set_logging(
+            log_level="INFO",
+            max_backup_count=6,
+            file_rotate_by="nonsense",
+            max_file_size=1000000,
+            log_file_name=log.name,
+        )
     assert "Incorrect 'file_rotate_by'" in str(err.value)
 
 


### PR DESCRIPTION
Multiple nested `with` blocks imposes unnecessary scope work.