### PR TITLE
Set state to error for exceptions caught before the thread start.

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -330,6 +330,7 @@ class DecisionEngine(socketserver.ThreadingMixIn, xmlrpc.server.SimpleXMLRPCServ
             except Exception as e:
                 self.logger.exception(f"Channel {name} failed to start : {e}")
 
+        self.logger.debug("Waiting for channels to exit ProcessingState.State.BOOT")
         self.block_while(ProcessingState.State.BOOT)
 
     def rpc_start_channel(self, channel_name):

--- a/src/decisionengine/framework/engine/Workers.py
+++ b/src/decisionengine/framework/engine/Workers.py
@@ -95,6 +95,7 @@ class Worker(multiprocessing.Process):
                 }
             )
         else:
+            self.task_manager.state.set(ProcessingState.State.ERROR)
             raise ValueError(f"Incorrect 'logger_rotate_by':'{logger_rotate_by}:'")
 
         logconf["loggers"].update(

--- a/src/decisionengine/framework/taskmanager/TaskManager.py
+++ b/src/decisionengine/framework/taskmanager/TaskManager.py
@@ -501,7 +501,7 @@ class TaskManager(ComponentManager):
         source_threads = []
 
         for key, source in self.workflow.source_workers.items():
-            self.logger.info(f"starting loop for {key}")
+            self.logger.info(f"starting loop for {source.name}->{key}")
             event_list.append(source.data_updated)
             SOURCE_ACQUIRE_GAUGE.labels(self.name, source.name)
             thread = threading.Thread(target=self.run_source, name=source.name, args=(source,))
@@ -511,6 +511,7 @@ class TaskManager(ComponentManager):
 
         # This is the boot phase
         # Wait until all sources run at least once
+        self.logger.debug(f"Waiting for events ({event_list}) in {self.name}")
         self.wait_for_all(event_list)
         return source_threads
 


### PR DESCRIPTION
Technically there is a code path where things can get stuck if you
send in a strange enough config.  I'm not clear that code path is
real, but it may be possible to get stuck waiting on a State for
a thread that was never started.