### PR TITLE
Possible logging simplification

### DIFF
--- a/src/decisionengine/framework/logicengine/LogicEngine.py
+++ b/src/decisionengine/framework/logicengine/LogicEngine.py
@@ -1,11 +1,9 @@
 from itertools import chain
 
 import pandas
-import structlog
 
 from decisionengine.framework.logicengine.BooleanExpression import BooleanExpression
 from decisionengine.framework.logicengine.RuleEngine import RuleEngine
-from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
 from decisionengine.framework.modules.Module import Module
 
 
@@ -27,8 +25,6 @@ def passthrough_configuration(publisher_names):
 class LogicEngine(Module):
     def __init__(self, cfg):
         super().__init__(cfg)
-        self.logger = structlog.getLogger(CHANNELLOGGERNAME)
-        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], channel=self.channel_name)
         self.facts = {name: BooleanExpression(expr) for name, expr in cfg["facts"].items()}
         self.rule_engine = RuleEngine(cfg["facts"].keys(), cfg["rules"])
 

--- a/src/decisionengine/framework/modules/Module.py
+++ b/src/decisionengine/framework/modules/Module.py
@@ -18,7 +18,7 @@ class Module:
         self.channel_name = set_of_parameters["channel_name"]
 
         self.logger = structlog.getLogger(CHANNELLOGGERNAME)
-        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], channel=self.channel_name)
+        self.logger = self.logger.bind(class_name=type(self).__name__, channel=self.channel_name)
 
     def get_parameters(self):
         return self.parameters

--- a/src/decisionengine/framework/modules/Publisher.py
+++ b/src/decisionengine/framework/modules/Publisher.py
@@ -13,7 +13,6 @@ class Publisher(Module):
 
     def __init__(self, set_of_parameters):
         super().__init__(set_of_parameters)
-        self.logger.bind(class_module=__name__.split(".")[-1])
 
     def publish(self, data_block=None):
         pass

--- a/src/decisionengine/framework/modules/Source.py
+++ b/src/decisionengine/framework/modules/Source.py
@@ -14,7 +14,6 @@ class Source(Module):
 
     def __init__(self, set_of_parameters):
         super().__init__(set_of_parameters)
-        self.logger.bind(class_module=__name__.split(".")[-1])
 
     # acquire: The action function for a source. Will
     # retrieve data from external sources and issue a

--- a/src/decisionengine/framework/modules/SourceProxy.py
+++ b/src/decisionengine/framework/modules/SourceProxy.py
@@ -34,7 +34,6 @@ class SourceProxy(Source.Source):
         self.data_keys = translate_all(config["Dataproducts"])
         self.retries = config.get("retries", RETRIES)
         self.retry_to = config.get("retry_timeout", RETRY_TO)
-        self.logger = self.logger.bind(class_module=__name__.split(".")[-1])
 
         # Hack - it is possible for a subclass to declare @produces,
         #        in which case, we do not want to override that.

--- a/src/decisionengine/framework/modules/Transform.py
+++ b/src/decisionengine/framework/modules/Transform.py
@@ -15,7 +15,6 @@ class Transform(Module):
     def __init__(self, set_of_parameters):
         super().__init__(set_of_parameters)
         self.name_list = []
-        self.logger.bind(class_module=__name__.split(".")[-1])
 
     """
     decide: The action function for a Transform. Will


### PR DESCRIPTION
The motivation for this is that in every module that wants to use framework-supported logging, that module must provide the following boilerplate in the module constructor

```python
self.logger = self.logger.bind(class_module=__name__.split(".")[-1], )
```

This PR removes this boilerplate by adding the following in **only** the framework's `Module` constructor:

```python
self.logger = self.logger.bind(class_name=type(self).__name__, ...)
```

In many cases, the name of the Python module and the name of the class are the same, so this would not change those cases.  This works because the `self` argument is the type of the most derived class that invokes `super().__init__(...)` in its own module constructor.

**Question**: Is this simplification desired despite the slight change in behavior? 