### PR TITLE
remove unnecessary 'import gc'

### DIFF
--- a/src/decisionengine/framework/modules/tests/test_QueueLogger.py
+++ b/src/decisionengine/framework/modules/tests/test_QueueLogger.py
@@ -1,4 +1,3 @@
-import gc
 import logging
 
 import pytest


### PR DESCRIPTION
The extraneous 'import gc' line is causing the FLAKE8 test to fail.