### PR TITLE
Unconditionally execute publishers with default configured logic engine

### DIFF
--- a/src/decisionengine/framework/config/ChannelConfigHandler.py
+++ b/src/decisionengine/framework/config/ChannelConfigHandler.py
@@ -4,8 +4,7 @@ Manager of channel configurations.
 The ChannelConfigHandler manages only channel configurations and not
 the global decision-engine configuration.  It is responsible for
 loading channel configuration files and validating that the channels
-have the correct configuration artifacts and inter-module product
-dependencies.
+have the correct configuration artifacts.
 """
 
 import os
@@ -16,8 +15,8 @@ import decisionengine.framework.util.fs as fs
 from decisionengine.framework.config import ValidConfig
 from decisionengine.framework.modules.logging_configDict import DELOGGER_CHANNEL_NAME
 
-_MANDATORY_CHANNEL_KEYS = {"sources", "logicengines", "transforms", "publishers"}
-_ALLOWED_CHANNEL_KEYS = _MANDATORY_CHANNEL_KEYS | {"task_manager"}
+_MANDATORY_CHANNEL_KEYS = {"sources", "transforms", "publishers"}
+_ALLOWED_CHANNEL_KEYS = _MANDATORY_CHANNEL_KEYS | {"logicengines", "task_manager"}
 _MANDATORY_MODULE_KEYS = {"module", "parameters"}
 
 
@@ -90,7 +89,7 @@ class ChannelConfigHandler:
         except Exception as msg:
             return (
                 False,
-                f"Failed to open channel configuration file {path} " f"contains error\n-> {msg}\nSKIPPING channel",
+                f"Failed to open channel configuration file {path} contains error\n-> {msg}\nSKIPPING channel",
             )
 
         try:
@@ -98,7 +97,7 @@ class ChannelConfigHandler:
         except Exception as msg:
             return (
                 False,
-                f"The channel configuration file {path} contains a " f"validation error\n{msg}\nSKIPPING channel",
+                f"The channel configuration file {path} contains a validation error\n{msg}\nSKIPPING channel",
             )
         self.logger.debug(f"Channel {channel_name} config is valid.")
 

--- a/src/decisionengine/framework/config/tests/channels/invalid_modules_list/invalid_modules_list.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/invalid_modules_list/invalid_modules_list.jsonnet
@@ -1,6 +1,5 @@
 {
   "sources": [],
   "transforms": {},
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/config/tests/channels/invalid_modules_no_keys/invalid_modules_no_keys.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/invalid_modules_no_keys/invalid_modules_no_keys.jsonnet
@@ -1,6 +1,5 @@
 {
   "sources": {"test": ""},
   "transforms": {},
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/config/tests/channels/invalid_modules_string/invalid_modules_string.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/invalid_modules_string/invalid_modules_string.jsonnet
@@ -1,6 +1,5 @@
 {
   "sources": "",
   "transforms": {},
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/config/tests/channels/module_missing_all/module_missing_all.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/module_missing_all/module_missing_all.jsonnet
@@ -3,6 +3,5 @@
     "source1": {}
   },
   "transforms": {},
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/config/tests/channels/module_missing_module/module_missing_module.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/module_missing_module/module_missing_module.jsonnet
@@ -6,6 +6,5 @@
      }
   },
   "transforms": {},
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/config/tests/channels/module_missing_parameters/module_missing_parameters.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/module_missing_parameters/module_missing_parameters.jsonnet
@@ -6,6 +6,5 @@
      }
   },
   "transforms": {},
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/config/tests/channels/no_modules/no_modules.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/no_modules/no_modules.jsonnet
@@ -1,6 +1,5 @@
 {
   "sources": {},
   "transforms": {},
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/logicengine/LogicEngine.py
+++ b/src/decisionengine/framework/logicengine/LogicEngine.py
@@ -9,6 +9,21 @@ from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAM
 from decisionengine.framework.modules.Module import Module
 
 
+def passthrough_configuration(publisher_names):
+    """Assembles logic-engine configuration to unconditionally execute all publishers."""
+    if len(publisher_names) == 0:
+        return {}
+    return {
+        "logic_engine": {
+            "module": "decisionengine.framework.logicengine.LogicEngine",
+            "parameters": {
+                "facts": {},
+                "rules": {"r1": {"expression": "True", "actions": list(publisher_names)}},
+            },
+        }
+    }
+
+
 class LogicEngine(Module):
     def __init__(self, cfg):
         super().__init__(cfg)

--- a/src/decisionengine/framework/taskmanager/TaskManager.py
+++ b/src/decisionengine/framework/taskmanager/TaskManager.py
@@ -9,8 +9,7 @@ import pandas as pd
 import structlog
 
 from decisionengine.framework.dataspace import datablock
-from decisionengine.framework.logicengine.LogicEngine import LogicEngine
-from decisionengine.framework.logicengine.LogicEngine import passthrough_configuration
+from decisionengine.framework.logicengine.LogicEngine import LogicEngine, passthrough_configuration
 from decisionengine.framework.managers.ComponentManager import ComponentManager
 from decisionengine.framework.modules import Module
 from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME, DELOGGER_CHANNEL_NAME, LOGGERNAME
@@ -35,11 +34,11 @@ def _find_only_one_subclass(module, base_class):
     subclasses = all_subclasses(module, base_class)
     if not subclasses:
         raise RuntimeError(
-            f"Could not find a decision-engine '{base_class.__name__}' in the module:\n" f"  '{module.__name__}'"
+            f"Could not find a decision-engine '{base_class.__name__}' in the module '{module.__name__}'"
         )
     if len(subclasses) > 1:
         error_msg = (
-            f"Found more than one decision-engine '{base_class.__name__}' in the module\n" + f"'{module.__name__}':\n\n"
+            f"Found more than one decision-engine '{base_class.__name__}' in the module '{module.__name__}':\n\n"
         )
         for cls in subclasses:
             error_msg += " - " + cls + "\n"
@@ -115,6 +114,9 @@ class Channel:
         delogger.debug("Creating channel logicengine")
         configured_le_s = channel_dict.get("logicengines")
         if configured_le_s is None:
+            delogger.debug(
+                "No 'logicengines' configuration detected; will use default configuration, which unconditionally executes all configured publishers."
+            )
             configured_le_s = passthrough_configuration(channel_dict["publishers"].keys())
         if len(configured_le_s) > 1:
             raise RuntimeError("Cannot support more than one logic engine per channel.")

--- a/src/decisionengine/framework/taskmanager/tests/channels/multiple_logic_engines.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/multiple_logic_engines.jsonnet
@@ -1,0 +1,9 @@
+{
+  sources: {},
+  transforms: {},
+  logicengines: {
+    le1: {},
+    le2: {}
+  },
+  publishers: {}
+}

--- a/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
@@ -13,22 +13,6 @@
       "schedule": 1
     }
   },
-  "logicengines": {
-    "le1": {
-      "module": "decisionengine.framework.logicengine.LogicEngine",
-      "parameters": {
-        "facts": {
-          "pass_all": "True"
-        },
-        "rules": {
-          "r1": {
-            "expression": "pass_all",
-            "actions": ["publisher1"]
-          }
-        }
-      }
-    }
-  },
   "publishers": {
     "publisher1": {
       "module": "decisionengine.framework.tests.PublisherNOP",

--- a/src/decisionengine/framework/taskmanager/tests/channels/test_channel2.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/test_channel2.jsonnet
@@ -14,22 +14,6 @@
       "schedule": 1
     }
   },
-  "logicengines": {
-    "le1": {
-      "module": "decisionengine.framework.logicengine.LogicEngine",
-      "parameters": {
-        "facts": {
-          "pass_all": "True"
-        },
-        "rules": {
-          "r1": {
-            "expression": "pass_all",
-            "actions": ["publisher1"]
-          }
-        }
-      }
-    }
-  },
   "publishers": {
     "publisher1": {
       "module": "decisionengine.framework.tests.PublisherNOP",

--- a/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
@@ -9,7 +9,7 @@ import decisionengine.framework.config.policies as policies
 
 from decisionengine.framework.config.ValidConfig import ValidConfig
 from decisionengine.framework.dataspace import datablock
-from decisionengine.framework.taskmanager.TaskManager import State, TaskManager
+from decisionengine.framework.taskmanager.TaskManager import Channel, State, TaskManager
 from decisionengine.framework.taskmanager.tests.fixtures import (  # noqa: F401
     DATABASES_TO_TEST,
     dataspace,
@@ -122,3 +122,8 @@ def test_no_data_to_transform(global_config):
             task_manager.run_publishers("action", "facts")
             task_manager.run_logic_engine()
             task_manager.take_offline(None)
+
+
+def test_multiple_logic_engines_not_supported():
+    with pytest.raises(RuntimeError, match="Cannot support more than one logic engine per channel."):
+        Channel(get_channel_config("multiple_logic_engines"), "multiple_logic_engines")

--- a/src/decisionengine/framework/tests/etc/decisionengine/config.d/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/config.d/test_channel.jsonnet
@@ -13,22 +13,6 @@
       "schedule": 1
     }
   },
-  "logicengines": {
-    "le1": {
-      "module": "decisionengine.framework.logicengine.LogicEngine",
-      "parameters": {
-        "facts": {
-          "pass_all": "True"
-        },
-        "rules": {
-          "r1": {
-            "expression": "pass_all",
-            "actions": ["publisher1"]
-          }
-        }
-      }
-    }
-  },
   "publishers": {
     "publisher1": {
       "module": "decisionengine.framework.tests.PublisherNOP",

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_bad_source.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_bad_source.jsonnet
@@ -7,6 +7,5 @@
     }
   },
   "transforms": {},
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_bad_transform.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_bad_transform.jsonnet
@@ -6,6 +6,5 @@
       "parameters": {}
     }
   },
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_missing_product.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_missing_product.jsonnet
@@ -6,6 +6,5 @@
       "parameters": {}
     }
   },
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_product_circularity.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_product_circularity.jsonnet
@@ -10,6 +10,5 @@
       "parameters": {}
     }
   },
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-error-on-acquire/error_on_acquire.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-error-on-acquire/error_on_acquire.jsonnet
@@ -12,6 +12,5 @@
     }
   },
   "transforms": {},
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_channel.jsonnet
@@ -19,6 +19,5 @@
     }
   },
 
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_source_proxy.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_source_proxy.jsonnet
@@ -20,6 +20,5 @@
      }
    },
 
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_channel.jsonnet
@@ -17,6 +17,5 @@
     }
   },
 
-  "logicengines": {},
   "publishers": {}
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_source_proxy.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_source_proxy.jsonnet
@@ -20,6 +20,5 @@
      }
    },
 
-  "logicengines": {},
   "publishers": {}
 }


### PR DESCRIPTION
To simplify user configurations, this PR enables the unconditional execution of publishers whenever no `logicengines` block has been specified.  The following configuration:

```.jsonnet
{
  sources: {...},
  transforms: {...},
  logicengines: {
    logicengine1: {
      module: "decisionengine.framework.logicengine.LogicEngine",
      parameters: {
        facts: {}
        rules: {
          r1: {
            expression: "True",
            actions: ["pub1", "pub2"]
          }
        }
      }
    }
  },
  publishers: {
    pub1: {...},
    pub2: {...}
  }
}
```

can be replaced with:

```jsonnet
{
  sources: {...},
  transforms: {...},
  publishers: {
    pub1: {...},
    pub2: {...}
  }
}
```