### PR TITLE
Porting EmptySource to 1.7 branch

### DIFF
--- a/src/decisionengine/framework/modules/EmptySource.py
+++ b/src/decisionengine/framework/modules/EmptySource.py
@@ -1,0 +1,30 @@
+"""
+This dummy source takes the name of a source datablock
+from config file as parameter "data_product_name" and produces
+an empty pandas DataFrame as a datablock with that name
+"""
+import pandas as pd
+
+from decisionengine.framework.modules import Source
+from decisionengine.framework.modules.Source import Parameter
+
+
+@Source.supports_config(
+    Parameter("data_product_name", default=""),
+)
+class EmptySource(Source.Source):
+    def __init__(self, config):
+        super().__init__(config)
+
+        self.data_product_name = config.get("data_product_name")
+        if not self.data_product_name:
+            raise RuntimeError("No data_product_name found in configuration")
+
+        self._produces = {self.data_product_name: pd.DataFrame}
+
+    def acquire(self):
+        self.logger.debug(f"in EmptySource: {self.data_product_name} acquire")
+        return {self.data_product_name: pd.DataFrame()}
+
+
+Source.describe(EmptySource)

--- a/src/decisionengine/framework/modules/tests/test_EmptySource.py
+++ b/src/decisionengine/framework/modules/tests/test_EmptySource.py
@@ -1,0 +1,25 @@
+import pytest
+
+from decisionengine.framework.modules.EmptySource import EmptySource, pd
+
+
+def test_empty_source_structure():
+    params = {"data_product_name": "empty_data", "channel_name": "test"}
+    test_empty_source = EmptySource(params)
+
+    assert test_empty_source.get_parameters() == {"data_product_name": "empty_data", "channel_name": "test"}
+    assert test_empty_source.data_product_name == "empty_data"
+
+    assert test_empty_source._produces == {test_empty_source.data_product_name: pd.DataFrame}
+
+    key, df = test_empty_source.acquire().popitem()
+    assert key == test_empty_source.data_product_name
+    assert type(df) == pd.DataFrame
+    assert df.empty
+
+
+def test_missing_data_product_name_not_supported():
+    params = {"data_product_name": "", "channel_name": "test"}
+
+    with pytest.raises(RuntimeError, match="No data_product_name found in configuration"):
+        EmptySource(params)


### PR DESCRIPTION
This PR (cherry picked from commit c1cb8258726042bb0217a0d89fde764baa0f965a) is to port EmptySource to 1.7 branch.