### PR TITLE
Remove now-unnecessary blocking

### DIFF
--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -22,7 +22,6 @@ from decisionengine.framework.engine.DecisionEngine import (
     _start_de_server,
     parse_program_options,
 )
-from decisionengine.framework.taskmanager.TaskManager import State
 from decisionengine.framework.util.sockets import get_random_port
 
 __all__ = [
@@ -178,18 +177,6 @@ def DEServer(
         logger.debug(
             f"DE Fixture: Done waiting for startup state: is_set={server_proc.de_server.startup_complete.is_set()}"
         )
-
-        # The following block only works if there are
-        # active workers; if it is called before any workers
-        # exist, then it will return and not block as requested.
-        # so long as your config contains at least one worker,
-        # this will work as you'd expect.
-        #
-        # Some unit tests will hang forver under some unknown conditions
-        # if there is no timeout.  30 seconds should easily cover any working
-        # tests and not block forever on any non-working ones.
-        logger.debug("DE Fixture: Waiting on channels to start, timeout=30")
-        server_proc.de_server.block_while(State.BOOT, timeout=30)
 
         if not server_proc.is_alive():
             raise RuntimeError("Could not start PrivateDEServer fixture")

--- a/src/decisionengine/framework/tests/test_error_on_acquire.py
+++ b/src/decisionengine/framework/tests/test_error_on_acquire.py
@@ -18,9 +18,5 @@ deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=_channel_confi
 
 @pytest.mark.usefixtures("deserver")
 def test_source_only_channel(deserver):
-    # The following 'block-while' call will be unnecessary once the
-    # deserver fixture can reliably block when no workers have yet
-    # been constructed.
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--stop-channel", "error_on_acquire")
     assert output == "Channel error_on_acquire stopped cleanly."

--- a/src/decisionengine/framework/tests/test_query_tool_server.py
+++ b/src/decisionengine/framework/tests/test_query_tool_server.py
@@ -38,7 +38,6 @@ DEFAULT_OUTPUT = (
 @pytest.mark.usefixtures("deserver")
 def test_query_tool_default(deserver):
     # Test default output
-    deserver.de_client_run_cli("--block-while", "BOOT"),
     output = deserver.de_query_tool_run_cli("foo")
     assert output.startswith(DEFAULT_OUTPUT)
 
@@ -46,7 +45,6 @@ def test_query_tool_default(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_query_tool_csv(deserver):
     # Test csv output
-    deserver.de_client_run_cli("--block-while", "BOOT"),
     output = deserver.de_query_tool_run_cli("foo", "--format=csv")
     assert output.startswith(
         "Product foo:  Found in channel test_channel\n"
@@ -63,7 +61,6 @@ def test_query_tool_csv(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_query_tool_json(deserver):
     # Test json output
-    deserver.de_client_run_cli("--block-while", "BOOT"),
     output = deserver.de_query_tool_run_cli("foo", "--format=json")
     assert output.startswith("Product foo:  Found in channel test_channel\n")
 
@@ -96,8 +93,6 @@ def test_query_tool_json(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_query_tool_since(deserver):
     recently = datetime.datetime.now() - datetime.timedelta(minutes=3)
-    # give the channel a moment to complete setup
-    deserver.de_client_run_cli("--block-while", "BOOT"),
     output = deserver.de_query_tool_run_cli("foo", f'--since="{recently.strftime("%Y-%m-%d %H:%M:%S")}"')
     assert output.startswith(DEFAULT_OUTPUT)
 
@@ -105,6 +100,5 @@ def test_query_tool_since(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_query_tool_invalid_product(deserver):
     # Test invalid product output
-    deserver.de_client_run_cli("--block-while", "BOOT"),
     output = deserver.de_query_tool_run_cli("not_foo")
     assert output == "Product not_foo: Not produced by any module\n"

--- a/src/decisionengine/framework/tests/test_restart_channel.py
+++ b/src/decisionengine/framework/tests/test_restart_channel.py
@@ -10,7 +10,6 @@ from decisionengine.framework.engine.DecisionEngine import (
     _get_de_conf_manager,
     parse_program_options,
 )
-from decisionengine.framework.taskmanager.TaskManager import State
 from decisionengine.framework.util.sockets import get_random_port
 
 _this_dir = pathlib.Path(__file__).parent.resolve()
@@ -27,7 +26,6 @@ def deserver_mock_data_block(mock_data_block):  # noqa: F811
     )
     server = _create_de_server(global_config, channel_config_handler)
     server.start_channels()
-    server.block_while(State.BOOT)
     yield server
     server.stop_channels()
 

--- a/src/decisionengine/framework/tests/test_sample_config.py
+++ b/src/decisionengine/framework/tests/test_sample_config.py
@@ -28,7 +28,6 @@ _STOPPED_CHANNEL_OPTS = [
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_de_server_status(deserver):
     """Verify channel enters stable state"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--status")
     assert "state = STEADY" in output
 
@@ -37,7 +36,6 @@ def test_client_can_get_de_server_status(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_wait_timeout_works(deserver):
     """Verify channel enters stable state and timeout works too"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     deserver.de_client_run_cli("--block-while", "STABLE", "--timeout", "3")
     output = deserver.de_client_run_cli("--status")
     assert "state = STEADY" in output
@@ -46,7 +44,6 @@ def test_client_wait_timeout_works(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_stop_server(deserver):
     """Verify de-client can run --stop"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--status")
     assert "state = STEADY" in output
     output = deserver.de_client_run_cli("--stop")
@@ -56,7 +53,6 @@ def test_client_can_stop_server(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_products(deserver):
     """Verify client can get channel products"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--print-products")
     assert "source1" in output
     assert "transform1" in output
@@ -65,7 +61,6 @@ def test_client_can_get_products(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_products_no_channels(deserver):
     """Verify client can get channel products even when none are run"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--stop-channels")
     output = deserver.de_client_run_cli("--print-products")
     assert "No channels are currently active." in output
@@ -74,7 +69,6 @@ def test_client_can_get_products_no_channels(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_cannot_double_start(deserver):
     """Verify client cannot double start channels"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--show-config")
     assert "decisionengine.framework.tests.SourceNOP" in output
     assert "decisionengine.framework.tests.TransformNOP" in output
@@ -85,7 +79,6 @@ def test_client_cannot_double_start(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_stop_channels(deserver):
     """Verify client can stop channels"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--show-config")
     assert "decisionengine.framework.tests.SourceNOP" in output
     assert "decisionengine.framework.tests.TransformNOP" in output
@@ -97,7 +90,6 @@ def test_client_can_stop_channels(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_stop_one_channel(deserver):
     """Verify client can stop a single channel"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--stop-channel", "test_channel")
     assert "Channel test_channel stopped cleanly." in output
     output = deserver.de_client_run_cli("--status")
@@ -108,7 +100,6 @@ def test_client_can_stop_one_channel(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_start_one_channel(deserver):
     """Verify client can start a single channel"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--stop-channel", "test_channel")
     assert "Channel test_channel stopped cleanly." in output
     output = deserver.de_client_run_cli("--status")
@@ -121,7 +112,6 @@ def test_client_can_start_one_channel(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_start_all_channel(deserver):
     """Verify client can start all channel"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--stop-channel", "test_channel")
     assert "Channel test_channel stopped cleanly." in output
     output = deserver.de_client_run_cli("--status")
@@ -134,7 +124,6 @@ def test_client_can_start_all_channel(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_kill_one_channel(deserver):
     """Verify client can kill a single channel"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--status")
     assert "test_channel" in output
     assert "state = STEADY" in output
@@ -148,7 +137,6 @@ def test_client_can_kill_one_channel(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_kill_one_channel_force(deserver):
     """Verify client can kill a single channel with force"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--status")
     assert "test_channel" in output
     assert "state = STEADY" in output
@@ -162,7 +150,6 @@ def test_client_can_kill_one_channel_force(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_kill_one_channel_timeout(deserver):
     """Verify client can kill a single channel with timeout"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--status")
     assert "test_channel" in output
     assert "state = STEADY" in output
@@ -175,7 +162,6 @@ def test_client_can_kill_one_channel_timeout(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_de_server_show_config(deserver):
     """Verify config has expected items"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--show-config")
     assert "decisionengine.framework.tests.SourceNOP" in output
     assert "decisionengine.framework.tests.TransformNOP" in output
@@ -184,7 +170,6 @@ def test_client_can_get_de_server_show_config(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_de_server_channel_config(deserver):
     """Verify config has expected items"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--show-channel-config", "test_channel")
     assert "test_channel" in output
     assert "decisionengine.framework.tests.SourceNOP" in output
@@ -194,7 +179,6 @@ def test_client_can_get_de_server_channel_config(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_get_non_real_channel(deserver):
     """Verify config for missing channel does what it should"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--show-channel-config", "ISNT_REAL")
     assert "There is no active channel named ISNT_REAL." in output
 
@@ -202,7 +186,6 @@ def test_client_get_non_real_channel(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_start_non_real_channel(deserver):
     """Verify start for missing channel does what it should"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--start-channel", "ISNT_REAL")
     assert "Failed to open channel configuration file" in output
 
@@ -210,7 +193,6 @@ def test_client_start_non_real_channel(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_stop_non_real_channel(deserver):
     """Verify stop for missing channel does what it should"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--stop-channel", "ISNT_REAL")
     assert "No channel found with the name ISNT_REAL." in output
 
@@ -218,7 +200,6 @@ def test_client_stop_non_real_channel(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_de_server_show_logger_level(deserver):
     """Verify can fetch log level"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--print-engine-loglevel")
     assert output in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
@@ -226,7 +207,6 @@ def test_client_can_get_de_server_show_logger_level(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_de_server_channel_log_level(deserver):
     """Verify can fetch log level for a channel"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--get-channel-loglevel", "test_channel")
     assert output in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
@@ -234,7 +214,6 @@ def test_client_can_get_de_server_channel_log_level(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_set_de_server_channel_log_level(deserver):
     """Verify set log level for a channel"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--set-channel-loglevel", "test_channel", "DEBUG")
     output = deserver.de_client_run_cli("--get-channel-loglevel", "test_channel")
     assert output == "DEBUG"
@@ -243,7 +222,6 @@ def test_client_can_set_de_server_channel_log_level(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_double_set_de_server_channel_log_level(deserver):
     """Verify set log level to current level isn't an error"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--set-channel-loglevel", "test_channel", "DEBUG")
     output = deserver.de_client_run_cli("--get-channel-loglevel", "test_channel")
     assert output == "DEBUG"
@@ -255,7 +233,6 @@ def test_client_can_double_set_de_server_channel_log_level(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_get_channel_log_fails_cleanly(deserver):
     """Verify graceful fail on bogus channel"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--get-channel-loglevel", "ISNT_REAL")
     assert output == "No channel found with the name ISNT_REAL."
 
@@ -263,6 +240,5 @@ def test_client_get_channel_log_fails_cleanly(deserver):
 @pytest.mark.usefixtures("deserver")
 def test_client_set_channel_log_fails_cleanly(deserver):
     """Verify graceful fail on bogus channel"""
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--set-channel-loglevel", "ISNT_REAL", "DEBUG")
     assert output == "No channel found with the name ISNT_REAL."

--- a/src/decisionengine/framework/tests/test_source_proxy.py
+++ b/src/decisionengine/framework/tests/test_source_proxy.py
@@ -23,10 +23,6 @@ deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=_channel_confi
 
 @pytest.mark.usefixtures("deserver")
 def test_working_source_proxy(deserver):
-    # The following 'block-while' call be unnecessary once the
-    # deserver fixture can reliably block when no workers have yet
-    # been constructed.
-    deserver.de_client_run_cli("--block-while", "BOOT")
     output = deserver.de_client_run_cli("--status")
     assert re.search("test_source_proxy.*state = STEADY", output, re.DOTALL)
     deserver.de_client_run_cli("--stop-channel", "test_source_proxy")
@@ -42,10 +38,6 @@ deserver_fail = DEServer(
 
 @pytest.mark.usefixtures("deserver_fail")
 def test_stop_failing_source_proxy(deserver_fail):
-    # The following 'block-while' call be unnecessary once the
-    # deserver fixture can reliably block when no workers have yet
-    # been constructed.
-    deserver_fail.de_client_run_cli("--block-while", "BOOT")
     output = deserver_fail.de_client_run_cli("--status")
     assert re.search("test_source_proxy.*state = OFFLINE", output, re.DOTALL)
     deserver_fail.de_client_run_cli("--stop-channel", "test_source_proxy")

--- a/src/decisionengine/framework/tests/test_start_with_bad_channels.py
+++ b/src/decisionengine/framework/tests/test_start_with_bad_channels.py
@@ -47,7 +47,6 @@ def _expected_circularity(test_str):
 @pytest.mark.usefixtures("deserver")
 def test_client_can_get_products_no_channels(deserver, caplog):
     """Verify client can get channel products even when none are run"""
-    deserver.de_client_run_cli("--block-while", "BOOT"),
     output = deserver.de_client_run_cli("--print-products")
     assert "No channels are currently active." in output
 

--- a/src/decisionengine/framework/tests/test_start_with_no_channels.py
+++ b/src/decisionengine/framework/tests/test_start_with_no_channels.py
@@ -14,7 +14,6 @@ from decisionengine.framework.engine.DecisionEngine import (
     _get_de_conf_manager,
     parse_program_options,
 )
-from decisionengine.framework.taskmanager.TaskManager import State
 from decisionengine.framework.tests.fixtures import TEST_CHANNEL_CONFIG_PATH, TEST_CONFIG_PATH
 from decisionengine.framework.util.sockets import get_random_port
 
@@ -30,7 +29,6 @@ def deserver_mock_data_block(mock_data_block):  # noqa: F811
     )
     server = _create_de_server(global_config, channel_config_handler)
     server.start_channels()
-    server.block_while(State.BOOT)
     yield server
     server.stop_channels()
 
@@ -54,7 +52,6 @@ def test_start_from_nothing(deserver_mock_data_block):
 
     # Activate channel and check for steady state
     deserver.rpc_start_channel("test_channel")
-    deserver.block_while(State.BOOT)
     output = deserver.rpc_status()
     assert re.search("test_channel.*state = STEADY", output)
 
@@ -68,7 +65,6 @@ def test_start_from_nothing(deserver_mock_data_block):
 
     # Bring channel back online
     deserver.rpc_start_channel("test_channel")
-    deserver.block_while(State.BOOT)
     output = deserver.rpc_status()
     assert re.search("test_channel.*state = STEADY", output)
 


### PR DESCRIPTION
Enough adjustments have been made to the DE server that it is no longer necessary to explicitly block for each unit tests. 