### PR TITLE
Segment the update for setuptools so it gets cached correctly

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -38,19 +38,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-
             ${{ runner.os }}-pip-
+
       - name: Note Python version/implementation
         run: |
           which python3
           python3 -c 'import sys; print(sys.version)'
           python3 -c 'import platform; print(platform.python_implementation())'
           python3 -m pip cache dir
-      - name: Install dependencies
+
+      - name: Ensure pip/setuptools is up to date
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install --upgrade wheel setuptools
+
+      - name: Install dependencies
+        run: |
           python3 -m pip install --upgrade pytest
           python3 -m pip install -e . --user
           python3 -m pip install -e .[develop] --user
+
       - name: Ensure version.py exists
         run: python3 setup.py bdist_wheel
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ runtime_require = [
     "psycopg2-binary >= 2.8.6; platform_python_implementation == 'CPython'",  # noqa: E501
 ]  # noqa: E501
 
-
 devel_req = [
     "setuptools >= 51.2",
     "setuptools_scm >= 6.3.1",


### PR DESCRIPTION
With the uncovered setuptools bug, this should help isolate it for re-occurrence.