### PR TITLE
Set Apache 2.0 license and added REUSE compliance

### DIFF
--- a/.Jenkins/workflows/Jenkinsfile
+++ b/.Jenkins/workflows/Jenkinsfile
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+// SPDX-License-Identifier: Apache-2.0
+
 pipeline {
     agent { label 'docker' }
     stages{

--- a/.github/actions/python-command-in-sl7-container/action.yaml
+++ b/.github/actions/python-command-in-sl7-container/action.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: "Python Action"
 description: "Run python3 action in preconfigured SL7 container image"
 inputs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 name: Run CI
 on:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # For most projects, this workflow file will not need changing; you simply need
 # to commit it to your repository.
 #

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 name: Make Our Github Pages
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 name: Linters
 on:
@@ -104,6 +107,13 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/src
         run: |
           pylint src/decisionengine/
+
+  license-check:
+    name: Run REUSE to check license compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: fsfe/reuse-action@v1
 
   pre-commit:
     name: Validate our pre-commit hooks pass

--- a/.github/workflows/pytest-in-sl7.yaml
+++ b/.github/workflows/pytest-in-sl7.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 name: Test in EL7 container
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,10 @@ repos:
       - id: pyupgrade
         args:
           - "--py36-plus"
+  - repo: "https://github.com/fsfe/reuse-tool"
+    rev: latest
+    hooks:
+      - id: reuse
 #  jsonnetfmt requires golang 1.11+ and git 2.0, uncomment when we are compatible
 #  - repo: https://github.com/google/go-jsonnet.git
 #    rev: 2f2f6d664f06d064c4b3525ea34a789c1ac95cda

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,22 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: decisionengine
+Upstream-Contact: HEPCloud team <>
+Source: https://github.com/HEPCloud/decisionengine
+
+# Sample paragraph, commented out:
+#
+# Files: src/*
+# Copyright: $YEAR $NAME <$CONTACT>
+# License: ...
+
+Files: src/*.jsonnet src/*.libsonnet src/*/readme src/*.conf src/*.fixture src/*.csv src/*/test_filename_typo.jsonet src/*/log_sample.txt
+Copyright: 2017 Fermi Research Alliance, LLC
+License: Apache-2.0
+
+Files: .codecov.yml .coveragerc .editorconfig .gitignore .lgtm.yaml .pep8speaks.yml .pre-commit-config.yaml .pylintrc config/decision_engine.jsonnet pyproject.toml
+Copyright: 2017 Fermi Research Alliance, LLC
+License: Apache-2.0
+
+Files: package/rpm/* package/systemd/*
+Copyright: 2017 Fermi Research Alliance, LLC
+License: Apache-2.0

--- a/.reuse/templates/compact.jinja2
+++ b/.reuse/templates/compact.jinja2
@@ -1,0 +1,6 @@
+{% for copyright_line in copyright_lines %}
+{{ copyright_line }}
+{% endfor %}
+{% for expression in spdx_expressions %}
+SPDX-License-Identifier: {{ expression }}
+{% endfor %}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # HEPCloud Decision Engine
 
 HEPCloud Decision Engine framework development

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,34 +1,202 @@
-Fermilab Software Legal Information (BSD License)
-Copyright (c) 2009, Fermi Research Alliance, LLC
-All rights reserved.
 
-Copyright (2009). Fermi Research Alliance, LLC.
-This software was produced under U.S. Government contract DE-AC02-07CH11359
-for Fermi National Accelerator Laboratory (Fermilab), which is operated by
-Fermi Research Alliance, LLC for the U.S. Department of Energy.
-The U.S. Government has rights to use, reproduce, and distribute this software.
- NEITHER THE GOVERNMENT NOR FERMI RESEARCH ALLIANCE, LLC MAKES ANY WARRANTY,
-EXPRESS OR IMPLIED, OR ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Additionally, redistribution and use in source and binary forms, with or
-without modification, are permitted provided that the following conditions
-are met:
-- Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-- Neither the name of Fermi Research Alliance, LLC, Fermi National Accelerator
-  Laboratory, Fermilab, the U.S. Government, nor the names of its contributors
-  may be used to endorse or promote products derived from this software
-  without specific prior written permission.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-THIS SOFTWARE IS PROVIDED BY FERMI RESEARCH ALLIANCE, LLC AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # HEPCloud Decision Engine
 
 The Decision Engine is a critical component of the HEP Cloud Facility. It provides the

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Minimal makefile for Sphinx documentation
 #
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,15 @@
+<!--
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0
+-->
+
+## Directory containing users documents
+
+To manually build the documents run:
+
+```
 yum install python3-sphinx
 make rst
 make html
 make latexpdf
+```

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/doc/source/docker.rst
+++ b/doc/source/docker.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Decisionengine Docker image
 ===========================
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Welcome to decisionengine's documentation!
 ==========================================
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Installing and running HEPCloud's Decision Engine
 =================================================
 

--- a/doc/source/jenkins.rst
+++ b/doc/source/jenkins.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Decisionengine CI with Jenkins pipeline
 =======================================
 

--- a/doc/source/jenkins_pic/DE_nightly_ci_build_branch_cfg.png.license
+++ b/doc/source/jenkins_pic/DE_nightly_ci_build_branch_cfg.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0

--- a/doc/source/jenkins_pic/DE_nightly_ci_build_dashboard.png.license
+++ b/doc/source/jenkins_pic/DE_nightly_ci_build_dashboard.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0

--- a/doc/source/jenkins_pic/DE_nightly_ci_build_proj_cfg.png.license
+++ b/doc/source/jenkins_pic/DE_nightly_ci_build_proj_cfg.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0

--- a/doc/source/jenkins_pic/DE_nightly_ci_build_schedule_cfg.png.license
+++ b/doc/source/jenkins_pic/DE_nightly_ci_build_schedule_cfg.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0

--- a/doc/source/jenkins_pic/DE_pipeline_PR_icon.png.license
+++ b/doc/source/jenkins_pic/DE_pipeline_PR_icon.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0

--- a/doc/source/jenkins_pic/DE_pipeline_build_button.png.license
+++ b/doc/source/jenkins_pic/DE_pipeline_build_button.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0

--- a/doc/source/jenkins_pic/DE_pipeline_build_params.png.license
+++ b/doc/source/jenkins_pic/DE_pipeline_build_params.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0

--- a/doc/source/jenkins_pic/DE_pipeline_dashboard.png.license
+++ b/doc/source/jenkins_pic/DE_pipeline_dashboard.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0

--- a/doc/source/jenkins_pic/DE_pipeline_download_icon.png.license
+++ b/doc/source/jenkins_pic/DE_pipeline_download_icon.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+SPDX-License-Identifier: Apache-2.0

--- a/doc/source/redis.rst
+++ b/doc/source/redis.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Decisionengine Redis broker
 ===========================
 

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Release Notes
 =============
 

--- a/doc/source/release_notes/release_notes_1.1.rst
+++ b/doc/source/release_notes/release_notes_1.1.rst
@@ -1,3 +1,5 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
 
 Release 1.1.0
 -------------

--- a/doc/source/release_notes/release_notes_1.2.rst
+++ b/doc/source/release_notes/release_notes_1.2.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Release 1.2.0
 -------------
 

--- a/doc/source/release_notes/release_notes_1.3.rst
+++ b/doc/source/release_notes/release_notes_1.3.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Release 1.3.0
 -------------
 

--- a/doc/source/release_notes/release_notes_1.4.rst
+++ b/doc/source/release_notes/release_notes_1.4.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Release 1.4.1
 -------------
 

--- a/doc/source/release_notes/release_notes_1.5.rst
+++ b/doc/source/release_notes/release_notes_1.5.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Release 1.5.0
 -------------
 

--- a/doc/source/release_notes/release_notes_1.6.rst
+++ b/doc/source/release_notes/release_notes_1.6.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Release 1.6.2
 -------------
 

--- a/doc/source/release_notes/release_notes_1.7.rst
+++ b/doc/source/release_notes/release_notes_1.7.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+.. SPDX-License-Identifier: Apache-2.0
+
 Release 1.7.0
 -------------
 

--- a/package/ci/Dockerfile
+++ b/package/ci/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ARG BASEIMAGE=hepcloud/decision-engine-ci
 FROM ${BASEIMAGE}
 COPY python3-entrypoint.sh /entrypoint.sh

--- a/package/ci/python3-entrypoint.sh
+++ b/package/ci/python3-entrypoint.sh
@@ -1,4 +1,8 @@
 #!/bin/bash -xe
+
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 CMD=${1:- -m pytest}
 LOGFILE=${2:- pytest.log}
 

--- a/package/container/Dockerfile
+++ b/package/container/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # on dockerhub hepcloud/decision-engine-ci
 FROM sl:7
 LABEL description="hepcloud/decision-engine"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Eventually this should move to pyproject.toml
 #  but setuptools must first gain support for parsing that
 
@@ -56,6 +59,7 @@ devel_req = [
     "pytest-xdist[psutil] >= 2.3.0",
     "pre-commit >= 2.13.0",
     "pylint >= 2.7.4",
+    "reuse",
     "importlib_resources >= 5.1.2; python_version <= '3.8'",
     "sphinx >= 3.5.3",
     "sphinx_rtd_theme >= 0.5.1",

--- a/src/decisionengine/framework/__init__.py
+++ b/src/decisionengine/framework/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from .about import __version__  # noqa: F401

--- a/src/decisionengine/framework/about.py
+++ b/src/decisionengine/framework/about.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
     PEP-0396 provides instructions for providing module versions
     While we are at it, add a few other useful bits

--- a/src/decisionengine/framework/config/ChannelConfigHandler.py
+++ b/src/decisionengine/framework/config/ChannelConfigHandler.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Manager of channel configurations.
 

--- a/src/decisionengine/framework/config/ValidConfig.py
+++ b/src/decisionengine/framework/config/ValidConfig.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 ValidConfig represents a valid JSON document.
 

--- a/src/decisionengine/framework/config/policies.py
+++ b/src/decisionengine/framework/config/policies.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Decision-engine default configuration policies.
 

--- a/src/decisionengine/framework/config/tests/test_config.py
+++ b/src/decisionengine/framework/config/tests/test_config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import re
 

--- a/src/decisionengine/framework/config/tests/test_de_std.py
+++ b/src/decisionengine/framework/config/tests/test_de_std.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 
 import pytest

--- a/src/decisionengine/framework/config/tests/test_policies.py
+++ b/src/decisionengine/framework/config/tests/test_policies.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 import decisionengine.framework.config.policies as policies

--- a/src/decisionengine/framework/dataspace/datablock.py
+++ b/src/decisionengine/framework/dataspace/datablock.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import ast
 import copy
 import pickle

--- a/src/decisionengine/framework/dataspace/datasource.py
+++ b/src/decisionengine/framework/dataspace/datasource.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import abc
 
 import structlog

--- a/src/decisionengine/framework/dataspace/datasources/null.py
+++ b/src/decisionengine/framework/dataspace/datasources/null.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import decisionengine.framework.dataspace.datasource as ds
 
 

--- a/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/__init__.py
+++ b/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Top level import so we can rationally segment items of the ORM
 """

--- a/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/datasource_api.py
+++ b/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/datasource_api.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 The datasource layer for our abstraction
 """

--- a/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/db_schema.py
+++ b/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/db_schema.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 The table layout and utilities for our SQLAlchemy ORM
 """

--- a/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/utils.py
+++ b/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
     Code not written by us
 """

--- a/src/decisionengine/framework/dataspace/datasources/tests/fixtures.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/fixtures.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """pytest fixtures/constants"""
 import datetime
 import gc

--- a/src/decisionengine/framework/dataspace/datasources/tests/test_datasource_api.py
+++ b/src/decisionengine/framework/dataspace/datasources/tests/test_datasource_api.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # pylint: disable=redefined-outer-name,wrong-import-order,unused-import
 """
 This test plan covers a generic dataspace object via

--- a/src/decisionengine/framework/dataspace/dataspace.py
+++ b/src/decisionengine/framework/dataspace/dataspace.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import importlib
 
 import structlog

--- a/src/decisionengine/framework/dataspace/maintain.py
+++ b/src/decisionengine/framework/dataspace/maintain.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import threading
 
 import structlog

--- a/src/decisionengine/framework/dataspace/tests/fixtures.py
+++ b/src/decisionengine/framework/dataspace/tests/fixtures.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import gc
 
 import pytest

--- a/src/decisionengine/framework/dataspace/tests/test_Reaper.py
+++ b/src/decisionengine/framework/dataspace/tests/test_Reaper.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import contextlib
 import gc
 import logging

--- a/src/decisionengine/framework/dataspace/tests/test_datablock.py
+++ b/src/decisionengine/framework/dataspace/tests/test_datablock.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import ast
 
 import pytest

--- a/src/decisionengine/framework/dataspace/tests/test_datablock_zlib.py
+++ b/src/decisionengine/framework/dataspace/tests/test_datablock_zlib.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import ast
 import pickle
 import zlib

--- a/src/decisionengine/framework/dataspace/tests/test_datasource.py
+++ b/src/decisionengine/framework/dataspace/tests/test_datasource.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.dataspace.datasource import DataSource
 
 

--- a/src/decisionengine/framework/dataspace/tests/test_dataspace.py
+++ b/src/decisionengine/framework/dataspace/tests/test_dataspace.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import datetime
 
 import pytest

--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Main loop for Decision Engine.
 The following environment variable points to decision engine configuration file:

--- a/src/decisionengine/framework/engine/Workers.py
+++ b/src/decisionengine/framework/engine/Workers.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import multiprocessing
 import os

--- a/src/decisionengine/framework/engine/de_client.py
+++ b/src/decisionengine/framework/engine/de_client.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import xmlrpc.client
 

--- a/src/decisionengine/framework/engine/de_query_tool.py
+++ b/src/decisionengine/framework/engine/de_query_tool.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import xmlrpc.client
 

--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """pytest defaults"""
 import gc
 import logging

--- a/src/decisionengine/framework/engine/tests/test_client_only.py
+++ b/src/decisionengine/framework/engine/tests/test_client_only.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import re
 import subprocess

--- a/src/decisionengine/framework/engine/tests/test_query_tool_only.py
+++ b/src/decisionengine/framework/engine/tests/test_query_tool_only.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import re
 import subprocess
 

--- a/src/decisionengine/framework/engine/tests/test_startup.py
+++ b/src/decisionengine/framework/engine/tests/test_startup.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import tempfile
 
 import pytest

--- a/src/decisionengine/framework/logicengine/BooleanExpression.py
+++ b/src/decisionengine/framework/logicengine/BooleanExpression.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # A BooleanExpression represents one expression known to the LogicEngine.
 
 # The intent is that user-supplied expressions can make use of objects

--- a/src/decisionengine/framework/logicengine/FactLookup.py
+++ b/src/decisionengine/framework/logicengine/FactLookup.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import structlog
 
 from toposort import toposort_flatten

--- a/src/decisionengine/framework/logicengine/LogicEngine.py
+++ b/src/decisionengine/framework/logicengine/LogicEngine.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from itertools import chain
 
 import pandas

--- a/src/decisionengine/framework/logicengine/Rule.py
+++ b/src/decisionengine/framework/logicengine/Rule.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.logicengine.BooleanExpression import BooleanExpression
 
 

--- a/src/decisionengine/framework/logicengine/RuleEngine.py
+++ b/src/decisionengine/framework/logicengine/RuleEngine.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import structlog
 
 from decisionengine.framework.logicengine.FactLookup import FactLookup

--- a/src/decisionengine/framework/logicengine/tests/test_bool_function_name.py
+++ b/src/decisionengine/framework/logicengine/tests/test_bool_function_name.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import ast
 
 import pytest

--- a/src/decisionengine/framework/logicengine/tests/test_cascaded_rules.py
+++ b/src/decisionengine/framework/logicengine/tests/test_cascaded_rules.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pandas as pd
 import pytest
 

--- a/src/decisionengine/framework/logicengine/tests/test_construction.py
+++ b/src/decisionengine/framework/logicengine/tests/test_construction.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from decisionengine.framework.logicengine.LogicEngine import LogicEngine

--- a/src/decisionengine/framework/logicengine/tests/test_duplicate_fact_names.py
+++ b/src/decisionengine/framework/logicengine/tests/test_duplicate_fact_names.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.logicengine.LogicEngine import LogicEngine
 
 

--- a/src/decisionengine/framework/logicengine/tests/test_facts.py
+++ b/src/decisionengine/framework/logicengine/tests/test_facts.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from decisionengine.framework.logicengine.BooleanExpression import _facts_globals, BooleanExpression

--- a/src/decisionengine/framework/logicengine/tests/test_fail_on_error.py
+++ b/src/decisionengine/framework/logicengine/tests/test_fail_on_error.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from decisionengine.framework.logicengine.LogicEngine import LogicEngine

--- a/src/decisionengine/framework/logicengine/tests/test_pandas_fact.py
+++ b/src/decisionengine/framework/logicengine/tests/test_pandas_fact.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pandas as pd
 import pytest
 

--- a/src/decisionengine/framework/logicengine/tests/test_rule_with_negated_fact.py
+++ b/src/decisionengine/framework/logicengine/tests/test_rule_with_negated_fact.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pandas as pd
 import pytest
 

--- a/src/decisionengine/framework/logicengine/tests/test_simple_configuration.py
+++ b/src/decisionengine/framework/logicengine/tests/test_simple_configuration.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pandas as pd
 import pytest
 

--- a/src/decisionengine/framework/managers/ComponentManager.py
+++ b/src/decisionengine/framework/managers/ComponentManager.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Decision Engine ComponentManager
 (Base class for ChannelManager and SourceManager)

--- a/src/decisionengine/framework/modules/EmptySource.py
+++ b/src/decisionengine/framework/modules/EmptySource.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This dummy source takes the name of a source datablock
 from config file as parameter "data_product_name" and produces

--- a/src/decisionengine/framework/modules/Module.py
+++ b/src/decisionengine/framework/modules/Module.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import OrderedDict
 from typing import Any
 

--- a/src/decisionengine/framework/modules/Publisher.py
+++ b/src/decisionengine/framework/modules/Publisher.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import describe
 from decisionengine.framework.modules.describe import Parameter, supports_config
 from decisionengine.framework.modules.Module import consumes, Module

--- a/src/decisionengine/framework/modules/Source.py
+++ b/src/decisionengine/framework/modules/Source.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pprint
 import sys
 

--- a/src/decisionengine/framework/modules/SourceProxy.py
+++ b/src/decisionengine/framework/modules/SourceProxy.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Fill in data from another channel data block
 """

--- a/src/decisionengine/framework/modules/Transform.py
+++ b/src/decisionengine/framework/modules/Transform.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import describe
 from decisionengine.framework.modules.describe import Parameter, supports_config
 from decisionengine.framework.modules.Module import consumes, Module, produces

--- a/src/decisionengine/framework/modules/de_logger.py
+++ b/src/decisionengine/framework/modules/de_logger.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Logger to use in all modules
 """

--- a/src/decisionengine/framework/modules/describe.py
+++ b/src/decisionengine/framework/modules/describe.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 from decisionengine.framework.modules.print_description import (

--- a/src/decisionengine/framework/modules/logging_configDict.py
+++ b/src/decisionengine/framework/modules/logging_configDict.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Global Logger config dictionary used by all loggers (in their own subkeys)
 """

--- a/src/decisionengine/framework/modules/print_description.py
+++ b/src/decisionengine/framework/modules/print_description.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import inspect
 import pathlib
 import sys

--- a/src/decisionengine/framework/modules/tests/test_EmptySource.py
+++ b/src/decisionengine/framework/modules/tests/test_EmptySource.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from decisionengine.framework.modules.EmptySource import EmptySource, pd

--- a/src/decisionengine/framework/modules/tests/test_Module.py
+++ b/src/decisionengine/framework/modules/tests/test_Module.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules.Module import Module
 
 

--- a/src/decisionengine/framework/modules/tests/test_Publisher.py
+++ b/src/decisionengine/framework/modules/tests/test_Publisher.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules.Publisher import Publisher
 
 

--- a/src/decisionengine/framework/modules/tests/test_Source.py
+++ b/src/decisionengine/framework/modules/tests/test_Source.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules.Source import Source
 
 

--- a/src/decisionengine/framework/modules/tests/test_Transform.py
+++ b/src/decisionengine/framework/modules/tests/test_Transform.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules.Transform import Transform
 
 

--- a/src/decisionengine/framework/modules/tests/test_de_logger.py
+++ b/src/decisionengine/framework/modules/tests/test_de_logger.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import gc
 import tempfile
 

--- a/src/decisionengine/framework/modules/tests/test_module_decorators.py
+++ b/src/decisionengine/framework/modules/tests/test_module_decorators.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from decisionengine.framework.modules import Publisher, Source

--- a/src/decisionengine/framework/modules/tests/test_translate_product_name.py
+++ b/src/decisionengine/framework/modules/tests/test_translate_product_name.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from decisionengine.framework.modules.translate_product_name import translate, translate_all

--- a/src/decisionengine/framework/modules/translate_product_name.py
+++ b/src/decisionengine/framework/modules/translate_product_name.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # The functionality provided here supports the translation of one
 # string to another using the syntax 'old -> new', subject to the
 # following constraints:

--- a/src/decisionengine/framework/taskmanager/ProcessingState.py
+++ b/src/decisionengine/framework/taskmanager/ProcessingState.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 The ProcessingState class can represent any of the following task-manager states:
 

--- a/src/decisionengine/framework/taskmanager/TaskManager.py
+++ b/src/decisionengine/framework/taskmanager/TaskManager.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Task manager
 """

--- a/src/decisionengine/framework/taskmanager/module_graph.py
+++ b/src/decisionengine/framework/taskmanager/module_graph.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Ensure no circularities in produces and consumes.
 """

--- a/src/decisionengine/framework/taskmanager/tests/NoSource.py
+++ b/src/decisionengine/framework/taskmanager/tests/NoSource.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+
 class NoSource:
     def __init__(self, parameters):
         pass

--- a/src/decisionengine/framework/taskmanager/tests/TwoSources.py
+++ b/src/decisionengine/framework/taskmanager/tests/TwoSources.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules.Source import Source
 
 

--- a/src/decisionengine/framework/taskmanager/tests/fixtures.py
+++ b/src/decisionengine/framework/taskmanager/tests/fixtures.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.dataspace.datasources.tests.fixtures import mock_data_block
 from decisionengine.framework.dataspace.tests.fixtures import (
     DATABASES_TO_TEST,

--- a/src/decisionengine/framework/taskmanager/tests/test_module_graph.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_module_graph.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest.mock import patch
 
 from decisionengine.framework.taskmanager.module_graph import ensure_no_circularities

--- a/src/decisionengine/framework/taskmanager/tests/test_module_inference.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_module_inference.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from decisionengine.framework.modules.Source import Source

--- a/src/decisionengine/framework/taskmanager/tests/test_processing_state.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_processing_state.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import multiprocessing
 import time
 

--- a/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
+++ b/src/decisionengine/framework/taskmanager/tests/test_task_manager.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import threading
 

--- a/src/decisionengine/framework/tests/ABTransform.py
+++ b/src/decisionengine/framework/tests/ABTransform.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import Transform
 
 

--- a/src/decisionengine/framework/tests/BATransform.py
+++ b/src/decisionengine/framework/tests/BATransform.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import Transform
 
 

--- a/src/decisionengine/framework/tests/DynamicPublisher.py
+++ b/src/decisionengine/framework/tests/DynamicPublisher.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import Publisher
 from decisionengine.framework.modules.Publisher import Parameter
 

--- a/src/decisionengine/framework/tests/DynamicSource.py
+++ b/src/decisionengine/framework/tests/DynamicSource.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import Source
 from decisionengine.framework.modules.Source import Parameter
 

--- a/src/decisionengine/framework/tests/DynamicTransform.py
+++ b/src/decisionengine/framework/tests/DynamicTransform.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import Transform
 from decisionengine.framework.modules.Transform import Parameter
 

--- a/src/decisionengine/framework/tests/ErrorOnAcquire.py
+++ b/src/decisionengine/framework/tests/ErrorOnAcquire.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import Source
 
 

--- a/src/decisionengine/framework/tests/FailingPublisher.py
+++ b/src/decisionengine/framework/tests/FailingPublisher.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import Publisher
 
 

--- a/src/decisionengine/framework/tests/FailingSourceNOP.py
+++ b/src/decisionengine/framework/tests/FailingSourceNOP.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import Source
 
 

--- a/src/decisionengine/framework/tests/ModuleProgramOptions.py
+++ b/src/decisionengine/framework/tests/ModuleProgramOptions.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import re
 import subprocess

--- a/src/decisionengine/framework/tests/PublisherNOP.py
+++ b/src/decisionengine/framework/tests/PublisherNOP.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pandas as pd
 
 from decisionengine.framework.modules import Publisher

--- a/src/decisionengine/framework/tests/PublisherWithMissingConsumes.py
+++ b/src/decisionengine/framework/tests/PublisherWithMissingConsumes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import Publisher
 
 

--- a/src/decisionengine/framework/tests/SourceAlias.py
+++ b/src/decisionengine/framework/tests/SourceAlias.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import Source
 from decisionengine.framework.tests import SourceWithSampleConfigNOP
 

--- a/src/decisionengine/framework/tests/SourceNOP.py
+++ b/src/decisionengine/framework/tests/SourceNOP.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pandas as pd
 
 from prometheus_client import Gauge

--- a/src/decisionengine/framework/tests/SourceWithSampleConfigNOP.py
+++ b/src/decisionengine/framework/tests/SourceWithSampleConfigNOP.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pandas as pd
 
 from decisionengine.framework.modules import Source

--- a/src/decisionengine/framework/tests/SupportsConfigPublisher.py
+++ b/src/decisionengine/framework/tests/SupportsConfigPublisher.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.modules import Publisher
 from decisionengine.framework.modules.Publisher import Parameter
 

--- a/src/decisionengine/framework/tests/TransformNOP.py
+++ b/src/decisionengine/framework/tests/TransformNOP.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pandas as pd
 
 from decisionengine.framework.modules import Transform

--- a/src/decisionengine/framework/tests/TransformWithMissingProducesConsumes.py
+++ b/src/decisionengine/framework/tests/TransformWithMissingProducesConsumes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pandas as pd
 
 from decisionengine.framework.modules import Transform

--- a/src/decisionengine/framework/tests/WriteToDisk.py
+++ b/src/decisionengine/framework/tests/WriteToDisk.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Special publisher used to register publish calls with an external file.
 
 It is difficult to interact with individual publishers while testing a

--- a/src/decisionengine/framework/tests/fixtures.py
+++ b/src/decisionengine/framework/tests/fixtures.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """defaults for pytest"""
 import os
 

--- a/src/decisionengine/framework/tests/test_client_errors.py
+++ b/src/decisionengine/framework/tests/test_client_errors.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture based DE Server tests of the sample config"""
 # pylint: disable=redefined-outer-name
 

--- a/src/decisionengine/framework/tests/test_client_server.py
+++ b/src/decisionengine/framework/tests/test_client_server.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture based DE Server for the de-client tests"""
 # pylint: disable=redefined-outer-name
 

--- a/src/decisionengine/framework/tests/test_defaults.py
+++ b/src/decisionengine/framework/tests/test_defaults.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture based DE Server tests of the sample config"""
 # pylint: disable=redefined-outer-name
 

--- a/src/decisionengine/framework/tests/test_dynamic_test_modules.py
+++ b/src/decisionengine/framework/tests/test_dynamic_test_modules.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # A test for testing test modules [sigh]
 
 from .DynamicPublisher import DynamicPublisher

--- a/src/decisionengine/framework/tests/test_empty_config.py
+++ b/src/decisionengine/framework/tests/test_empty_config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture based DE Server tests of adding a channel later on"""
 # pylint: disable=redefined-outer-name
 import os

--- a/src/decisionengine/framework/tests/test_error_on_acquire.py
+++ b/src/decisionengine/framework/tests/test_error_on_acquire.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 
 import pytest

--- a/src/decisionengine/framework/tests/test_module_program_options.py
+++ b/src/decisionengine/framework/tests/test_module_program_options.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from decisionengine.framework.tests import ModuleProgramOptions as opts
 
 

--- a/src/decisionengine/framework/tests/test_query_tool_server.py
+++ b/src/decisionengine/framework/tests/test_query_tool_server.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture based DE Server for the de-query-tool tests"""
 # pylint: disable=redefined-outer-name
 

--- a/src/decisionengine/framework/tests/test_reaper.py
+++ b/src/decisionengine/framework/tests/test_reaper.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture based DE Server for the reaper tests"""
 # pylint: disable=redefined-outer-name
 

--- a/src/decisionengine/framework/tests/test_sample_config.py
+++ b/src/decisionengine/framework/tests/test_sample_config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture based DE Server tests of the defaults"""
 # pylint: disable=redefined-outer-name
 

--- a/src/decisionengine/framework/tests/test_source_proxy.py
+++ b/src/decisionengine/framework/tests/test_source_proxy.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture based tests of the SourceProxy module."""
 # pylint: disable=redefined-outer-name
 

--- a/src/decisionengine/framework/tests/test_source_proxy_3G.py
+++ b/src/decisionengine/framework/tests/test_source_proxy_3G.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture based tests of the SourceProxy module (tests three generations of source-proxies)."""
 # pylint: disable=redefined-outer-name
 

--- a/src/decisionengine/framework/tests/test_start_with_bad_channels.py
+++ b/src/decisionengine/framework/tests/test_start_with_bad_channels.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixture based DE Server tests of invalid channel configs"""
 # pylint: disable=redefined-outer-name
 

--- a/src/decisionengine/framework/util/fs.py
+++ b/src/decisionengine/framework/util/fs.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 
 from pathlib import Path

--- a/src/decisionengine/framework/util/logparser.py
+++ b/src/decisionengine/framework/util/logparser.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import fileinput
 import json

--- a/src/decisionengine/framework/util/metrics.py
+++ b/src/decisionengine/framework/util/metrics.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import prometheus_client
 
 from prometheus_client.multiprocess import MultiProcessCollector

--- a/src/decisionengine/framework/util/reaper.py
+++ b/src/decisionengine/framework/util/reaper.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 A stand-alone script purges data in database older than specified
 in configuration. Configuration file has to have this bit added:

--- a/src/decisionengine/framework/util/singleton.py
+++ b/src/decisionengine/framework/util/singleton.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import abc
 import gc
 

--- a/src/decisionengine/framework/util/sockets.py
+++ b/src/decisionengine/framework/util/sockets.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import socket
 
 import structlog

--- a/src/decisionengine/framework/util/subclasses.py
+++ b/src/decisionengine/framework/util/subclasses.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import inspect
 
 

--- a/src/decisionengine/framework/util/tests/test_fs.py
+++ b/src/decisionengine/framework/util/tests/test_fs.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import tempfile
 
 from pathlib import Path

--- a/src/decisionengine/framework/util/tests/test_logparser.py
+++ b/src/decisionengine/framework/util/tests/test_logparser.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import re
 import subprocess

--- a/src/decisionengine/framework/util/tests/test_metrics.py
+++ b/src/decisionengine/framework/util/tests/test_metrics.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/src/decisionengine/framework/util/tests/test_reaper.py
+++ b/src/decisionengine/framework/util/tests/test_reaper.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 The utils/reaper.py is one of our console entry points.
 Testing it requires the test user be either root or decisionengine,

--- a/src/decisionengine/framework/util/tests/test_singleton.py
+++ b/src/decisionengine/framework/util/tests/test_singleton.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import abc
 import concurrent.futures
 import threading

--- a/src/decisionengine/tests/test_framework_package.py
+++ b/src/decisionengine/tests/test_framework_package.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Make sure decisionengine.framework is a valid python package
 """

--- a/src/tests/test_framework_package.py
+++ b/src/tests/test_framework_package.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Make sure decisionengine is a valid python package
 """


### PR DESCRIPTION
Set Apache 2.0 license and added REUSE compliance

Added REUSE configuration files, DEP5 file, and SPDX headers
Added also pre-commit checks and CI compliance test

See https://reuse.software/