### PR TITLE
Lower timeout for actions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         run: python3 setup.py bdist_wheel
 
       - name: Run Unit Tests on Python ${{ matrix.python-version }}
-        timeout-minutes: 55
+        timeout-minutes: 35
         env:
           PYTEST_TIMEOUT: 90
           PYTHONPATH: ${{ github.workspace }}/src


### PR DESCRIPTION
Now that we've dropped PyPy and added `xdist`, the timeout
can be set much lower for a rational test run.