### PR TITLE
Porting EmptySource to 1.7 branch

### DIFF
--- a/doc/source/release_notes/release_notes_1.7.rst
+++ b/doc/source/release_notes/release_notes_1.7.rst
@@ -8,13 +8,13 @@ This release features:
 - Added SQLAlchemy object-relational mapper to increase the testability of DB interactions and to allow different database backends.
   Switching between datasource backends requires dropping all objects if you wish to reuse the tablespace.
 - Packaging via setuptools for both decisionengine and decisionengine_modules: Dependencies are not yet fully listed in the RPMs.
-- A new, optional, configuration parameter called "channel_name" is available. "channel_name" is one of the keys in the output dictionary of the structured logging and will be used in the upcoming monitoring. If the variable is not defined in the configuration file, then it is taken from the name of the file, e.g. the job_classification.jsonnet config file gives a default "channel_name" value of "job_classification".  
+- A new, optional, configuration parameter called "channel_name" is available. "channel_name" is one of the keys in the output dictionary of the structured logging and will be used in the upcoming monitoring. If the variable is not defined in the configuration file, then it is taken from the name of the file, e.g. the job_classification.jsonnet config file gives a default "channel_name" value of "job_classification".
 
 .. note::
     Added requirement on SQLAlchemy (for new datasource backend).
     Non-SQLAlchemy users should ensure the indexes from `13c2f283 <https://github.com/HEPCloud/decisionengine/commit/13c2f28325d697701d9417fb2116364f018da535>` are in their database.
 .. note::
-    Added requirement on prometheus-client. 
+    Added requirement on prometheus-client.
     Prometheus will be used as optional monitoring component.
 .. note::
     The "channel_name" key in the Source Proxy config dictionaries needs to be changed to "source_channel". "channel_name" is now being used to describe the name of the channel itself, not the name of the channel the Source Proxy is gettting information from.

--- a/src/decisionengine/framework/modules/EmptySource.py
+++ b/src/decisionengine/framework/modules/EmptySource.py
@@ -1,0 +1,30 @@
+"""
+This dummy source takes the name of a source datablock
+from config file as parameter "data_product_name" and produces
+an empty pandas DataFrame as a datablock with that name
+"""
+import pandas as pd
+
+from decisionengine.framework.modules import Source
+from decisionengine.framework.modules.Source import Parameter
+
+
+@Source.supports_config(
+    Parameter("data_product_name", default=""),
+)
+class EmptySource(Source.Source):
+    def __init__(self, config):
+        super().__init__(config)
+
+        self.data_product_name = config.get("data_product_name")
+        if not self.data_product_name:
+            raise RuntimeError("No data_product_name found in configuration")
+
+        self._produces = {self.data_product_name: pd.DataFrame}
+
+    def acquire(self):
+        self.logger.debug(f"in EmptySource: {self.data_product_name} acquire")
+        return {self.data_product_name: pd.DataFrame()}
+
+
+Source.describe(EmptySource)

--- a/src/decisionengine/framework/modules/tests/test_EmptySource.py
+++ b/src/decisionengine/framework/modules/tests/test_EmptySource.py
@@ -1,0 +1,25 @@
+import pytest
+
+from decisionengine.framework.modules.EmptySource import EmptySource, pd
+
+
+def test_empty_source_structure():
+    params = {"data_product_name": "empty_data", "channel_name": "test"}
+    test_empty_source = EmptySource(params)
+
+    assert test_empty_source.get_parameters() == {"data_product_name": "empty_data", "channel_name": "test"}
+    assert test_empty_source.data_product_name == "empty_data"
+
+    assert test_empty_source._produces == {test_empty_source.data_product_name: pd.DataFrame}
+
+    key, df = test_empty_source.acquire().popitem()
+    assert key == test_empty_source.data_product_name
+    assert type(df) == pd.DataFrame
+    assert df.empty
+
+
+def test_missing_data_product_name_not_supported():
+    params = {"data_product_name": "", "channel_name": "test"}
+
+    with pytest.raises(RuntimeError, match="No data_product_name found in configuration"):
+        EmptySource(params)


### PR DESCRIPTION
This PR is a cherry picked from commit c1cb825 to port  EmptySource to 1.7 branch.