### PR TITLE
Add error for running server as root

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,15 @@
 #  but setuptools must first gain support for parsing that
 
 import importlib
+import os
 import pathlib
 import site
 import sys
 
 from setuptools import find_packages, setup
+
+if os.geteuid() == 0:
+    raise RuntimeError("You should not run this as root, make a wheel or rpm as not root")
 
 here = pathlib.Path(__file__).parent.resolve()
 

--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -585,4 +585,7 @@ def main(args=None):
 
 
 if __name__ == "__main__":
+    if os.geteuid() == 0:
+        raise RuntimeError("You cannot run this as root")
+
     main()


### PR DESCRIPTION
The DE server should never be run as root.  There are a ton of good reasons to forbid this.