### PR TITLE
Make sure product is a string

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -151,8 +151,11 @@ class DecisionEngine(socketserver.ThreadingMixIn,
         return self.global_config.dump()
 
     def rpc_print_product(self, product, columns=None, query=None, types=False, format=None):
+        if not isinstance(product, str):
+            raise ValueError(f"Requested product should be a string not {type(product)}")
+
         found = False
-        txt = "Product {}: ".format(product)
+        txt = f"Product {product}: "
         with self.workers.access() as workers:
             for ch, worker in workers.items():
                 if not worker.is_alive():
@@ -165,7 +168,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
                 if not r:
                     continue
                 found = True
-                txt += " Found in channel {}\n".format(ch)
+                txt += f" Found in channel {ch}\n"
                 self.logger.debug(f"Found channel:{ch} active when running rpc_print_product")
                 tm = self.dataspace.get_taskmanager(ch)
                 self.logger.debug(f"rpc_print_product - channel:{ch} taskmanager:{tm}")
@@ -208,7 +211,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
                         else:
                             txt += dataframe_formatter(df)
                 except Exception as e:  # pragma: no cover
-                    txt += "\t\t{}\n".format(e)
+                    txt += f"\t\t{e}\n"
         if not found:
             txt += "Not produced by any module\n"
         return txt[:-1]

--- a/src/decisionengine/framework/tests/test_client_server.py
+++ b/src/decisionengine/framework/tests/test_client_server.py
@@ -61,6 +61,18 @@ def test_client_print_product_not_real(deserver):
     assert output == "Product NO_SUCH_PRODUCT: Not produced by any module"
 
 @pytest.mark.usefixtures("deserver")
+def test_client_print_product_not_string(deserver):
+    """Make sure the public API is protected against bad values"""
+    with pytest.raises(ValueError, match=r"Requested product should be a string.*"):
+        deserver.de_server.rpc_print_product(123)
+    with pytest.raises(ValueError, match=r"Requested product should be a string.*"):
+        deserver.de_server.rpc_print_product(b"123")
+    with pytest.raises(ValueError, match=r"Requested product should be a string.*"):
+        deserver.de_server.rpc_print_product(pytest)
+    with pytest.raises(ValueError, match=r"Requested product should be a string.*"):
+        deserver.de_server.rpc_print_product({"a": "b"})
+
+@pytest.mark.usefixtures("deserver")
 def test_client_print_product_types(deserver):
     # Test --types
     output = deserver.de_client_run_cli('--print-product', 'foo', '--types')


### PR DESCRIPTION
Since we are using it (a) comes from "the internet" (b) is a value
for keys, and (c) is sent back "as a string", it needs to be
a type of data we can trust.