### PR TITLE
addition of queue logging

### DIFF
--- a/src/decisionengine/framework/config/ChannelConfigHandler.py
+++ b/src/decisionengine/framework/config/ChannelConfigHandler.py
@@ -25,7 +25,7 @@ def _make_de_logger(global_config):
         raise RuntimeError("No logger configuration has been specified.")
     try:
         logger_config = global_config["logger"]
-        de_logger.set_logging(
+        de_logger.configure_logging(
             log_level=logger_config.get("log_level", "INFO"),
             file_rotate_by=logger_config.get("file_rotate_by", "size"),
             rotation_time_unit=logger_config.get("rotation_time_unit", "D"),

--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -25,6 +25,7 @@ import tabulate
 
 import decisionengine.framework.dataspace.datablock as datablock
 import decisionengine.framework.dataspace.dataspace as dataspace
+import decisionengine.framework.modules.de_logger as de_logger
 import decisionengine.framework.taskmanager.ProcessingState as ProcessingState
 import decisionengine.framework.taskmanager.TaskManager as TaskManager
 
@@ -278,6 +279,7 @@ class DecisionEngine(socketserver.ThreadingMixIn, xmlrpc.server.SimpleXMLRPCServ
         self.stop_channels()
         self.reaper_stop()
         self.dataspace.close()
+        de_logger.get_queue_logger().stop()
         return "OK"
 
     def start_channel(self, channel_name, channel_config):

--- a/src/decisionengine/framework/engine/Workers.py
+++ b/src/decisionengine/framework/engine/Workers.py
@@ -5,12 +5,11 @@ import threading
 
 import structlog
 
+import decisionengine.framework.modules.de_logger as de_logger
+import decisionengine.framework.modules.logging_configDict as logconf
 import decisionengine.framework.taskmanager.ProcessingState as ProcessingState
 
-from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
-from decisionengine.framework.modules.logging_configDict import pylogconfig as logconf
-
-MAX_CHANNEL_FILE_SIZE = 200 * 1000000
+MB = 1000000
 
 
 class Worker(multiprocessing.Process):
@@ -51,60 +50,39 @@ class Worker(multiprocessing.Process):
         return self.task_manager.get_consumes()
 
     def run(self):
-
         myname = self.task_manager.name
         myfilename = os.path.join(os.path.dirname(self.logger_config["log_file"]), myname + ".log")
 
-        self.logger = structlog.getLogger(CHANNELLOGGERNAME)
+        self.logger = structlog.getLogger(logconf.CHANNELLOGGERNAME)
 
         # setting a default value here. value from config file is set in call
         # self.task_manager.set_loglevel_value after logger configuration is completed
-        logging.getLogger(CHANNELLOGGERNAME).setLevel(logging.DEBUG)
+        logging.getLogger(logconf.CHANNELLOGGERNAME).setLevel(logging.DEBUG)
 
-        # TODO:
-        # alter decisionengine.framework.modules.de_logger set_logging
-        # so we can reuse it here and reduce duplication
         logger_rotate_by = self.logger_config.get("file_rotate_by", "size")
-
-        # logconf is our global object edited in global space on purpose
-
         if logger_rotate_by == "size":
-            logconf["handlers"].update(
-                {
-                    myname: {
-                        "level": "DEBUG",
-                        "filename": myfilename,
-                        "formatter": "plain",
-                        "class": "logging.handlers.RotatingFileHandler",
-                        "maxBytes": MAX_CHANNEL_FILE_SIZE,
-                        "backupCount": self.logger_config.get("max_backup_count", 6),
-                    }
-                }
+            handler = logging.handlers.RotatingFileHandler(
+                filename=myfilename,
+                maxBytes=self.logger_config.get("max_file_size", 200 * MB),
+                backupCount=self.logger_config.get("max_backup_count", 6),
             )
+
         elif logger_rotate_by == "time":
-            logconf["handlers"].update(
-                {
-                    myname: {
-                        "level": "DEBUG",
-                        "filename": myfilename,
-                        "formatter": "plain",
-                        "class": "logging.handlers.TimedRotatingFileHandler",
-                        "when": "D",
-                        "interval": 1,
-                    }
-                }
+            handler = logging.handlers.TimedRotatingFileHandler(
+                filename=myfilename,
+                when=self.logger_config.get("rotation_time_unit", "D"),
+                interval=self.logger_config.get("rotation_time_interval", 1),
+                backupCount=self.logger_config.get("max_backup_count", 6),
             )
         else:
             raise ValueError(f"Incorrect 'logger_rotate_by':'{logger_rotate_by}:'")
 
-        logconf["loggers"].update(
-            {
-                CHANNELLOGGERNAME: {
-                    "handlers": [myname, "file_structlog_debug"],
-                }
-            }
-        )
-        logging.config.dictConfig(logconf)
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(logging.Formatter(logconf.userformat))
+
+        self.logger.addHandler(handler)
+        self.logger.addHandler(de_logger.get_queue_logger().structlog_q_handler)
+
         self.logger = self.logger.bind(module=__name__.split(".")[-1], channel=myname)
 
         channel_log_level = self.logger_config.get("global_channel_log_level", "WARNING")

--- a/src/decisionengine/framework/modules/QueueLogger.py
+++ b/src/decisionengine/framework/modules/QueueLogger.py
@@ -1,0 +1,26 @@
+import multiprocessing
+
+from logging.handlers import QueueHandler, QueueListener
+
+
+class QueueLogger:
+    def __init__(self):
+        self.structlog_q = multiprocessing.Queue(-1)
+        self.structlog_q_handler = QueueHandler(self.structlog_q)
+        self.structlog_listener = None
+
+    def format_logger(self, logger):
+        logger.addHandler(self.structlog_q_handler)
+
+    def configure_listener(self, handlers):
+        self.structlog_listener = QueueListener(self.structlog_q, *handlers, respect_handler_level=True)
+
+    def setup_queue_logging(self, logger, handlers):
+        self.format_logger(logger)
+        self.configure_listener(handlers)
+
+    def start(self):
+        self.structlog_listener.start()
+
+    def stop(self):
+        self.structlog_listener.stop()

--- a/src/decisionengine/framework/modules/tests/test_de_logger.py
+++ b/src/decisionengine/framework/modules/tests/test_de_logger.py
@@ -16,15 +16,12 @@ def log_setup():
     # make sure it is in a known "unconfigured state"
     while len(my_log.handlers) > 0:
         my_log.removeHandler(my_log.handlers[0])
-    de_logger._reset_config()
 
     yield my_log
 
     # make sure we leave this without any handlers
     while len(my_log.handlers) > 0:
         my_log.removeHandler(my_log.handlers[0])
-
-    de_logger._reset_config()
 
     gc.collect()
 
@@ -33,7 +30,7 @@ def log_setup():
 def test_by_nonsense_is_err(log_setup):
     with pytest.raises(ValueError, match=r".*Incorrect 'file_rotate_by'.*"), tempfile.NamedTemporaryFile() as log:
         log.flush()
-        de_logger.set_logging(
+        de_logger.configure_logging(
             log_level="INFO",
             max_backup_count=6,
             file_rotate_by="nonsense",
@@ -46,12 +43,12 @@ def test_by_nonsense_is_err(log_setup):
 def test_by_size(log_setup):
     with tempfile.NamedTemporaryFile() as log:
         log.flush()
-        de_logger.set_logging(
+        de_logger.configure_logging(
             log_level="INFO", max_backup_count=6, file_rotate_by="size", max_file_size=1000000, log_file_name=log.name
         )
 
         assert log_setup.hasHandlers() is True
-        assert "RotatingFileHandler" in str(log_setup.handlers)
+        assert "QueueHandler" in str(log_setup.handlers)
         assert log_setup.debug("debug") is None
         assert log_setup.info("infomsg") is None
 
@@ -60,11 +57,11 @@ def test_by_size(log_setup):
 def test_by_time(log_setup):
     with tempfile.NamedTemporaryFile() as log:
         log.flush()
-        de_logger.set_logging(
+        de_logger.configure_logging(
             log_level="INFO", rotation_interval=1, file_rotate_by="time", rotation_time_unit="D", log_file_name=log.name
         )
 
         assert log_setup.hasHandlers() is True
-        assert "TimedRotatingFileHandler" in str(log_setup.handlers)
+        assert "QueueHandler" in str(log_setup.handlers)
         assert log_setup.debug("debug") is None
         assert log_setup.info("infomsg") is None


### PR DESCRIPTION
All loggers, "decisionengine" and "channel" loggers now operate using a QueueHandler that stashes the messages into the logging queue.
- There is one QueueHandler, with one corresponding multiprocessing queue that is sends log messages to. All loggers have this handler attached. (They also have their standard file handlers attached.)
- There is one QueueListener that monitors the logging queue for log messages, and sends them to the "DEBUG" level file handler with structlog formatting.