### PR TITLE
addition of queue logging for multiprocessing

### DIFF
--- a/src/decisionengine/framework/config/ChannelConfigHandler.py
+++ b/src/decisionengine/framework/config/ChannelConfigHandler.py
@@ -25,7 +25,7 @@ def _make_de_logger(global_config):
         raise RuntimeError("No logger configuration has been specified.")
     try:
         logger_config = global_config["logger"]
-        de_logger.set_logging(
+        de_logger.configure_logging(
             log_level=logger_config.get("log_level", "INFO"),
             file_rotate_by=logger_config.get("file_rotate_by", "size"),
             rotation_time_unit=logger_config.get("rotation_time_unit", "D"),
@@ -33,6 +33,7 @@ def _make_de_logger(global_config):
             max_backup_count=logger_config.get("max_backup_count", 6),
             max_file_size=logger_config.get("max_file_size", 1000000),
             log_file_name=logger_config["log_file"],
+            start_q_logger=logger_config.get("start_q_logger", "True"),
         )
         return de_logger.get_logger()
     except Exception as msg:  # pragma: no cover

--- a/src/decisionengine/framework/config/tests/de/decision_engine.jsonnet
+++ b/src/decisionengine/framework/config/tests/de/decision_engine.jsonnet
@@ -4,5 +4,6 @@
     max_file_size: 200000000,
     max_backup_count: 6,
     log_level: "DEBUG",
+    start_q_logger: "False",
   },
 }

--- a/src/decisionengine/framework/config/tests/de/minimal.conf
+++ b/src/decisionengine/framework/config/tests/de/minimal.conf
@@ -3,6 +3,7 @@
     "log_file": "/tmp/de_config_tests/decision_engine_log",
     "max_file_size": 200 * 1000000,
     "max_backup_count": 6,
-    "log_level": "DEBUG"
+    "log_level": "DEBUG",
+    "start_q_logger": "False",
   }
 }

--- a/src/decisionengine/framework/config/tests/de/minimal.jsonnet
+++ b/src/decisionengine/framework/config/tests/de/minimal.jsonnet
@@ -4,5 +4,6 @@
     max_file_size: 200 * 1000000,
     max_backup_count: 6,
     log_level: "DEBUG",
+    start_q_logger: "False",
   },
 }

--- a/src/decisionengine/framework/config/tests/de/minimal_with_address.jsonnet
+++ b/src/decisionengine/framework/config/tests/de/minimal_with_address.jsonnet
@@ -5,5 +5,6 @@
     max_file_size: 200000000,
     max_backup_count: 6,
     log_level: "DEBUG",
+    start_q_logger: "False",
   },
 }

--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -28,6 +28,7 @@ import tabulate
 
 import decisionengine.framework.dataspace.datablock as datablock
 import decisionengine.framework.dataspace.dataspace as dataspace
+import decisionengine.framework.modules.de_logger as de_logger
 import decisionengine.framework.taskmanager.ProcessingState as ProcessingState
 import decisionengine.framework.taskmanager.TaskManager as TaskManager
 
@@ -316,6 +317,7 @@ class DecisionEngine(socketserver.ThreadingMixIn, xmlrpc.server.SimpleXMLRPCServ
         self.stop_channels()
         self.reaper_stop()
         self.dataspace.close()
+        de_logger.stop_queue_logger()
         return "OK"
 
     def start_channel(self, channel_name, channel_config):

--- a/src/decisionengine/framework/engine/tests/config/test_channel.jsonnet
+++ b/src/decisionengine/framework/engine/tests/config/test_channel.jsonnet
@@ -1,0 +1,21 @@
+{
+  sources: {
+    source1: {
+      module: "decisionengine.framework.tests.SourceNOP",
+      parameters: {},
+      schedule: 1,
+    },
+  },
+  transforms: {
+    transform1: {
+      module: "decisionengine.framework.tests.TransformNOP",
+      parameters: {},
+    },
+  },
+  publishers: {
+    publisher1: {
+      module: "decisionengine.framework.tests.PublisherNOP",
+      parameters: {},
+    },
+  },
+}

--- a/src/decisionengine/framework/engine/tests/test_Workers.py
+++ b/src/decisionengine/framework/engine/tests/test_Workers.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+import gc
 import os
 
 import pytest

--- a/src/decisionengine/framework/engine/tests/test_Workers.py
+++ b/src/decisionengine/framework/engine/tests/test_Workers.py
@@ -1,0 +1,69 @@
+import gc
+import os
+
+import pytest
+
+import decisionengine.framework.config.policies as policies
+
+from decisionengine.framework.config.ValidConfig import ValidConfig
+from decisionengine.framework.engine.Workers import Worker
+from decisionengine.framework.taskmanager.TaskManager import TaskManager
+from decisionengine.framework.taskmanager.tests.fixtures import (  # noqa: F401
+    DATABASES_TO_TEST,
+    dataspace,
+    PG_DE_DB_WITHOUT_SCHEMA,
+    PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_TEMPFILE_SQLITE,
+)
+
+_CWD = os.path.dirname(os.path.abspath(__file__))
+_CONFIG_PATH = os.path.join(_CWD, "../../tests/etc/decisionengine")
+_CHANNEL_CONFIG_DIR = os.path.join(_CWD, "config")
+
+channel = "test_channel"
+
+
+def get_channel_config(name):
+    return ValidConfig(os.path.join(_CHANNEL_CONFIG_DIR, name + ".jsonnet"))
+
+
+@pytest.fixture()
+@pytest.mark.usefixtures("dataspace")
+def global_config(dataspace):  # noqa: F811
+    conf = ValidConfig(policies.global_config_file(_CONFIG_PATH))
+    conf["dataspace"] = dataspace.config["dataspace"]
+    yield conf
+
+
+@pytest.fixture()
+@pytest.mark.usefixtures("global_config")
+def task_manager(global_config):
+    task_manager = TaskManager(channel, get_channel_config(channel), global_config)
+    yield task_manager
+
+    gc.collect()
+
+
+@pytest.mark.usefixtures("task_manager", "global_config")
+def test_worker_name(task_manager, global_config):
+    worker = Worker(task_manager, global_config["logger"])
+
+    assert worker.name == f"DEWorker-{task_manager.name}"
+
+
+@pytest.mark.usefixtures("task_manager", "global_config")
+def test_worker_logger_sized_rotation(task_manager, global_config):
+    worker = Worker(task_manager, global_config["logger"])
+    worker.setup_logger()
+
+    assert "RotatingFileHandler" in str(worker.logger.handlers)
+
+
+@pytest.mark.usefixtures("task_manager", "global_config")
+def test_worker_logger_timed_rotation(task_manager, global_config):
+    global_config["logger"]["file_rotate_by"] = "time"
+    worker = Worker(task_manager, global_config["logger"])
+    worker.setup_logger()
+
+    assert "TimedRotatingFileHandler" in str(worker.logger.handlers)

--- a/src/decisionengine/framework/engine/tests/test_Workers.py
+++ b/src/decisionengine/framework/engine/tests/test_Workers.py
@@ -1,4 +1,6 @@
-import gc
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 
 import pytest

--- a/src/decisionengine/framework/modules/QueueLogger.py
+++ b/src/decisionengine/framework/modules/QueueLogger.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import multiprocessing
 
 from logging.handlers import QueueHandler, QueueListener

--- a/src/decisionengine/framework/modules/QueueLogger.py
+++ b/src/decisionengine/framework/modules/QueueLogger.py
@@ -1,0 +1,34 @@
+import multiprocessing
+
+from logging.handlers import QueueHandler, QueueListener
+
+
+class QueueLogger:
+    def __init__(self):
+        self.structlog_q = None
+        self.structlog_q_handler = None
+        self.structlog_listener = None
+        self.initialized = False
+
+    def initialize_q(self):
+        self.structlog_q = multiprocessing.Queue(-1)
+        self.structlog_q_handler = QueueHandler(self.structlog_q)
+        self.initialized = True
+
+    def format_logger(self, logger):
+        logger.addHandler(self.structlog_q_handler)
+
+    def configure_listener(self, handlers):
+        self.structlog_listener = QueueListener(self.structlog_q, *handlers, respect_handler_level=True)
+
+    def setup_queue_logging(self, logger, handlers):
+        self.initialize_q()
+        self.format_logger(logger)
+        self.configure_listener(handlers)
+
+    def start(self):
+        self.structlog_listener.start()
+
+    def stop(self):
+        if self.initialized:
+            self.structlog_listener.stop()

--- a/src/decisionengine/framework/modules/de_logger.py
+++ b/src/decisionengine/framework/modules/de_logger.py
@@ -1,7 +1,6 @@
 """
 Logger to use in all modules
 """
-import importlib
 import logging
 import logging.config
 import logging.handlers
@@ -10,28 +9,25 @@ import os
 import structlog
 
 import decisionengine.framework.modules.logging_configDict as logconf
+import decisionengine.framework.modules.QueueLogger as QueueLogger
 
 MB = 1000000
 
-logger = structlog.getLogger(logconf.LOGGERNAME)
-logger = logger.bind(module=__name__.split(".")[-1], channel=logconf.DELOGGER_CHANNEL_NAME)
+delogger = structlog.getLogger(logconf.LOGGERNAME)
+delogger = delogger.bind(module=__name__.split(".")[-1], channel=logconf.DELOGGER_CHANNEL_NAME)
+
+queue_logger = QueueLogger.QueueLogger()
 
 
-def _reset_config():
-    """
-    Reset the logconf.pylogconfig dictionary
-    """
-    importlib.reload(logconf)
-
-
-def set_logging(
-    log_level,
-    file_rotate_by,
+def configure_logging(
+    log_level="DEBUG",
+    file_rotate_by="size",
     rotation_time_unit="D",
     rotation_interval=1,
     max_backup_count=6,
     max_file_size=200 * MB,
     log_file_name="/tmp/decision_engine_logs/decisionengine.log",
+    start_q_logger="True",
 ):
     """
 
@@ -55,67 +51,50 @@ def set_logging(
     if dirname and not os.path.exists(dirname):
         os.makedirs(dirname)
 
-    logger.setLevel(getattr(logging, log_level.upper()))
-    if logger.handlers:
-        logger.debug("Reusing existing logging handlers")
+    delogger.setLevel(getattr(logging, log_level.upper()))
+    if delogger.handlers:
+        delogger.debug("Reusing existing logging handlers")
         return None
 
-    # logconf.pylogconfig is our global object edited in global space on purpose
-
-    logconf.pylogconfig["handlers"]["de_file_debug"].update({"filename": f"{log_file_name}_debug.log"})
-    logconf.pylogconfig["handlers"]["de_file_info"].update({"filename": f"{log_file_name}.log"})
-    logconf.pylogconfig["handlers"]["file_structlog_debug"].update({"filename": f"{log_file_name}_structlog_debug.log"})
+    # configure handlers
+    handlers_list = []
 
     if file_rotate_by == "size":
-        logconf.pylogconfig["handlers"]["de_file_debug"].update(
-            {
-                "class": "logging.handlers.RotatingFileHandler",
-                "maxBytes": max_file_size,
-                "backupCount": max_backup_count,
-            }
-        )
-        logconf.pylogconfig["handlers"]["de_file_info"].update(
-            {
-                "class": "logging.handlers.RotatingFileHandler",
-                "maxBytes": max_file_size,
-                "backupCount": max_backup_count,
-            }
-        )
-        logconf.pylogconfig["handlers"]["file_structlog_debug"].update(
-            {
-                "class": "logging.handlers.RotatingFileHandler",
-                "maxBytes": max_file_size,
-                "backupCount": max_backup_count,
-            }
-        )
+        for files in logconf.de_outfile_info:
+            handler = logging.handlers.RotatingFileHandler(
+                filename=f"{log_file_name}" + files[0], maxBytes=max_file_size, backupCount=max_backup_count
+            )
+            handler.setLevel(files[1])
+            handler.setFormatter(logging.Formatter(files[2]))
+            handlers_list.append(handler)
 
     elif file_rotate_by == "time":
-        logconf.pylogconfig["handlers"]["de_file_debug"].update(
-            {
-                "class": "logging.handlers.TimedRotatingFileHandler",
-                "when": rotation_time_unit,
-                "interval": rotation_interval,
-            }
-        )
-        logconf.pylogconfig["handlers"]["de_file_info"].update(
-            {
-                "class": "logging.handlers.TimedRotatingFileHandler",
-                "when": rotation_time_unit,
-                "interval": rotation_interval,
-            }
-        )
-        logconf.pylogconfig["handlers"]["file_structlog_debug"].update(
-            {
-                "class": "logging.handlers.TimedRotatingFileHandler",
-                "when": rotation_time_unit,
-                "interval": rotation_interval,
-            }
-        )
+        for files in logconf.de_outfile_info:
+            handler = logging.handlers.TimedRotatingFileHandler(
+                filename=f"{log_file_name}" + files[0],
+                when=rotation_time_unit,
+                interval=rotation_interval,
+                backupCount=max_backup_count,
+            )
+            handler.setLevel(files[1])
+            handler.setFormatter(logging.Formatter(files[2]))
+            handlers_list.append(handler)
+
     else:
         raise ValueError(f"Incorrect 'file_rotate_by':'{file_rotate_by}:'")
 
-    logging.config.dictConfig(logconf.pylogconfig)
-    logger.debug("de logging setup complete")
+    structlog_handlers_list = [handlers_list.pop(i) for i in logconf.structlog_file_index]
+
+    # setup standard file handlers
+    for h in handlers_list:
+        delogger.addHandler(h)
+
+    # setup the queue logger
+    if start_q_logger == "True":
+        queue_logger.setup_queue_logging(delogger, structlog_handlers_list)
+        queue_logger.start()
+
+    delogger.debug("de logging setup complete")
 
 
 def get_logger():
@@ -123,11 +102,23 @@ def get_logger():
     get default logger - "decisionengine"
     :rtype: :class:`logging.Logger` - rotating file logger
     """
-    return logger
+    return delogger
+
+
+def get_queue_logger():
+    """
+    get QueueLogger which owns the logging queues and listeners
+    :rtype: :class:`decisionengine.framework.modules.QueueLogger``
+    """
+    return queue_logger
+
+
+def stop_queue_logger():
+    queue_logger.stop()
 
 
 if __name__ == "__main__":
-    set_logging(
+    configure_logging(
         "ERROR",
         "size",
         "D",
@@ -136,6 +127,6 @@ if __name__ == "__main__":
         max_file_size=100000,
         log_file_name=f"{os.environ.get('HOME')}/de_log/decision_engine_log0",
     )
-    logger.error("THIS IS ERROR")
-    logger.info("THIS IS INFO")
-    logger.debug("THIS IS DEBUG")
+    delogger.error("THIS IS ERROR")
+    delogger.info("THIS IS INFO")
+    delogger.debug("THIS IS DEBUG")

--- a/src/decisionengine/framework/modules/tests/test_QueueLogger.py
+++ b/src/decisionengine/framework/modules/tests/test_QueueLogger.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import gc
 import logging
 

--- a/src/decisionengine/framework/modules/tests/test_QueueLogger.py
+++ b/src/decisionengine/framework/modules/tests/test_QueueLogger.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-import gc
 import logging
 
 import pytest

--- a/src/decisionengine/framework/modules/tests/test_QueueLogger.py
+++ b/src/decisionengine/framework/modules/tests/test_QueueLogger.py
@@ -1,0 +1,65 @@
+import gc
+import logging
+
+import pytest
+
+import decisionengine.framework.modules.QueueLogger as QueueLogger
+
+
+@pytest.fixture()
+def queue_logger_setup():
+    q_log = QueueLogger.QueueLogger()
+    yield q_log
+
+    del q_log
+
+
+@pytest.fixture()
+def log_setup():
+    test_log = logging.getLogger("test_logger")
+    yield test_log
+
+    del test_log
+
+
+@pytest.fixture()
+def handler_setup():
+    test_handler = [logging.FileHandler(filename="/tmp/decisionengine.log")]
+    yield test_handler
+
+    del test_handler
+
+
+@pytest.fixture(autouse=True)
+def setup_queue_logging(queue_logger_setup, log_setup, handler_setup):
+    queue_logger_setup.setup_queue_logging(log_setup, handler_setup)
+    yield queue_logger_setup
+
+    del queue_logger_setup
+
+
+@pytest.mark.usefixtures("queue_logger_setup", "log_setup", "handler_setup")
+def test_setup_queue_logging(queue_logger_setup, log_setup, handler_setup):
+    # queue_logger_setup.setup_queue_logging(log_setup, handler_setup)
+
+    assert queue_logger_setup.structlog_q is not None
+    assert isinstance(queue_logger_setup.structlog_q_handler, logging.handlers.QueueHandler)
+    assert "QueueHandler" in str(log_setup.handlers)
+    assert isinstance(queue_logger_setup.structlog_listener, logging.handlers.QueueListener)
+
+
+@pytest.mark.usefixtures("queue_logger_setup", "log_setup", "handler_setup")
+def test_start_queue_logger(queue_logger_setup, log_setup, handler_setup):
+    # queue_logger_setup.setup_queue_logging(log_setup, handler_setup)
+    queue_logger_setup.start()
+
+    assert queue_logger_setup.structlog_listener._thread is not None
+
+
+@pytest.mark.usefixtures("queue_logger_setup", "log_setup", "handler_setup")
+def test_stop_queue_logger(queue_logger_setup, log_setup, handler_setup):
+    # queue_logger_setup.setup_queue_logging(log_setup, handler_setup)
+    queue_logger_setup.start()
+    queue_logger_setup.stop()
+
+    assert queue_logger_setup.structlog_listener._thread is None

--- a/src/decisionengine/framework/modules/tests/test_de_logger.py
+++ b/src/decisionengine/framework/modules/tests/test_de_logger.py
@@ -16,15 +16,12 @@ def log_setup():
     # make sure it is in a known "unconfigured state"
     while len(my_log.handlers) > 0:
         my_log.removeHandler(my_log.handlers[0])
-    de_logger._reset_config()
 
     yield my_log
 
     # make sure we leave this without any handlers
     while len(my_log.handlers) > 0:
         my_log.removeHandler(my_log.handlers[0])
-
-    de_logger._reset_config()
 
     gc.collect()
 
@@ -33,7 +30,7 @@ def log_setup():
 def test_by_nonsense_is_err(log_setup):
     with pytest.raises(ValueError, match=r".*Incorrect 'file_rotate_by'.*"), tempfile.NamedTemporaryFile() as log:
         log.flush()
-        de_logger.set_logging(
+        de_logger.configure_logging(
             log_level="INFO",
             max_backup_count=6,
             file_rotate_by="nonsense",
@@ -46,8 +43,13 @@ def test_by_nonsense_is_err(log_setup):
 def test_by_size(log_setup):
     with tempfile.NamedTemporaryFile() as log:
         log.flush()
-        de_logger.set_logging(
-            log_level="INFO", max_backup_count=6, file_rotate_by="size", max_file_size=1000000, log_file_name=log.name
+        de_logger.configure_logging(
+            log_level="INFO",
+            max_backup_count=6,
+            file_rotate_by="size",
+            max_file_size=1000000,
+            log_file_name=log.name,
+            start_q_logger="False",
         )
 
         assert log_setup.hasHandlers() is True
@@ -60,8 +62,13 @@ def test_by_size(log_setup):
 def test_by_time(log_setup):
     with tempfile.NamedTemporaryFile() as log:
         log.flush()
-        de_logger.set_logging(
-            log_level="INFO", rotation_interval=1, file_rotate_by="time", rotation_time_unit="D", log_file_name=log.name
+        de_logger.configure_logging(
+            log_level="INFO",
+            rotation_interval=1,
+            file_rotate_by="time",
+            rotation_time_unit="D",
+            log_file_name=log.name,
+            start_q_logger="False",
         )
 
         assert log_setup.hasHandlers() is True

--- a/src/decisionengine/framework/tests/etc/decisionengine/decision_engine.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/decision_engine.jsonnet
@@ -8,6 +8,7 @@
     file_rotate_by: "size",
     log_level: "DEBUG",
     global_channel_log_level: "DEBUG",
+    start_q_logger: "False",
   },
 
   server_address: ["localhost", 8888],


### PR DESCRIPTION
All loggers, "decisionengine" and "channel" loggers now operate using a QueueHandler that stashes the messages into the logging queue.

There is one QueueHandler, with one corresponding multiprocessing queue that is sends log messages to. All loggers have this handler attached. (They also have their standard file handlers attached.)
There is one QueueListener that monitors the logging queue for log messages, and sends them to the "DEBUG" level file handler with structlog formatting.

IMPORTANT NOTE: The QueueLogger causes all kinds of trouble if enabled during unit tests. Therefore, I have added an additional configuration parameter to the "logging' section of the config dictionary, "start_q_logger". This parameter should be set to "True" for any configuration file that is running a job and "False" for any configuration file that is doing a unit test.
