### PR TITLE
EL7 doesn't ship with a new enough golang for jsonnetfmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,25 +43,28 @@ repos:
         additional_dependencies:
           - "prettier"
           - "prettier-plugin-toml@0.3.1"
-  - repo: https://github.com/google/go-jsonnet.git
-    rev: 2f2f6d664f06d064c4b3525ea34a789c1ac95cda
-    hooks:
-      - id: jsonnet-format
-        exclude: "empty.*|invalid.jsonnet"
-        args:
-          - "--in-place"
-          - "--string-style"
-          - "d"
-          - "--comment-style"
-          - "s"
   - repo: "https://github.com/asottile/pyupgrade"
     rev: v2.29.0
     hooks:
       - id: pyupgrade
         args:
           - "--py36-plus"
+#  jsonnetfmt requires golang 1.11+ and git 2.0, uncomment when we are compatible
+#  - repo: https://github.com/google/go-jsonnet.git
+#    rev: 2f2f6d664f06d064c4b3525ea34a789c1ac95cda
+#    hooks:
+#      - id: jsonnet-format
+#        language_version: "1.11"
+#        exclude: "empty.*|invalid.jsonnet"
+#        args:
+#          - "--in-place"
+#          - "--string-style"
+#          - "d"
+#          - "--comment-style"
+#          - "s"
 #  sort-all requires python 3.8+, uncomment when we are compatible
 #  - repo: "https://github.com/aio-libs/sort-all"
 #    rev: v1.1.0
 #    hooks:
 #      - id: sort-all
+#        language_version: "3.8"


### PR DESCRIPTION
Turns out my test EL7 box had a newer golang in /usr/local/bin/ from when I was hacking on jsonnet for packaging purposes.