### PR TITLE
Increase coverage of testing TaskManager

### DIFF
--- a/src/decisionengine/framework/tests/SourceNoData.py
+++ b/src/decisionengine/framework/tests/SourceNoData.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+from decisionengine.framework.modules import Source
+
+
+@Source.produces(foo=pd.DataFrame)
+class SourceNoData(Source.Source):
+    def __init__(self, config):
+        super().__init__(config)
+
+    def acquire(self):
+        return None
+
+
+Source.describe(SourceNoData)

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-source-no-data/test-source-no-data.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-source-no-data/test-source-no-data.jsonnet
@@ -1,0 +1,11 @@
+{
+  "sources": {
+    "source1": {
+      "module": "decisionengine.framework.tests.SourceNoData",
+      "parameters": {},
+      "schedule": 0
+    }
+  },
+  "transforms": {},
+  "publishers": {}
+}

--- a/src/decisionengine/framework/tests/test_source_no_data.py
+++ b/src/decisionengine/framework/tests/test_source_no_data.py
@@ -1,0 +1,27 @@
+import os
+
+import pytest
+
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    DEServer,
+    PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
+    PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_TEMPFILE_SQLITE,
+    TEST_CONFIG_PATH,
+)
+
+_channel_config_dir = os.path.join(TEST_CONFIG_PATH, "test-source-no-data")  # noqa: F405
+deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=_channel_config_dir)  # pylint: disable=invalid-name
+
+
+@pytest.mark.usefixtures("deserver")
+def test_source_only_channel(deserver):
+    # The following 'block-while' call will be unnecessary once the
+    # deserver fixture can reliably block when no workers have yet
+    # been constructed.
+    deserver.de_client_run_cli("--block-while", "BOOT")
+    output = deserver.de_client_run_cli("--status")
+    assert "test-source-no-data" in output
+    assert "state = OFFLINE" in output


### PR DESCRIPTION
This should help the TaksManager check single run instances
and instances where no data is returned.