### PR TITLE
Use kombu to communicate data from sources to cycles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 runtime_require = [
     "cherrypy >= 18.6.0",
     "DBUtils >= 2.0",
+    "kombu[redis] >= 5.1.0",
     "jsonnet >= 0.17.0",
     "prometheus-client >= 0.10.0",
     "tabulate >= 0.8.7",

--- a/src/decisionengine/framework/taskmanager/tests/channels/run_source_once.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/run_source_once.jsonnet
@@ -1,0 +1,11 @@
+{
+  sources: {
+    run_once: {
+      module: "decisionengine.framework.tests.SourceNOP",
+      parameters: {},
+      schedule: 0,
+    },
+  },
+  transforms: {},
+  publishers: {},
+}

--- a/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
@@ -118,8 +118,6 @@ def test_no_data_to_transform(global_config):
         with RunChannel(global_config, channel) as task_manager:
             task_manager.state.wait_while(State.BOOT)
             task_manager.run_transforms()
-            task_manager.run_publishers("action", "facts")
-            task_manager.run_logic_engine()
             task_manager.take_offline()
 
 

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_source_proxy.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_source_proxy.jsonnet
@@ -5,7 +5,7 @@
       parameters: {
         source_channel: "test_channel",
         Dataproducts: ["foo"],
-        max_attempts: 1,
+        max_attempts: 5,
       },
       schedule: 1,
     },

--- a/src/decisionengine/framework/tests/test_source_proxy.py
+++ b/src/decisionengine/framework/tests/test_source_proxy.py
@@ -28,6 +28,7 @@ def test_cannot_inherit_from_source_proxy():
             pass
 
 
+@pytest.mark.timeout(180)
 @pytest.mark.usefixtures("deserver")
 def test_single_source_proxy(deserver):
     output = deserver.de_client_run_cli("--status")

--- a/src/decisionengine/framework/tests/test_source_proxy_3G.py
+++ b/src/decisionengine/framework/tests/test_source_proxy_3G.py
@@ -2,7 +2,6 @@
 # pylint: disable=redefined-outer-name
 
 import os
-import platform
 import re
 
 import pytest
@@ -21,10 +20,6 @@ _channel_config_dir = os.path.join(TEST_CONFIG_PATH, "test-source-proxy-3g")  # 
 deserver = DEServer(conf_path=TEST_CONFIG_PATH, channel_conf_path=_channel_config_dir)  # pylint: disable=invalid-name
 
 
-@pytest.mark.skipif(
-    platform.python_implementation() == "PyPy",
-    reason="Times out under PyPy with the PG_DE_DB_WITH_SCHEMA fixture value.",
-)
 @pytest.mark.usefixtures("deserver")
 def test_many_source_proxies(deserver):
     output = deserver.de_client_run_cli("--status")


### PR DESCRIPTION
This PR uses kombu to communicate data products from sources to cycles.  There are no user-facing breaking changes.  By default, all communication happens in memory.  A different communication backend can be enabled by specifying the `broker_url` parameter as part of the global configuration (e.g.):

```jsonnet
{
  broker_url: "redis://localhost:6379/0"
}
```