### PR TITLE
Ensure file is "flushed" so name is fully established

### DIFF
--- a/src/decisionengine/framework/modules/tests/test_de_logger.py
+++ b/src/decisionengine/framework/modules/tests/test_de_logger.py
@@ -28,6 +28,7 @@ def log_setup():
 @pytest.mark.skip(reason="test failing under structlog config, needs re-working")
 def test_by_nonsense_is_err(log_setup):
     with pytest.raises(ValueError) as err, tempfile.NamedTemporaryFile() as log:
+        log.flush()
         de_logger.set_logging(
             log_level="INFO",
             max_backup_count=6,
@@ -42,6 +43,7 @@ def test_by_nonsense_is_err(log_setup):
 @pytest.mark.skip(reason="test failing under structlog config, needs re-working")
 def test_by_size(log_setup):
     with tempfile.NamedTemporaryFile() as log:
+        log.flush()
         de_logger.set_logging(
             log_level="INFO", max_backup_count=6, file_rotate_by="size", max_file_size=1000000, log_file_name=log.name
         )
@@ -56,6 +58,7 @@ def test_by_size(log_setup):
 @pytest.mark.skip(reason="test failing under structlog config, needs re-working")
 def test_by_time(log_setup):
     with tempfile.NamedTemporaryFile() as log:
+        log.flush()
         de_logger.set_logging(
             log_level="INFO", rotation_interval=1, file_rotate_by="time", rotation_time_unit="D", log_file_name=log.name
         )

--- a/src/decisionengine/framework/tests/ModuleProgramOptions.py
+++ b/src/decisionengine/framework/tests/ModuleProgramOptions.py
@@ -141,6 +141,7 @@ class AcquireWithConfig:
     def test(self, byte_str, expected_stderr=''):
         with tempfile.NamedTemporaryFile(suffix='.jsonnet') as config_file:
             config_file.write(byte_str)
+            config_file.flush()
             config_file.seek(0)
             rc, stdout, stderr = _run_as_main(self.name, '--acquire-with-config', config_file.name)
             if expected_stderr:


### PR DESCRIPTION
The "random" tmp name should be fully established before we rely on that name existing on disk.  In this case `flush()` is the cleanest way to ensure things look as expected.