### PR TITLE
Support latest setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
-requires = ["setuptools>=51.2", "wheel>=0.36.2", "setuptools_scm[toml]>=6.0.1"]
+requires = ["setuptools>=51.2", "wheel>=0.36.2", "setuptools_scm>=6.3.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/decisionengine/framework/version.py"
-version_scheme = "post-release"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/setup.py
+++ b/setup.py
@@ -73,9 +73,8 @@ site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 #
 # Much of it comes out of decisionengine.framework.about.py
 setup(
-    setup_requires=["setuptools >= 51.2", "wheel >= 0.36.2", "setuptools_scm[toml] >= 6.0.1"],
+    setup_requires=["setuptools >= 51.2", "wheel >= 0.36.2", "setuptools_scm >= 6.3.1"],
     name=about.__title__,
-    use_scm_version={"version_scheme": "post-release"},
     description=about.__description__,
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
A new version of setuptools_scm is now up on pypi.  It doesn't appear to like our existing tagging methods.  These changes should fix up the config to better support our current patterns.