### PR TITLE
porting "Improve parameter and variable names." to 1.7 branch

### DIFF
--- a/src/decisionengine/framework/modules/tests/test_QueueLogger.py
+++ b/src/decisionengine/framework/modules/tests/test_QueueLogger.py
@@ -1,4 +1,3 @@
-import gc
 import logging
 
 import pytest

--- a/src/decisionengine/framework/taskmanager/TaskManager.py
+++ b/src/decisionengine/framework/taskmanager/TaskManager.py
@@ -25,8 +25,7 @@ from decisionengine.framework.util.subclasses import all_subclasses
 from decisionengine.framework.modules.logging_configDict import LOGGERNAME, DELOGGER_CHANNEL_NAME
 from decisionengine.framework.modules.logging_configDict import CHANNELLOGGERNAME
 
-_TRANSFORMS_TO = 300  # 5 minutes
-_DEFAULT_SCHEDULE = 300  # ""
+_DEFAULT_SCHEDULE = 300  # 5 minutes
 
 delogger = structlog.getLogger(LOGGERNAME)
 delogger = delogger.bind(module=__name__.split(".")[-1], channel=DELOGGER_CHANNEL_NAME)

--- a/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/test_channel.jsonnet
@@ -10,7 +10,6 @@
     "transform1": {
       "module": "decisionengine.framework.tests.TransformNOP",
       "parameters": {},
-      "schedule": 1
     }
   },
   "logicengines": {

--- a/src/decisionengine/framework/taskmanager/tests/channels/test_channel2.jsonnet
+++ b/src/decisionengine/framework/taskmanager/tests/channels/test_channel2.jsonnet
@@ -11,7 +11,6 @@
     "transform1": {
       "module": "decisionengine.framework.tests.TransformNOP",
       "parameters": {},
-      "schedule": 1
     }
   },
   "logicengines": {

--- a/src/decisionengine/framework/tests/etc/decisionengine/config.d/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/config.d/test_channel.jsonnet
@@ -10,7 +10,6 @@
     "transform1": {
       "module": "decisionengine.framework.tests.TransformNOP",
       "parameters": {},
-      "schedule": 1
     }
   },
   "logicengines": {

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_channel.jsonnet
@@ -2,7 +2,6 @@
   "sources": {
     "source1": {
       "module": "decisionengine.framework.tests.SourceNOP",
-      "name": "SourceNOP",
       "parameters": {
         "sleep_for": 5
       },
@@ -13,9 +12,7 @@
   "transforms": {
     "transform1": {
       "module": "decisionengine.framework.tests.TransformNOP",
-      "name": "TransformNOP",
       "parameters": {},
-      "schedule": 1
     }
   },
 

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_source_proxy.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-failing-source-proxy/test_source_proxy.jsonnet
@@ -5,8 +5,7 @@
       "parameters": {
         "source_channel": "test_channel",
         "Dataproducts": ["foo"],
-        "retries": 1,
-        "retry_to": 0
+        "max_attempts": 1,
       },
       "schedule": 1
      }
@@ -15,8 +14,7 @@
    "transforms": {
      "transform1": {
        "module": "decisionengine.framework.tests.TransformNOP",
-       "parameters": {},
-       "schedule": 1
+       "parameters": {}
      }
    },
 

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_channel.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_channel.jsonnet
@@ -13,7 +13,6 @@
     "transform1": {
       "module": "decisionengine.framework.tests.TransformNOP",
       "parameters": {},
-      "schedule": 1
     }
   },
 

--- a/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_source_proxy.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/test-source-proxy/test_source_proxy.jsonnet
@@ -5,8 +5,7 @@
       "parameters": {
         "source_channel": "test_channel",
         "Dataproducts": ["foo"],
-        "retries": 1,
-        "retry_to": 0
+        "max_attempts": 1,
       },
       "schedule": 1
      }
@@ -16,7 +15,6 @@
      "transform1": {
        "module": "decisionengine.framework.tests.TransformNOP",
        "parameters": {},
-       "schedule": 1
      }
    },
 


### PR DESCRIPTION
This PR ports DE #527 to branch 1.7

Includes:

- Removing the 'schedule' parameter from transform configurations,
  which no longer require it.

- Making the following changes for the SourceProxy:
    retries -> max_attempts
    retry_timeout -> retry_interval

(cherry picked from commit c4fc599723ab1e88d06206c158c346b80f86920e)