### PR TITLE
Improve parameter and variable names

### DIFF
--- a/src/decisionengine/framework/managers/ChannelManager.py
+++ b/src/decisionengine/framework/managers/ChannelManager.py
@@ -14,7 +14,7 @@ from decisionengine.framework.managers.SourceSubscriptionManager import Subscrip
 from decisionengine.framework.modules.logging_configDict import LOGGERNAME
 from decisionengine.framework.taskmanager.ProcessingState import State
 
-_TRANSFORMS_TO = 300  # 5 minutes
+_MAX_WAIT = 300  # 5 minutes
 _DEFAULT_SCHEDULE = 300  # ""
 
 delogger = structlog.getLogger(LOGGERNAME)
@@ -321,7 +321,7 @@ class ChannelManager(ComponentManager):
         :type data_block: :obj:`~datablock.DataBlock`
         :arg data_block: data block
         """
-        data_to = self.channel.channel_manager.get("data_TO", _TRANSFORMS_TO)
+        max_wait = self.channel.channel_manager.get("data_TO", _MAX_WAIT)
         consume_keys = transform.runner.consumes()
 
         delogger.info(
@@ -350,8 +350,8 @@ class ChannelManager(ComponentManager):
                 delogger.info(f"received stop_running signal for {transform.name}")
                 break
             loop_counter += 1
-            if loop_counter == data_to:
-                delogger.info(f"transform {transform.name} did not get consumes data" f"in {data_to} seconds. Exiting")
+            if loop_counter == max_wait:
+                delogger.info(f"transform {transform.name} did not get consumes data" f"in {max_wait} seconds. Exiting")
                 break
         transform.data_updated.set()
 

--- a/src/decisionengine/framework/managers/SourceManager.py
+++ b/src/decisionengine/framework/managers/SourceManager.py
@@ -11,8 +11,7 @@ from decisionengine.framework.managers.ComponentManager import ComponentManager,
 from decisionengine.framework.modules.logging_configDict import LOGGERNAME
 from decisionengine.framework.taskmanager.ProcessingState import State
 
-_TRANSFORMS_TO = 300  # 5 minutes
-_DEFAULT_SCHEDULE = 300  # ""
+_DEFAULT_SCHEDULE = 300  # 5 minutes
 
 delogger = structlog.getLogger(LOGGERNAME)
 delogger = delogger.bind(module=__name__.split(".")[-1])

--- a/src/decisionengine/framework/modules/SourceProxy.py
+++ b/src/decisionengine/framework/modules/SourceProxy.py
@@ -14,16 +14,16 @@ from decisionengine.framework.modules import Source
 from decisionengine.framework.modules.Source import Parameter
 from decisionengine.framework.modules.translate_product_name import translate_all
 
-RETRIES = 10
-RETRY_TO = 60
+MAX_ATTEMPTS = 10
+RETRY_INTERVAL = 60
 must_have = ("source_channel", "Dataproducts")
 
 
 @Source.supports_config(
     Parameter("source_channel", type=str, comment="Channel from which to retrieve data products."),
     Parameter("Dataproducts", type=list, comment="List of data products to retrieve."),
-    Parameter("retries", default=RETRIES, comment="Number of attempts allowed to fetch products."),
-    Parameter("retry_timeout", default=RETRY_TO, comment="Number of seconds to wait between retries."),
+    Parameter("max_attempts", default=MAX_ATTEMPTS, comment="Number of attempts allowed to fetch products."),
+    Parameter("retry_interval", default=RETRY_INTERVAL, comment="Number of seconds to wait between retries."),
 )
 class SourceProxy(Source.Source):
     def __init__(self, config):
@@ -32,8 +32,8 @@ class SourceProxy(Source.Source):
             raise RuntimeError(f"SourceProxy misconfigured. Must have {must_have} defined")
         self.source_channel = config["source_channel"]
         self.data_keys = translate_all(config["Dataproducts"])
-        self.retries = config.get("retries", RETRIES)
-        self.retry_to = config.get("retry_timeout", RETRY_TO)
+        self.max_attempts = config.get("max_attempts", MAX_ATTEMPTS)
+        self.retry_interval = config.get("retry_interval", RETRY_INTERVAL)
 
         # Hack - it is possible for a subclass to declare @produces,
         #        in which case, we do not want to override that.
@@ -60,7 +60,7 @@ class SourceProxy(Source.Source):
         Overrides Source class method
         """
         data_block = None
-        for _ in range(self.retries):
+        for _ in range(self.max_attempts):
             try:
                 tm = self.dataspace.get_taskmanager(self.source_channel)
                 self.logger.debug("task manager %s", tm)
@@ -80,14 +80,14 @@ class SourceProxy(Source.Source):
             except Exception as detail:
                 self.logger.error("Error getting datablock for %s %s", self.source_channel, detail)
 
-            time.sleep(self.retry_to)
+            time.sleep(self.retry_interval)
 
         if not data_block:
             raise RuntimeError("Could not get data.")
 
         rc = {}
         filled_keys = []
-        for _ in range(self.retries):
+        for _ in range(self.max_attempts):
             if len(filled_keys) != len(self.data_keys):
                 for k_in, k_out in self.data_keys.items():
                     if k_in not in filled_keys:
@@ -99,7 +99,7 @@ class SourceProxy(Source.Source):
             if len(filled_keys) == len(self.data_keys):
                 break
             # expected data is not ready yet
-            time.sleep(self.retry_to)
+            time.sleep(self.retry_interval)
 
         if len(filled_keys) != len(self.data_keys):
             raise RuntimeError(f"Could not get all data. Expected {self.data_keys} Filled {filled_keys}")

--- a/src/decisionengine/framework/taskmanager/TaskManager.py
+++ b/src/decisionengine/framework/taskmanager/TaskManager.py
@@ -20,8 +20,7 @@ from decisionengine.framework.taskmanager.module_graph import ensure_no_circular
 from decisionengine.framework.taskmanager.ProcessingState import ProcessingState, State
 from decisionengine.framework.util.subclasses import all_subclasses
 
-_TRANSFORMS_TO = 300  # 5 minutes
-_DEFAULT_SCHEDULE = 300  # ""
+_DEFAULT_SCHEDULE = 300  # 5 minutes
 
 delogger = structlog.getLogger(LOGGERNAME)
 delogger = delogger.bind(module=__name__.split(".")[-1], channel=DELOGGER_CHANNEL_NAME)

--- a/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
@@ -10,7 +10,6 @@
     "transform1": {
       "module": "decisionengine.framework.tests.TransformNOP",
       "parameters": {},
-      "schedule": 1
     }
   },
   "publishers": {

--- a/src/decisionengine/framework/taskmanager/tests/channels/test_channel2.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/test_channel2.jsonnet
@@ -11,7 +11,6 @@
     "transform1": {
       "module": "decisionengine.framework.tests.TransformNOP",
       "parameters": {},
-      "schedule": 1
     }
   },
   "publishers": {

--- a/src/decisionengine/framework/tests/etc/decisionengine/config.d/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/config.d/test_channel.jsonnet
@@ -10,7 +10,6 @@
     "transform1": {
       "module": "decisionengine.framework.tests.TransformNOP",
       "parameters": {},
-      "schedule": 1
     }
   },
   "publishers": {

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_channel.jsonnet
@@ -2,7 +2,6 @@
   "sources": {
     "source1": {
       "module": "decisionengine.framework.tests.SourceNOP",
-      "name": "SourceNOP",
       "parameters": {
         "sleep_for": 5
       },
@@ -13,9 +12,7 @@
   "transforms": {
     "transform1": {
       "module": "decisionengine.framework.tests.TransformNOP",
-      "name": "TransformNOP",
       "parameters": {},
-      "schedule": 1
     }
   },
 

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_source_proxy.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_source_proxy.jsonnet
@@ -5,8 +5,7 @@
       "parameters": {
         "source_channel": "test_channel",
         "Dataproducts": ["foo"],
-        "retries": 1,
-        "retry_to": 0
+        "max_attempts": 1,
       },
       "schedule": 1
      }
@@ -15,8 +14,7 @@
    "transforms": {
      "transform1": {
        "module": "decisionengine.framework.tests.TransformNOP",
-       "parameters": {},
-       "schedule": 1
+       "parameters": {}
      }
    },
 

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_channel.jsonnet
@@ -13,7 +13,6 @@
     "transform1": {
       "module": "decisionengine.framework.tests.TransformNOP",
       "parameters": {},
-      "schedule": 1
     }
   },
 

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_source_proxy.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_source_proxy.jsonnet
@@ -5,8 +5,7 @@
       "parameters": {
         "source_channel": "test_channel",
         "Dataproducts": ["foo"],
-        "retries": 1,
-        "retry_to": 0
+        "max_attempts": 1,
       },
       "schedule": 1
      }
@@ -16,7 +15,6 @@
      "transform1": {
        "module": "decisionengine.framework.tests.TransformNOP",
        "parameters": {},
-       "schedule": 1
      }
    },
 


### PR DESCRIPTION
This fix partly addresses https://github.com/HEPCloud/decisionengine_modules/issues/253.

- Removing the `schedule` parameter from transform configurations, which no longer require it.
- Making the following parameter changes for the SourceProxy:
    - `retries -> max_attempts`
    - `retry_timeout -> retry_interval`