### PR TITLE
Don't try to package obsolete sql file

### DIFF
--- a/package/rpm/install_section
+++ b/package/rpm/install_section
@@ -29,5 +29,4 @@ install -m 0644 -D package/systemd/decisionengine_sysconfig %{buildroot}/%{_sysc
 echo "%attr(0640,root,decisionengine) %config(noreplace) %{_sysconfdir}/sysconfig/decisionengine" >> INSTALLED_FILES
 
 mkdir -p %{buildroot}/%{_defaultdocdir}/%{name}/datasources/
-install -m 0644 src/decisionengine/framework/dataspace/datasources/postgresql.sql %{buildroot}/%{_defaultdocdir}/%{name}/datasources/postgresql.sql
 echo "%doc %{_defaultdocdir}/%{name}" >> INSTALLED_FILES


### PR DESCRIPTION
The postgresql.sql file isn't in the product any longer, we can drop the schema it includes.