### PR TITLE
Automatically format jsonnet files with jsonnetfmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,17 @@ repos:
         additional_dependencies:
           - "prettier"
           - "prettier-plugin-toml@0.3.1"
+  - repo: https://github.com/google/go-jsonnet.git
+    rev: 2f2f6d664f06d064c4b3525ea34a789c1ac95cda
+    hooks:
+      - id: jsonnet-format
+        exclude: "empty.*|invalid.jsonnet"
+        args:
+          - "--in-place"
+          - "--string-style"
+          - "d"
+          - "--comment-style"
+          - "s"
   - repo: "https://github.com/asottile/pyupgrade"
     rev: v2.29.0
     hooks:

--- a/config/decision_engine.jsonnet
+++ b/config/decision_engine.jsonnet
@@ -1,29 +1,29 @@
 {
-    "logger": {
-	"log_file": "/var/log/decisionengine/decision_engine_log",
-	"max_file_size": 200000000,
-	"max_backup_count": 6,
-	"log_level": "DEBUG",
-        "global_channel_log_level": "DEBUG"
-	},
+  logger: {
+    log_file: "/var/log/decisionengine/decision_engine_log",
+    max_file_size: 200000000,
+    max_backup_count: 6,
+    log_level: "DEBUG",
+    global_channel_log_level: "DEBUG",
+  },
 
-    "channels": "/etc/decisionengine/config.d",
+  channels: "/etc/decisionengine/config.d",
 
-    "dataspace": {
-	"reaper_start_delay_seconds": 1818,
-	"retention_interval_in_days": 365,
-	"datasource": {
-	    "module": "decisionengine.framework.dataspace.datasources.postgresql",
-	    "name": "Postgresql",
-	    "config": {
-		"user": "postgres",
-		"blocking": true,
-		"host": "localhost",
-		"port": 5432,
-		"database": "decisionengine",
-		"maxconnections": 100,
-		"maxcached": 10
-		}
-	    }
-	}
+  dataspace: {
+    reaper_start_delay_seconds: 1818,
+    retention_interval_in_days: 365,
+    datasource: {
+      module: "decisionengine.framework.dataspace.datasources.postgresql",
+      name: "Postgresql",
+      config: {
+        user: "postgres",
+        blocking: true,
+        host: "localhost",
+        port: 5432,
+        database: "decisionengine",
+        maxconnections: 100,
+        maxcached: 10,
+      },
+    },
+  },
 }

--- a/src/decisionengine/framework/config/tests/channels/invalid_modules_list/invalid_modules_list.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/invalid_modules_list/invalid_modules_list.jsonnet
@@ -1,5 +1,5 @@
 {
-  "sources": [],
-  "transforms": {},
-  "publishers": {}
+  sources: [],
+  transforms: {},
+  publishers: {},
 }

--- a/src/decisionengine/framework/config/tests/channels/invalid_modules_no_keys/invalid_modules_no_keys.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/invalid_modules_no_keys/invalid_modules_no_keys.jsonnet
@@ -1,5 +1,5 @@
 {
-  "sources": {"test": ""},
-  "transforms": {},
-  "publishers": {}
+  sources: { test: "" },
+  transforms: {},
+  publishers: {},
 }

--- a/src/decisionengine/framework/config/tests/channels/invalid_modules_string/invalid_modules_string.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/invalid_modules_string/invalid_modules_string.jsonnet
@@ -1,5 +1,5 @@
 {
-  "sources": "",
-  "transforms": {},
-  "publishers": {}
+  sources: "",
+  transforms: {},
+  publishers: {},
 }

--- a/src/decisionengine/framework/config/tests/channels/module_missing_all/module_missing_all.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/module_missing_all/module_missing_all.jsonnet
@@ -1,7 +1,7 @@
 {
-  "sources": {
-    "source1": {}
+  sources: {
+    source1: {},
   },
-  "transforms": {},
-  "publishers": {}
+  transforms: {},
+  publishers: {},
 }

--- a/src/decisionengine/framework/config/tests/channels/module_missing_module/module_missing_module.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/module_missing_module/module_missing_module.jsonnet
@@ -1,10 +1,10 @@
 {
-  "sources": {
-    "source1": {
-      "name": "SourceNOP",
-      "parameters": {}
-     }
+  sources: {
+    source1: {
+      name: "SourceNOP",
+      parameters: {},
+    },
   },
-  "transforms": {},
-  "publishers": {}
+  transforms: {},
+  publishers: {},
 }

--- a/src/decisionengine/framework/config/tests/channels/module_missing_parameters/module_missing_parameters.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/module_missing_parameters/module_missing_parameters.jsonnet
@@ -1,10 +1,10 @@
 {
-  "sources": {
-    "source1": {
-      "module": "decisionengine.framework.tests.SourceNOP",
-      "name": "SourceNOP"
-     }
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.SourceNOP",
+      name: "SourceNOP",
+    },
   },
-  "transforms": {},
-  "publishers": {}
+  transforms: {},
+  publishers: {},
 }

--- a/src/decisionengine/framework/config/tests/channels/no_modules/no_modules.jsonnet
+++ b/src/decisionengine/framework/config/tests/channels/no_modules/no_modules.jsonnet
@@ -1,5 +1,5 @@
 {
-  "sources": {},
-  "transforms": {},
-  "publishers": {}
+  sources: {},
+  transforms: {},
+  publishers: {},
 }

--- a/src/decisionengine/framework/config/tests/de/decision_engine.jsonnet
+++ b/src/decisionengine/framework/config/tests/de/decision_engine.jsonnet
@@ -1,8 +1,8 @@
 {
-  "logger": {
-    "log_file": "/dev/null",
-    "max_file_size": 200000000,
-    "max_backup_count": 6,
-    "log_level": "DEBUG"
-  }
+  logger: {
+    log_file: "/dev/null",
+    max_file_size: 200000000,
+    max_backup_count: 6,
+    log_level: "DEBUG",
+  },
 }

--- a/src/decisionengine/framework/config/tests/de/minimal.jsonnet
+++ b/src/decisionengine/framework/config/tests/de/minimal.jsonnet
@@ -1,8 +1,8 @@
 {
-  "logger": {
-    "log_file": "/tmp/de_config_tests/decision_engine_log",
-    "max_file_size": 200 * 1000000,
-    "max_backup_count": 6,
-    "log_level": "DEBUG"
-  }
+  logger: {
+    log_file: "/tmp/de_config_tests/decision_engine_log",
+    max_file_size: 200 * 1000000,
+    max_backup_count: 6,
+    log_level: "DEBUG",
+  },
 }

--- a/src/decisionengine/framework/config/tests/de/minimal_with_address.jsonnet
+++ b/src/decisionengine/framework/config/tests/de/minimal_with_address.jsonnet
@@ -1,9 +1,9 @@
 {
-  "server_address": ["localhost", 0],
-  "logger": {
-    "log_file": "/dev/null",
-    "max_file_size": 200000000,
-    "max_backup_count": 6,
-    "log_level": "DEBUG"
-  }
+  server_address: ["localhost", 0],
+  logger: {
+    log_file: "/dev/null",
+    max_file_size: 200000000,
+    max_backup_count: 6,
+    log_level: "DEBUG",
+  },
 }

--- a/src/decisionengine/framework/config/tests/libsonnet/A1.libsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/A1.libsonnet
@@ -1,11 +1,11 @@
-local default = import 'parameters.libsonnet';
+local default = import "parameters.libsonnet";
 
 {
   sources: {
     s1_a1: default.config,
-    s2_a1: default.config
+    s2_a1: default.config,
   },
   transforms: {
-    t_a1: default.config
-  }
+    t_a1: default.config,
+  },
 }

--- a/src/decisionengine/framework/config/tests/libsonnet/A1_source_proxy.libsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/A1_source_proxy.libsonnet
@@ -1,4 +1,4 @@
-local default = import 'parameters.libsonnet';
+local default = import "parameters.libsonnet";
 
 {
   sources: {
@@ -6,11 +6,11 @@ local default = import 'parameters.libsonnet';
     s2_a1: default.config,
     s3_a1: {
       parameters: {
-        source_channel: "A0"
-      }
-    }
+        source_channel: "A0",
+      },
+    },
   },
   transforms: {
-    t_a1: default.config
-  }
+    t_a1: default.config,
+  },
 }

--- a/src/decisionengine/framework/config/tests/libsonnet/A2.libsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/A2.libsonnet
@@ -1,7 +1,7 @@
-local default = import 'parameters.libsonnet';
+local default = import "parameters.libsonnet";
 
 {
   sources: {
-    s_a2: default.config
-  }
+    s_a2: default.config,
+  },
 }

--- a/src/decisionengine/framework/config/tests/libsonnet/A3.libsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/A3.libsonnet
@@ -1,10 +1,10 @@
-local default = import 'parameters.libsonnet';
+local default = import "parameters.libsonnet";
 
 {
   sources: {
-    s_a3: default.config
+    s_a3: default.config,
   },
   publishers: {
-    p_a3: {}
-  }
+    p_a3: {},
+  },
 }

--- a/src/decisionengine/framework/config/tests/libsonnet/B1_source_proxy.libsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/B1_source_proxy.libsonnet
@@ -1,12 +1,12 @@
-local default = import 'parameters.libsonnet';
+local default = import "parameters.libsonnet";
 
 {
   sources: {
     s_b1: default.config,
     source_proxy: {
       parameters: {
-        source_channel: "B0"
-      }
-    }
-  }
+        source_channel: "B0",
+      },
+    },
+  },
 }

--- a/src/decisionengine/framework/config/tests/libsonnet/B2_source_proxy.libsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/B2_source_proxy.libsonnet
@@ -1,12 +1,12 @@
-local default = import 'parameters.libsonnet';
+local default = import "parameters.libsonnet";
 
 {
   sources: {
     s_b2: default.config,
     source_proxy: {
       parameters: {
-        source_channel: "B0"
-      }
-    }
+        source_channel: "B0",
+      },
+    },
   },
 }

--- a/src/decisionengine/framework/config/tests/libsonnet/allow_duplicate_source_proxy_keys.jsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/allow_duplicate_source_proxy_keys.jsonnet
@@ -1,7 +1,9 @@
-local default = import 'parameters.libsonnet';
-local de_std = import 'de_std.libsonnet';
-local channels = [import 'B1_source_proxy.libsonnet',
-                  import 'B2_source_proxy.libsonnet'];
+local de_std = import "de_std.libsonnet";
+local default = import "parameters.libsonnet";
+local channels = [
+  import "B1_source_proxy.libsonnet",
+  import "B2_source_proxy.libsonnet",
+];
 
 {
   test: {
@@ -11,6 +13,6 @@ local channels = [import 'B1_source_proxy.libsonnet',
     sources: {
       s_b1: default.config,
       s_b2: default.config,
-    }
-  }
+    },
+  },
 }

--- a/src/decisionengine/framework/config/tests/libsonnet/combine_one_level.jsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/combine_one_level.jsonnet
@@ -1,17 +1,17 @@
-local default = import 'parameters.libsonnet';
-local de_std = import 'de_std.libsonnet';
-local channels = [import 'A1.libsonnet', import 'A2.libsonnet', import 'A3.libsonnet'];
+local de_std = import "de_std.libsonnet";
+local default = import "parameters.libsonnet";
+local channels = [import "A1.libsonnet", import "A2.libsonnet", import "A3.libsonnet"];
 
 {
   test: {
-    sources: de_std.sources_from(channels)
+    sources: de_std.sources_from(channels),
   },
   reference: {
     sources: {
       s1_a1: default.config,
       s2_a1: default.config,
       s_a2: default.config,
-      s_a3: default.config
-    }
-  }
+      s_a3: default.config,
+    },
+  },
 }

--- a/src/decisionengine/framework/config/tests/libsonnet/combine_one_level_skip_proxies.jsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/combine_one_level_skip_proxies.jsonnet
@@ -1,17 +1,17 @@
-local default = import 'parameters.libsonnet';
-local de_std = import 'de_std.libsonnet';
-local channels = [import 'A1_source_proxy.libsonnet', import 'A2.libsonnet', import 'A3.libsonnet'];
+local de_std = import "de_std.libsonnet";
+local default = import "parameters.libsonnet";
+local channels = [import "A1_source_proxy.libsonnet", import "A2.libsonnet", import "A3.libsonnet"];
 
 {
   test: {
-    sources: de_std.sources_from(channels)
+    sources: de_std.sources_from(channels),
   },
   reference: {
     sources: {
       s1_a1: default.config,
       s2_a1: default.config,
       s_a2: default.config,
-      s_a3: default.config
-    }
-  }
+      s_a3: default.config,
+    },
+  },
 }

--- a/src/decisionengine/framework/config/tests/libsonnet/error_on_duplicate_keys.jsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/error_on_duplicate_keys.jsonnet
@@ -1,6 +1,6 @@
-local de_std = import 'de_std.libsonnet';
-local channels = [import 'A1.libsonnet', import 'A1.libsonnet'];
+local de_std = import "de_std.libsonnet";
+local channels = [import "A1.libsonnet", import "A1.libsonnet"];
 
 {
-  sources: de_std.sources_from(channels)
+  sources: de_std.sources_from(channels),
 }

--- a/src/decisionengine/framework/config/tests/libsonnet/import_from_jpath.jsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/import_from_jpath.jsonnet
@@ -1,3 +1,3 @@
-local test = import 'from_different_dir.libsonnet';
+local test = import "from_different_dir.libsonnet";
 
 {}

--- a/src/decisionengine/framework/config/tests/libsonnet/parameters.libsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/parameters.libsonnet
@@ -1,5 +1,5 @@
 {
   config: {
-    parameters: {}
-  }
+    parameters: {},
+  },
 }

--- a/src/decisionengine/framework/taskmanager/tests/channels/failing_publisher.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/failing_publisher.jsonnet
@@ -1,38 +1,38 @@
 {
-  "sources": {
-    "source1": {
-      "module": "decisionengine.framework.tests.SourceNOP",
-      "parameters": {},
-      "schedule": 1
-     }
-   },
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.SourceNOP",
+      parameters: {},
+      schedule: 1,
+    },
+  },
 
-  "transforms": {
-    "bar_maker": {
-      "module": "decisionengine.framework.tests.TransformNOP",
-      "parameters": {}
-    }
+  transforms: {
+    bar_maker: {
+      module: "decisionengine.framework.tests.TransformNOP",
+      parameters: {},
+    },
   },
-  "logicengines": {
-    "le": {
-      "module": "decisionengine.framework.logicengine.LogicEngine",
-      "parameters": {
-        "facts": {
-          "pass_all": "fail_on_error(True)"
+  logicengines: {
+    le: {
+      module: "decisionengine.framework.logicengine.LogicEngine",
+      parameters: {
+        facts: {
+          pass_all: "fail_on_error(True)",
         },
-        "rules": {
-          "r1": {
-            "expression": "pass_all",
-            "actions": ["fail"]
-          }
-        }
-      }
-    }
+        rules: {
+          r1: {
+            expression: "pass_all",
+            actions: ["fail"],
+          },
+        },
+      },
+    },
   },
-  "publishers": {
-    "fail": {
-      "module": "decisionengine.framework.tests.FailingPublisher",
-      "parameters": {}
-    }
-  }
+  publishers: {
+    fail: {
+      module: "decisionengine.framework.tests.FailingPublisher",
+      parameters: {},
+    },
+  },
 }

--- a/src/decisionengine/framework/taskmanager/tests/channels/multiple_logic_engines.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/multiple_logic_engines.jsonnet
@@ -3,7 +3,7 @@
   transforms: {},
   logicengines: {
     le1: {},
-    le2: {}
+    le2: {},
   },
-  publishers: {}
+  publishers: {},
 }

--- a/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
@@ -1,21 +1,21 @@
 {
-  "sources": {
-    "source1": {
-      "module": "decisionengine.framework.tests.SourceNOP",
-      "parameters": {},
-      "schedule": 1
-    }
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.SourceNOP",
+      parameters: {},
+      schedule: 1,
+    },
   },
-  "transforms": {
-    "transform1": {
-      "module": "decisionengine.framework.tests.TransformNOP",
-      "parameters": {},
-    }
+  transforms: {
+    transform1: {
+      module: "decisionengine.framework.tests.TransformNOP",
+      parameters: {},
+    },
   },
-  "publishers": {
-    "publisher1": {
-      "module": "decisionengine.framework.tests.PublisherNOP",
-      "parameters": {}
-    }
-  }
+  publishers: {
+    publisher1: {
+      module: "decisionengine.framework.tests.PublisherNOP",
+      parameters: {},
+    },
+  },
 }

--- a/src/decisionengine/framework/taskmanager/tests/channels/test_channel2.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/test_channel2.jsonnet
@@ -1,22 +1,22 @@
 {
-  "channel_name": "name_in_config",
-  "sources": {
-    "source1": {
-      "module": "decisionengine.framework.tests.SourceNOP",
-      "parameters": {},
-      "schedule": 1
-    }
+  channel_name: "name_in_config",
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.SourceNOP",
+      parameters: {},
+      schedule: 1,
+    },
   },
-  "transforms": {
-    "transform1": {
-      "module": "decisionengine.framework.tests.TransformNOP",
-      "parameters": {},
-    }
+  transforms: {
+    transform1: {
+      module: "decisionengine.framework.tests.TransformNOP",
+      parameters: {},
+    },
   },
-  "publishers": {
-    "publisher1": {
-      "module": "decisionengine.framework.tests.PublisherNOP",
-      "parameters": {}
-    }
-  }
+  publishers: {
+    publisher1: {
+      module: "decisionengine.framework.tests.PublisherNOP",
+      parameters: {},
+    },
+  },
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/config.d/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/config.d/test_channel.jsonnet
@@ -1,21 +1,21 @@
 {
-  "sources": {
-    "source1": {
-      "module": "decisionengine.framework.tests.SourceNOP",
-      "parameters": {},
-      "schedule": 1
-    }
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.SourceNOP",
+      parameters: {},
+      schedule: 1,
+    },
   },
-  "transforms": {
-    "transform1": {
-      "module": "decisionengine.framework.tests.TransformNOP",
-      "parameters": {},
-    }
+  transforms: {
+    transform1: {
+      module: "decisionengine.framework.tests.TransformNOP",
+      parameters: {},
+    },
   },
-  "publishers": {
-    "publisher1": {
-      "module": "decisionengine.framework.tests.PublisherNOP",
-      "parameters": {}
-    }
-  }
+  publishers: {
+    publisher1: {
+      module: "decisionengine.framework.tests.PublisherNOP",
+      parameters: {},
+    },
+  },
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/decision_engine.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/decision_engine.jsonnet
@@ -1,34 +1,34 @@
 {
-  "logger" : {
-    "log_file": "/tmp/decisionengine.log",
-    "max_file_size": 200000000,
-    "max_backup_count": 6,
-    "rotation_time_unit":"D",
-    "rotation_time_interval":1,
-    "file_rotate_by":"size",
-    "log_level": "DEBUG",
-    "global_channel_log_level":"DEBUG"
+  logger: {
+    log_file: "/tmp/decisionengine.log",
+    max_file_size: 200000000,
+    max_backup_count: 6,
+    rotation_time_unit: "D",
+    rotation_time_interval: 1,
+    file_rotate_by: "size",
+    log_level: "DEBUG",
+    global_channel_log_level: "DEBUG",
   },
 
-  "server_address" : ["localhost",8888],
-  "shutdown_timeout" : 10,
+  server_address: ["localhost", 8888],
+  shutdown_timeout: 10,
 
-  "dataspace": {
-    "reaper_start_delay_seconds": 1818,
-    "retention_interval_in_days": 370,
+  dataspace: {
+    reaper_start_delay_seconds: 1818,
+    retention_interval_in_days: 370,
 
-    "datasource" : {
-      "module" : "decisionengine.framework.dataspace.datasources.postgresql",
-      "name" : "Postgresql",
-      "config" : {
-        "user" : "postgres",
-        "blocking" : "True",
-        "host" : "localhost",
-        "port" : 5432,
-        "database" : "decisionengine",
-        "maxconnections" : 100,
-        "maxcached" : 10
-      }
-    }
-  }
+    datasource: {
+      module: "decisionengine.framework.dataspace.datasources.postgresql",
+      name: "Postgresql",
+      config: {
+        user: "postgres",
+        blocking: "True",
+        host: "localhost",
+        port: 5432,
+        database: "decisionengine",
+        maxconnections: 100,
+        maxcached: 10,
+      },
+    },
+  },
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_bad_publisher.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_bad_publisher.jsonnet
@@ -1,12 +1,12 @@
 {
-  "sources": {},
-  "transforms": {},
-  "logicengines": {},
-  "publishers": {
-    "publisher1": {
-      "module": "decisionengine.framework.tests.PublisherWithMissingConsumes",
-      "name": "PublisherWithMissingConsumes",
-      "parameters": {}
-    }
-  }
+  sources: {},
+  transforms: {},
+  logicengines: {},
+  publishers: {
+    publisher1: {
+      module: "decisionengine.framework.tests.PublisherWithMissingConsumes",
+      name: "PublisherWithMissingConsumes",
+      parameters: {},
+    },
+  },
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_bad_source.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_bad_source.jsonnet
@@ -1,11 +1,11 @@
 {
-  "sources": {
-    "source1": {
-      "module": "decisionengine.framework.tests.FailingSourceNOP",
-      "name": "SourceWithMissingProduces",
-      "parameters": {}
-    }
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.FailingSourceNOP",
+      name: "SourceWithMissingProduces",
+      parameters: {},
+    },
   },
-  "transforms": {},
-  "publishers": {}
+  transforms: {},
+  publishers: {},
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_bad_transform.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_bad_transform.jsonnet
@@ -1,10 +1,10 @@
 {
-  "sources": {},
-  "transforms": {
-    "transform1": {
-      "module": "decisionengine.framework.tests.TransformWithMissingProducesConsumes",
-      "parameters": {}
-    }
+  sources: {},
+  transforms: {
+    transform1: {
+      module: "decisionengine.framework.tests.TransformWithMissingProducesConsumes",
+      parameters: {},
+    },
   },
-  "publishers": {}
+  publishers: {},
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_missing_product.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_missing_product.jsonnet
@@ -1,10 +1,10 @@
 {
-  "sources": {},
-  "transforms": {
-    "a_uses_b": {
-      "module": "decisionengine.framework.tests.ABTransform",
-      "parameters": {}
-    }
+  sources: {},
+  transforms: {
+    a_uses_b: {
+      module: "decisionengine.framework.tests.ABTransform",
+      parameters: {},
+    },
   },
-  "publishers": {}
+  publishers: {},
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_product_circularity.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-bad-channel/test_product_circularity.jsonnet
@@ -1,14 +1,14 @@
 {
-  "sources": {},
-  "transforms": {
-    "a_uses_b": {
-      "module": "decisionengine.framework.tests.ABTransform",
-      "parameters": {}
+  sources: {},
+  transforms: {
+    a_uses_b: {
+      module: "decisionengine.framework.tests.ABTransform",
+      parameters: {},
     },
-    "b_uses_a": {
-      "module": "decisionengine.framework.tests.BATransform",
-      "parameters": {}
-    }
+    b_uses_a: {
+      module: "decisionengine.framework.tests.BATransform",
+      parameters: {},
+    },
   },
-  "publishers": {}
+  publishers: {},
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-error-on-acquire/error_on_acquire.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-error-on-acquire/error_on_acquire.jsonnet
@@ -1,16 +1,16 @@
-# The ErrorOnAcquire source raises an exception as part of the acquire
-# method.  We then specify a ridiculous schedule of 10k seconds, to
-# test that the task manager does not wait 10k seconds before taking
-# the channel offline.
+// The ErrorOnAcquire source raises an exception as part of the acquire
+// method.  We then specify a ridiculous schedule of 10k seconds, to
+// test that the task manager does not wait 10k seconds before taking
+// the channel offline.
 
 {
-  "sources": {
-    "source1": {
-      "module": "decisionengine.framework.tests.ErrorOnAcquire",
-      "parameters": {},
-      "schedule": 10000
-    }
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.ErrorOnAcquire",
+      parameters: {},
+      schedule: 10000,
+    },
   },
-  "transforms": {},
-  "publishers": {}
+  transforms: {},
+  publishers: {},
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_channel.jsonnet
@@ -1,20 +1,20 @@
 {
-  "sources": {
-    "source1": {
-      "module": "decisionengine.framework.tests.SourceNOP",
-      "parameters": {
-        "sleep_for": 5
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.SourceNOP",
+      parameters: {
+        sleep_for: 5,
       },
-      "schedule": 1
-    }
+      schedule: 1,
+    },
   },
 
-  "transforms": {
-    "transform1": {
-      "module": "decisionengine.framework.tests.TransformNOP",
-      "parameters": {},
-    }
+  transforms: {
+    transform1: {
+      module: "decisionengine.framework.tests.TransformNOP",
+      parameters: {},
+    },
   },
 
-  "publishers": {}
+  publishers: {},
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_source_proxy.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_source_proxy.jsonnet
@@ -1,22 +1,22 @@
 {
-  "sources": {
-    "source1": {
-      "module": "decisionengine.framework.tests.FailingSourceProxy",
-      "parameters": {
-        "source_channel": "test_channel",
-        "Dataproducts": ["foo"],
-        "max_attempts": 1,
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.FailingSourceProxy",
+      parameters: {
+        source_channel: "test_channel",
+        Dataproducts: ["foo"],
+        max_attempts: 1,
       },
-      "schedule": 1
-     }
-   },
+      schedule: 1,
+    },
+  },
 
-   "transforms": {
-     "transform1": {
-       "module": "decisionengine.framework.tests.TransformNOP",
-       "parameters": {}
-     }
-   },
+  transforms: {
+    transform1: {
+      module: "decisionengine.framework.tests.TransformNOP",
+      parameters: {},
+    },
+  },
 
-  "publishers": {}
+  publishers: {},
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_channel.jsonnet
@@ -1,20 +1,20 @@
 {
-  "sources": {
-    "source1": {
-      "module": "decisionengine.framework.tests.SourceNOP",
-      "parameters": {
-        "sleep_for": 5
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.SourceNOP",
+      parameters: {
+        sleep_for: 5,
       },
-      "schedule": 1
-    }
+      schedule: 1,
+    },
   },
 
-  "transforms": {
-    "transform1": {
-      "module": "decisionengine.framework.tests.TransformNOP",
-      "parameters": {},
-    }
+  transforms: {
+    transform1: {
+      module: "decisionengine.framework.tests.TransformNOP",
+      parameters: {},
+    },
   },
 
-  "publishers": {}
+  publishers: {},
 }

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_source_proxy.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_source_proxy.jsonnet
@@ -1,22 +1,22 @@
 {
-  "sources": {
-    "source1": {
-      "module": "decisionengine.framework.tests.WorkingSourceProxy",
-      "parameters": {
-        "source_channel": "test_channel",
-        "Dataproducts": ["foo"],
-        "max_attempts": 1,
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.WorkingSourceProxy",
+      parameters: {
+        source_channel: "test_channel",
+        Dataproducts: ["foo"],
+        max_attempts: 1,
       },
-      "schedule": 1
-     }
-   },
+      schedule: 1,
+    },
+  },
 
-   "transforms": {
-     "transform1": {
-       "module": "decisionengine.framework.tests.TransformNOP",
-       "parameters": {},
-     }
-   },
+  transforms: {
+    transform1: {
+      module: "decisionengine.framework.tests.TransformNOP",
+      parameters: {},
+    },
+  },
 
-  "publishers": {}
+  publishers: {},
 }


### PR DESCRIPTION
This adds a pre-commit hook to make the jsonnet files format consistently with the provided jsonnetfmt tool.

Note, developers will need to have jsonnetfmt installed on their dev boxes for this hook to work, but the hook should be doing that for you ;)