### PR TITLE
Allow duplicate keys if their values are the same

### DIFF
--- a/src/decisionengine/framework/config/de_std.libsonnet
+++ b/src/decisionengine/framework/config/de_std.libsonnet
@@ -48,8 +48,9 @@ local append(res, block, skip_if) =
   local current_keys = std.objectFields(res);
   local new_keys = std.objectFields(new_configurations);
   local duplicate_keys = std.setInter(current_keys, new_keys);
-  if std.length(duplicate_keys) != 0 then
-    error "The following duplicate keys have been detected: " + std.toString(duplicate_keys)
+  local conflicting_keys = [k for k in duplicate_keys if res[k] != block[k]];
+  if std.length(conflicting_keys) != 0 then
+    error "An error occurred while combining configurations.\n" + "The following keys have conflicting values: " + std.toString(conflicting_keys)
   else
     res + new_configurations;
 

--- a/src/decisionengine/framework/config/tests/libsonnet/A1_conflicting.libsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/A1_conflicting.libsonnet
@@ -1,0 +1,11 @@
+local default = import "parameters.libsonnet";
+
+{
+  sources: {
+    s1_a1: default.config {
+      parameters: {
+        a: 4
+      },
+    },
+  },
+}

--- a/src/decisionengine/framework/config/tests/libsonnet/allow_duplicate_keys_same_values.jsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/allow_duplicate_keys_same_values.jsonnet
@@ -1,0 +1,13 @@
+# Specify the same channel twice, testing duplicate keys with the same values.
+
+local de_std = import "de_std.libsonnet";
+local one_channel = [import "A1.libsonnet"];
+
+{
+  test: {
+    sources: de_std.sources_from(one_channel + one_channel),
+  },
+  reference: {
+    sources: de_std.sources_from(one_channel),
+  },
+}

--- a/src/decisionengine/framework/config/tests/libsonnet/error_on_duplicate_keys.jsonnet
+++ b/src/decisionengine/framework/config/tests/libsonnet/error_on_duplicate_keys.jsonnet
@@ -1,5 +1,5 @@
 local de_std = import "de_std.libsonnet";
-local channels = [import "A1.libsonnet", import "A1.libsonnet"];
+local channels = [import "A1.libsonnet", import "A1_conflicting.libsonnet"];
 
 {
   sources: de_std.sources_from(channels),

--- a/src/decisionengine/framework/config/tests/test_de_std.py
+++ b/src/decisionengine/framework/config/tests/test_de_std.py
@@ -29,8 +29,13 @@ def test_combine_one_level_skip_proxies():
     assert cfg["test"] == cfg["reference"]
 
 
+def test_allow_duplicate_keys_same_values():
+    cfg = config("allow_duplicate_keys_same_values.jsonnet")
+    assert cfg["test"] == cfg["reference"]
+
+
 def test_error_on_duplicate_keys():
-    with pytest.raises(RuntimeError, match=".*duplicate keys have been detected.*s1_a1.*s2_a1"):
+    with pytest.raises(RuntimeError, match=".*The following keys have conflicting values.*s1_a1"):
         config("error_on_duplicate_keys.jsonnet")
 
 


### PR DESCRIPTION
The utilities in `de_std.libsonnet` forbids duplicate keys.  Although this prevents unintentional overwriting of configurations, it also prevents combining some configurations that use an identical configuration for a given key.  This PR allows duplicate keys if the configuration values are the same.