### PR TITLE
Porting PR#563 into 1.7 (adding queue logging to de_logger in 1.7 base branch)

### DIFF
--- a/src/decisionengine/framework/config/ChannelConfigHandler.py
+++ b/src/decisionengine/framework/config/ChannelConfigHandler.py
@@ -24,14 +24,17 @@ def _make_de_logger(global_config):
     if 'logger' not in global_config:
         raise RuntimeError("No logger configuration has been specified.")
     try:
-        logger_config = global_config['logger']
-        de_logger.set_logging(log_level=logger_config.get('log_level', 'INFO'),
-                              file_rotate_by=logger_config.get('file_rotate_by', "size"),
-                              rotation_time_unit=logger_config.get('rotation_time_unit', 'D'),
-                              rotation_interval=logger_config.get('rotation_time_interval', 1),
-                              max_backup_count=logger_config.get('max_backup_count', 6),
-                              max_file_size=logger_config.get('max_file_size', 1000000),
-                              log_file_name=logger_config['log_file'])
+        logger_config = global_config["logger"]
+        de_logger.configure_logging(
+            log_level=logger_config.get("log_level", "INFO"),
+            file_rotate_by=logger_config.get("file_rotate_by", "size"),
+            rotation_time_unit=logger_config.get("rotation_time_unit", "D"),
+            rotation_interval=logger_config.get("rotation_time_interval", 1),
+            max_backup_count=logger_config.get("max_backup_count", 6),
+            max_file_size=logger_config.get("max_file_size", 1000000),
+            log_file_name=logger_config["log_file"],
+            start_q_logger=logger_config.get("start_q_logger", "True"),
+        )
         return de_logger.get_logger()
     except Exception as msg:  # pragma: no cover
         raise RuntimeError(f"Failed to create log: {msg}")

--- a/src/decisionengine/framework/config/tests/de/decision_engine.jsonnet
+++ b/src/decisionengine/framework/config/tests/de/decision_engine.jsonnet
@@ -3,6 +3,7 @@
     "log_file": "/dev/null",
     "max_file_size": 200000000,
     "max_backup_count": 6,
-    "log_level": "DEBUG"
+    "log_level": "DEBUG",
+    "start_q_logger": "False",
   }
 }

--- a/src/decisionengine/framework/config/tests/de/minimal.jsonnet
+++ b/src/decisionengine/framework/config/tests/de/minimal.jsonnet
@@ -3,6 +3,7 @@
     "log_file": "/dev/null",
     "max_file_size": 200000000,
     "max_backup_count": 6,
-    "log_level": "DEBUG"
+    "log_level": "DEBUG",
+    "start_q_logger": "False",
   }
 }

--- a/src/decisionengine/framework/config/tests/de/minimal_jsonnet.conf
+++ b/src/decisionengine/framework/config/tests/de/minimal_jsonnet.conf
@@ -4,5 +4,6 @@
     'max_file_size': 200000000,
     'max_backup_count': 6,
     'log_level': "DEBUG",
+    'start_q_logger': "False",
   }
 }

--- a/src/decisionengine/framework/config/tests/de/minimal_python.conf
+++ b/src/decisionengine/framework/config/tests/de/minimal_python.conf
@@ -4,5 +4,6 @@
     'max_file_size': 200 * 1000000,
     'max_backup_count': 6,
     'log_level': "DEBUG",
+    'start_q_logger': "False",
   }
 }

--- a/src/decisionengine/framework/config/tests/de/minimal_with_address.jsonnet
+++ b/src/decisionengine/framework/config/tests/de/minimal_with_address.jsonnet
@@ -4,6 +4,7 @@
     "log_file": "/dev/null",
     "max_file_size": 200000000,
     "max_backup_count": 6,
-    "log_level": "DEBUG"
+    "log_level": "DEBUG",
+    "start_q_logger": "False",
   }
 }

--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -28,6 +28,7 @@ from decisionengine.framework.engine.Workers import Worker, Workers
 from decisionengine.framework.modules.logging_configDict import LOGGERNAME, DELOGGER_CHANNEL_NAME
 import decisionengine.framework.dataspace.datablock as datablock
 import decisionengine.framework.dataspace.dataspace as dataspace
+import decisionengine.framework.modules.de_logger as de_logger
 import decisionengine.framework.taskmanager.ProcessingState as ProcessingState
 import decisionengine.framework.taskmanager.TaskManager as TaskManager
 
@@ -293,6 +294,7 @@ class DecisionEngine(socketserver.ThreadingMixIn,
         self.stop_channels()
         self.reaper_stop()
         self.dataspace.close()
+        de_logger.stop_queue_logger()
         return "OK"
 
     def start_channel(self, channel_name, channel_config):

--- a/src/decisionengine/framework/engine/Workers.py
+++ b/src/decisionengine/framework/engine/Workers.py
@@ -4,11 +4,11 @@ import multiprocessing
 import os
 import threading
 
+import decisionengine.framework.modules.de_logger as de_logger
+import decisionengine.framework.modules.logging_configDict as logconf
 import decisionengine.framework.taskmanager.ProcessingState as ProcessingState
-from decisionengine.framework.modules.logging_configDict import pylogconfig as logconf
-from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
 
-MAX_CHANNEL_FILE_SIZE = 200 * 1000000
+MB = 1000000
 
 
 class Worker(multiprocessing.Process):
@@ -48,69 +48,52 @@ class Worker(multiprocessing.Process):
     def get_consumes(self):
         return self.task_manager.get_consumes()
 
-    def run(self):
-
+    def setup_logger(self):
         myname = self.task_manager.name
-        myfilename = os.path.join(
-            os.path.dirname(self.logger_config["log_file"]), myname + ".log"
-        )
+        myfilename = os.path.join(os.path.dirname(self.logger_config["log_file"]), myname + ".log")
+        start_q_logger = self.logger_config.get("start_q_logger", "True")
 
-        self.logger = structlog.getLogger(CHANNELLOGGERNAME)
+        self.logger = structlog.getLogger(logconf.CHANNELLOGGERNAME)
 
         # setting a default value here. value from config file is set in call
         # self.task_manager.set_loglevel_value after logger configuration is completed
-        logging.getLogger(CHANNELLOGGERNAME).setLevel(logging.DEBUG)
+        logging.getLogger(logconf.CHANNELLOGGERNAME).setLevel(logging.DEBUG)
 
-        # TODO:
-        # alter decisionengine.framework.modules.de_logger set_logging
-        # so we can reuse it here and reduce duplication
         logger_rotate_by = self.logger_config.get("file_rotate_by", "size")
-
-        # logconf is our global object edited in global space on purpose
-
         if logger_rotate_by == "size":
-            logconf["handlers"].update(
-                {
-                    myname: {
-                        "level": "DEBUG",
-                        "filename": myfilename,
-                        "formatter": "plain",
-                        "class": "logging.handlers.RotatingFileHandler",
-                        "maxBytes": MAX_CHANNEL_FILE_SIZE,
-                        "backupCount": self.logger_config.get("max_backup_count", 6),
-                    }
-                }
+            handler = logging.handlers.RotatingFileHandler(
+                filename=myfilename,
+                maxBytes=self.logger_config.get("max_file_size", 200 * MB),
+                backupCount=self.logger_config.get("max_backup_count", 6),
             )
+
         elif logger_rotate_by == "time":
-            logconf["handlers"].update(
-                {
-                    myname: {
-                        "level": "DEBUG",
-                        "filename": myfilename,
-                        "formatter": "plain",
-                        "class": "logging.handlers.TimedRotatingFileHandler",
-                        "when": "D",
-                        "interval": 1,
-                    }
-                }
+            handler = logging.handlers.TimedRotatingFileHandler(
+                filename=myfilename,
+                when=self.logger_config.get("rotation_time_unit", "D"),
+                interval=self.logger_config.get("rotation_time_interval", 1),
+                backupCount=self.logger_config.get("max_backup_count", 6),
             )
         else:
             raise ValueError(f"Incorrect 'logger_rotate_by':'{logger_rotate_by}:'")
 
-        logconf["loggers"].update(
-            {
-                CHANNELLOGGERNAME: {
-                    "handlers": [myname, "file_structlog_debug"],
-                }
-            }
-        )
-        logging.config.dictConfig(logconf)
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(logging.Formatter(logconf.userformat))
+
+        self.logger.addHandler(handler)
+
+        if start_q_logger == "True":
+            self.logger.addHandler(de_logger.get_queue_logger().structlog_q_handler)
+
         self.logger = self.logger.bind(module=__name__.split(".")[-1], channel=myname)
 
         channel_log_level = self.logger_config.get(
             "global_channel_log_level", "WARNING"
         )
         self.task_manager.set_loglevel_value(channel_log_level)
+
+    def run(self):
+        self.setup_logger()
         self.task_manager.run()
 
 

--- a/src/decisionengine/framework/engine/tests/config/test_channel.jsonnet
+++ b/src/decisionengine/framework/engine/tests/config/test_channel.jsonnet
@@ -1,0 +1,38 @@
+{
+  "sources": {
+    "source1": {
+      "module": "decisionengine.framework.tests.SourceNOP",
+      "parameters": {},
+      "schedule": 1
+    }
+  },
+  "transforms": {
+    "transform1": {
+      "module": "decisionengine.framework.tests.TransformNOP",
+      "parameters": {},
+      "schedule": 1
+    }
+  },
+  "logicengines": {
+    "le1": {
+      "module": "decisionengine.framework.logicengine.LogicEngine",
+      "parameters": {
+        "facts": {
+          "pass_all": "True"
+        },
+        "rules": {
+          "r1": {
+            "expression": "pass_all",
+            "actions": ["publisher1"]
+          }
+        }
+      }
+    }
+  },
+  "publishers": {
+    "publisher1": {
+      "module": "decisionengine.framework.tests.PublisherNOP",
+      "parameters": {}
+    }
+  }
+}

--- a/src/decisionengine/framework/engine/tests/test_Workers.py
+++ b/src/decisionengine/framework/engine/tests/test_Workers.py
@@ -1,0 +1,70 @@
+import gc
+import os
+
+import pytest
+
+import decisionengine.framework.config.policies as policies
+
+from decisionengine.framework.config.ValidConfig import ValidConfig
+from decisionengine.framework.engine.Workers import Worker
+from decisionengine.framework.taskmanager.TaskManager import TaskManager
+from decisionengine.framework.taskmanager.tests.fixtures import (  # noqa: F401
+    DATABASES_TO_TEST,
+    PG_DE_DB_WITH_SCHEMA,
+    PG_DE_DB_WITHOUT_SCHEMA,
+    PG_PROG,
+    SQLALCHEMY_TEMPFILE_SQLITE,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    dataspace,
+)
+
+_CWD = os.path.dirname(os.path.abspath(__file__))
+_CONFIG_PATH = os.path.join(_CWD, "../../tests/etc/decisionengine")
+_CHANNEL_CONFIG_DIR = os.path.join(_CWD, "config")
+
+channel = "test_channel"
+
+
+def get_channel_config(name):
+    return ValidConfig(os.path.join(_CHANNEL_CONFIG_DIR, name + ".jsonnet"))
+
+
+@pytest.fixture()
+@pytest.mark.usefixtures("dataspace")
+def global_config(dataspace):  # noqa: F811
+    conf = ValidConfig(policies.global_config_file(_CONFIG_PATH))
+    conf["dataspace"] = dataspace.config["dataspace"]
+    yield conf
+
+
+@pytest.fixture()
+@pytest.mark.usefixtures("global_config")
+def task_manager(global_config):
+    task_manager = TaskManager(channel, 1, get_channel_config(channel), global_config)
+    yield task_manager
+
+    gc.collect()
+
+
+@pytest.mark.usefixtures("task_manager", "global_config")
+def test_worker_name(task_manager, global_config):
+    worker = Worker(task_manager, global_config["logger"])
+
+    assert worker.name == f"DEWorker-{task_manager.name}"
+
+
+@pytest.mark.usefixtures("task_manager", "global_config")
+def test_worker_logger_sized_rotation(task_manager, global_config):
+    worker = Worker(task_manager, global_config["logger"])
+    worker.setup_logger()
+
+    assert "RotatingFileHandler" in str(worker.logger.handlers)
+
+
+@pytest.mark.usefixtures("task_manager", "global_config")
+def test_worker_logger_timed_rotation(task_manager, global_config):
+    global_config["logger"]["file_rotate_by"] = "time"
+    worker = Worker(task_manager, global_config["logger"])
+    worker.setup_logger()
+
+    assert "TimedRotatingFileHandler" in str(worker.logger.handlers)

--- a/src/decisionengine/framework/logicengine/LogicEngine.py
+++ b/src/decisionengine/framework/logicengine/LogicEngine.py
@@ -1,17 +1,13 @@
-import structlog
 import pandas
 from itertools import chain
 
 from decisionengine.framework.logicengine.RuleEngine import RuleEngine
 from decisionengine.framework.logicengine.BooleanExpression import BooleanExpression
 from decisionengine.framework.modules.Module import Module
-from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
 
 class LogicEngine(Module):
     def __init__(self, cfg):
         super().__init__(cfg)
-        self.logger = structlog.getLogger(CHANNELLOGGERNAME)
-        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], channel=self.channel_name)
         self.facts = {name: BooleanExpression(expr) for name, expr in cfg["facts"].items()}
         self.rule_engine = RuleEngine(cfg["facts"].keys(), cfg["rules"])
 

--- a/src/decisionengine/framework/modules/Module.py
+++ b/src/decisionengine/framework/modules/Module.py
@@ -17,7 +17,7 @@ class Module:
         self.channel_name = set_of_parameters["channel_name"]
 
         self.logger = structlog.getLogger(CHANNELLOGGERNAME)
-        self.logger = self.logger.bind(class_module=__name__.split(".")[-1], channel=self.channel_name)
+        self.logger = self.logger.bind(class_name=type(self).__name__, channel=self.channel_name)
 
     def get_parameters(self):
         return self.parameters

--- a/src/decisionengine/framework/modules/Publisher.py
+++ b/src/decisionengine/framework/modules/Publisher.py
@@ -11,7 +11,6 @@ class Publisher(Module):
 
     def __init__(self, set_of_parameters):
         super().__init__(set_of_parameters)
-        self.logger.bind(class_module=__name__.split(".")[-1])
 
     def publish(self, data_block=None):
         pass

--- a/src/decisionengine/framework/modules/QueueLogger.py
+++ b/src/decisionengine/framework/modules/QueueLogger.py
@@ -1,0 +1,34 @@
+import multiprocessing
+
+from logging.handlers import QueueHandler, QueueListener
+
+
+class QueueLogger:
+    def __init__(self):
+        self.structlog_q = None
+        self.structlog_q_handler = None
+        self.structlog_listener = None
+        self.initialized = False
+
+    def initialize_q(self):
+        self.structlog_q = multiprocessing.Queue(-1)
+        self.structlog_q_handler = QueueHandler(self.structlog_q)
+        self.initialized = True
+
+    def format_logger(self, logger):
+        logger.addHandler(self.structlog_q_handler)
+
+    def configure_listener(self, handlers):
+        self.structlog_listener = QueueListener(self.structlog_q, *handlers, respect_handler_level=True)
+
+    def setup_queue_logging(self, logger, handlers):
+        self.initialize_q()
+        self.format_logger(logger)
+        self.configure_listener(handlers)
+
+    def start(self):
+        self.structlog_listener.start()
+
+    def stop(self):
+        if self.initialized:
+            self.structlog_listener.stop()

--- a/src/decisionengine/framework/modules/Source.py
+++ b/src/decisionengine/framework/modules/Source.py
@@ -14,7 +14,6 @@ class Source(Module):
 
     def __init__(self, set_of_parameters):
         super().__init__(set_of_parameters)
-        self.logger.bind(class_module=__name__.split(".")[-1])
 
     # acquire: The action function for a source. Will
     # retrieve data from external sources and issue a

--- a/src/decisionengine/framework/modules/SourceProxy.py
+++ b/src/decisionengine/framework/modules/SourceProxy.py
@@ -31,7 +31,6 @@ class SourceProxy(Source.Source):
         self.data_keys = translate_all(config['Dataproducts'])
         self.retries = config.get('retries', RETRIES)
         self.retry_to = config.get('retry_timeout', RETRY_TO)
-        self.logger = self.logger.bind(class_module=__name__.split(".")[-1])
 
         # Hack - it is possible for a subclass to declare @produces,
         #        in which case, we do not want to override that.

--- a/src/decisionengine/framework/modules/Transform.py
+++ b/src/decisionengine/framework/modules/Transform.py
@@ -13,7 +13,6 @@ class Transform(Module):
     def __init__(self, set_of_parameters):
         super().__init__(set_of_parameters)
         self.name_list = []
-        self.logger.bind(class_module=__name__.split(".")[-1])
     """
     decide: The action function for a Transform. Will
     retrieve from the DataBlock the data products

--- a/src/decisionengine/framework/modules/de_logger.py
+++ b/src/decisionengine/framework/modules/de_logger.py
@@ -1,28 +1,33 @@
 """
 Logger to use in all modules
 """
-import os
 import logging
-import logging.handlers
 import logging.config
+import logging.handlers
+import os
+
 import structlog
-from decisionengine.framework.modules.logging_configDict import pylogconfig as logconf
-from decisionengine.framework.modules.logging_configDict import LOGGERNAME, DELOGGER_CHANNEL_NAME
+
+import decisionengine.framework.modules.logging_configDict as logconf
+import decisionengine.framework.modules.QueueLogger as QueueLogger
 
 MB = 1000000
 
-logger = structlog.getLogger(LOGGERNAME)
-logger = logger.bind(module=__name__.split(".")[-1], channel=DELOGGER_CHANNEL_NAME)
+delogger = structlog.getLogger(logconf.LOGGERNAME)
+delogger = delogger.bind(module=__name__.split(".")[-1], channel=logconf.DELOGGER_CHANNEL_NAME)
+
+queue_logger = QueueLogger.QueueLogger()
 
 
-def set_logging(
-    log_level,
-    file_rotate_by,
+def configure_logging(
+    log_level="DEBUG",
+    file_rotate_by="size",
     rotation_time_unit="D",
     rotation_interval=1,
     max_backup_count=6,
     max_file_size=200 * MB,
     log_file_name="/tmp/decision_engine_logs/decisionengine.log",
+    start_q_logger="True",
 ):
     """
 
@@ -46,67 +51,50 @@ def set_logging(
     if dirname and not os.path.exists(dirname):
         os.makedirs(dirname)
 
-    logger.setLevel(getattr(logging, log_level.upper()))
-    if logger.handlers:
-        logger.debug('Reusing existing logging handlers')
+    delogger.setLevel(getattr(logging, log_level.upper()))
+    if delogger.handlers:
+        delogger.debug("Reusing existing logging handlers")
         return None
 
-    # logconf is our global object edited in global space on purpose
-
-    logconf["handlers"]["de_file_debug"].update({"filename": f"{log_file_name}_debug.log"})
-    logconf["handlers"]["de_file_info"].update({"filename": f"{log_file_name}.log"})
-    logconf["handlers"]["file_structlog_debug"].update({"filename": f"{log_file_name}_structlog_debug.log"})
+    # configure handlers
+    handlers_list = []
 
     if file_rotate_by == "size":
-        logconf["handlers"]["de_file_debug"].update(
-            {
-                "class": "logging.handlers.RotatingFileHandler",
-                "maxBytes": max_file_size,
-                "backupCount": max_backup_count,
-            }
-        )
-        logconf["handlers"]["de_file_info"].update(
-            {
-                "class": "logging.handlers.RotatingFileHandler",
-                "maxBytes": max_file_size,
-                "backupCount": max_backup_count,
-            }
-        )
-        logconf["handlers"]["file_structlog_debug"].update(
-            {
-                "class": "logging.handlers.RotatingFileHandler",
-                "maxBytes": max_file_size,
-                "backupCount": max_backup_count,
-            }
-        )
+        for files in logconf.de_outfile_info:
+            handler = logging.handlers.RotatingFileHandler(
+                filename=f"{log_file_name}" + files[0], maxBytes=max_file_size, backupCount=max_backup_count
+            )
+            handler.setLevel(files[1])
+            handler.setFormatter(logging.Formatter(files[2]))
+            handlers_list.append(handler)
 
     elif file_rotate_by == "time":
-        logconf["handlers"]["de_file_debug"].update(
-            {
-                "class": "logging.handlers.TimedRotatingFileHandler",
-                "when": rotation_time_unit,
-                "interval": rotation_interval,
-            }
-        )
-        logconf["handlers"]["de_file_info"].update(
-            {
-                "class": "logging.handlers.TimedRotatingFileHandler",
-                "when": rotation_time_unit,
-                "interval": rotation_interval,
-            }
-        )
-        logconf["handlers"]["file_structlog_debug"].update(
-            {
-                "class": "logging.handlers.TimedRotatingFileHandler",
-                "when": rotation_time_unit,
-                "interval": rotation_interval,
-            }
-        )
+        for files in logconf.de_outfile_info:
+            handler = logging.handlers.TimedRotatingFileHandler(
+                filename=f"{log_file_name}" + files[0],
+                when=rotation_time_unit,
+                interval=rotation_interval,
+                backupCount=max_backup_count,
+            )
+            handler.setLevel(files[1])
+            handler.setFormatter(logging.Formatter(files[2]))
+            handlers_list.append(handler)
+
     else:
         raise ValueError(f"Incorrect 'file_rotate_by':'{file_rotate_by}:'")
 
-    logging.config.dictConfig(logconf)
-    logger.debug("de logging setup complete")
+    structlog_handlers_list = [handlers_list.pop(i) for i in logconf.structlog_file_index]
+
+    # setup standard file handlers
+    for h in handlers_list:
+        delogger.addHandler(h)
+
+    # setup the queue logger
+    if start_q_logger == "True":
+        queue_logger.setup_queue_logging(delogger, structlog_handlers_list)
+        queue_logger.start()
+
+    delogger.debug("de logging setup complete")
 
 
 def get_logger():
@@ -114,11 +102,23 @@ def get_logger():
     get default logger - "decisionengine"
     :rtype: :class:`logging.Logger` - rotating file logger
     """
-    return logger
+    return delogger
+
+
+def get_queue_logger():
+    """
+    get QueueLogger which owns the logging queues and listeners
+    :rtype: :class:`decisionengine.framework.modules.QueueLogger``
+    """
+    return queue_logger
+
+
+def stop_queue_logger():
+    queue_logger.stop()
 
 
 if __name__ == "__main__":
-    set_logging(
+    configure_logging(
         "ERROR",
         "size",
         "D",
@@ -127,6 +127,6 @@ if __name__ == "__main__":
         max_file_size=100000,
         log_file_name=f"{os.environ.get('HOME')}/de_log/decision_engine_log0",
     )
-    logger.error("THIS IS ERROR")
-    logger.info("THIS IS INFO")
-    logger.debug("THIS IS DEBUG")
+    delogger.error("THIS IS ERROR")
+    delogger.info("THIS IS INFO")
+    delogger.debug("THIS IS DEBUG")

--- a/src/decisionengine/framework/modules/tests/test_QueueLogger.py
+++ b/src/decisionengine/framework/modules/tests/test_QueueLogger.py
@@ -1,0 +1,65 @@
+import gc
+import logging
+
+import pytest
+
+import decisionengine.framework.modules.QueueLogger as QueueLogger
+
+
+@pytest.fixture()
+def queue_logger_setup():
+    q_log = QueueLogger.QueueLogger()
+    yield q_log
+
+    del q_log
+
+
+@pytest.fixture()
+def log_setup():
+    test_log = logging.getLogger('test_logger')
+    yield test_log
+
+    del test_log
+
+
+@pytest.fixture()
+def handler_setup():
+    test_handler = [logging.FileHandler(filename="/tmp/decisionengine.log")]
+    yield test_handler
+
+    del test_handler
+
+
+@pytest.fixture(autouse=True)
+def setup_queue_logging(queue_logger_setup, log_setup, handler_setup):
+    queue_logger_setup.setup_queue_logging(log_setup, handler_setup)
+    yield queue_logger_setup
+
+    del queue_logger_setup
+
+
+@pytest.mark.usefixtures("queue_logger_setup", "log_setup", "handler_setup")
+def test_setup_queue_logging(queue_logger_setup, log_setup, handler_setup):
+    #queue_logger_setup.setup_queue_logging(log_setup, handler_setup)
+
+    assert queue_logger_setup.structlog_q is not None
+    assert isinstance(queue_logger_setup.structlog_q_handler, logging.handlers.QueueHandler)
+    assert "QueueHandler" in str(log_setup.handlers)
+    assert isinstance(queue_logger_setup.structlog_listener, logging.handlers.QueueListener)
+
+
+@pytest.mark.usefixtures("queue_logger_setup", "log_setup", "handler_setup")
+def test_start_queue_logger(queue_logger_setup, log_setup, handler_setup):
+    #queue_logger_setup.setup_queue_logging(log_setup, handler_setup)
+    queue_logger_setup.start()
+
+    assert queue_logger_setup.structlog_listener._thread is not None
+
+
+@pytest.mark.usefixtures("queue_logger_setup", "log_setup", "handler_setup")
+def test_stop_queue_logger(queue_logger_setup, log_setup, handler_setup):
+    #queue_logger_setup.setup_queue_logging(log_setup, handler_setup)
+    queue_logger_setup.start()
+    queue_logger_setup.stop()
+
+    assert queue_logger_setup.structlog_listener._thread is None

--- a/src/decisionengine/framework/modules/tests/test_de_logger.py
+++ b/src/decisionengine/framework/modules/tests/test_de_logger.py
@@ -29,7 +29,7 @@ def log_setup():
 def test_by_nonsense_is_err(log_setup):
     with pytest.raises(ValueError) as err, tempfile.NamedTemporaryFile() as log:
         log.flush()
-        de_logger.set_logging(
+        de_logger.configure_logging(
             log_level="INFO",
             max_backup_count=6,
             file_rotate_by="nonsense",
@@ -44,8 +44,13 @@ def test_by_nonsense_is_err(log_setup):
 def test_by_size(log_setup):
     with tempfile.NamedTemporaryFile() as log:
         log.flush()
-        de_logger.set_logging(
-            log_level="INFO", max_backup_count=6, file_rotate_by="size", max_file_size=1000000, log_file_name=log.name
+        de_logger.configure_logging(
+            log_level="INFO",
+            max_backup_count=6,
+            file_rotate_by="size",
+            max_file_size=1000000,
+            log_file_name=log.name,
+            start_q_logger="False",
         )
 
         assert log_setup.hasHandlers() is True
@@ -59,8 +64,13 @@ def test_by_size(log_setup):
 def test_by_time(log_setup):
     with tempfile.NamedTemporaryFile() as log:
         log.flush()
-        de_logger.set_logging(
-            log_level="INFO", rotation_interval=1, file_rotate_by="time", rotation_time_unit="D", log_file_name=log.name
+        de_logger.configure_logging(
+            log_level="INFO",
+            rotation_interval=1,
+            file_rotate_by="time",
+            rotation_time_unit="D",
+            log_file_name=log.name,
+            start_q_logger="False",
         )
 
         assert log_setup.hasHandlers() is True

--- a/src/decisionengine/framework/modules/tests/test_de_logger.py
+++ b/src/decisionengine/framework/modules/tests/test_de_logger.py
@@ -25,7 +25,6 @@ def log_setup():
 
 
 @pytest.mark.usefixtures("log_setup")
-@pytest.mark.skip(reason="test failing under structlog config, needs re-working")
 def test_by_nonsense_is_err(log_setup):
     with pytest.raises(ValueError) as err, tempfile.NamedTemporaryFile() as log:
         log.flush()
@@ -40,7 +39,6 @@ def test_by_nonsense_is_err(log_setup):
 
 
 @pytest.mark.usefixtures("log_setup")
-@pytest.mark.skip(reason="test failing under structlog config, needs re-working")
 def test_by_size(log_setup):
     with tempfile.NamedTemporaryFile() as log:
         log.flush()
@@ -60,7 +58,6 @@ def test_by_size(log_setup):
 
 
 @pytest.mark.usefixtures("log_setup")
-@pytest.mark.skip(reason="test failing under structlog config, needs re-working")
 def test_by_time(log_setup):
     with tempfile.NamedTemporaryFile() as log:
         log.flush()

--- a/src/decisionengine/framework/tests/etc/decisionengine/decision_engine.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/decision_engine.jsonnet
@@ -7,7 +7,8 @@
     "rotation_time_interval":1,
     "file_rotate_by":"size",
     "log_level": "DEBUG",
-    "global_channel_log_level":"DEBUG"
+    "global_channel_log_level":"DEBUG",
+    "start_q_logger": "False",
   },
 
   "server_address" : ["localhost",8888],


### PR DESCRIPTION
This PR consist of two commits, one that cherry-picks the code from PR #563  and one that cherry-picks the code from PR #515 .

PR#563: Steve was seeing race conditions in the decision engine structured log file when running multiple channels. This is because the standard logging library is not thread-safe. When multiple channels are running and logging data is being pushed through 'quickly', the channels compete with each other to have their logs written to the single decisionengine_structlog file. I have added a QueueHandler and QueueListener to handle the logging into the structured log file from the channel processes and the main process in a thread-made manner.

PR#515: Kyle added simplifications to some of the logger definitions in the modules, based on the fact that the modules inherit from the Module class, which defines the specifics of the logger. 