### PR TITLE
Add a redis server to the CI testing containers

### DIFF
--- a/package/ci/python3-entrypoint.sh
+++ b/package/ci/python3-entrypoint.sh
@@ -2,8 +2,22 @@
 CMD=${1:- -m pytest}
 LOGFILE=${2:- pytest.log}
 
+# this trap shouldn't eat the exit code of python
+function stop_redis {
+    /opt/rh/rh-redis5/root/usr/libexec/redis-shutdown
+}
+trap stop_redis EXIT
+
 id
 getent passwd $(whoami)
+echo ''
+
+# Start redis in the background, stop server via traps
+/opt/rh/rh-redis5/root/usr/bin/redis-server &
+sleep 1
+echo ''
+
+# Useful info
 python3 -m site
 echo ''
 

--- a/package/container/Dockerfile
+++ b/package/container/Dockerfile
@@ -29,6 +29,9 @@ RUN yum -y install postgresql$(echo -n ${PG_VERSION} | tr -d '.')-server \
                    postgresql$(echo -n ${PG_VERSION} | tr -d '.') \
  && yum -y clean all
 
+# Install redis 5 server and tools
+RUN yum install -y rh-redis5
+
 # Install utils
 RUN yum -y install \
     python3 python3-pip python3-setuptools python3-wheel \


### PR DESCRIPTION
This should help us get kombu running as a multi process tool in the CI tests.

@vitodb if this looks right we'll need to rebuild the containers on docker hub and Jenkins.