### PR TITLE
Use local time for structlog timestamp

### DIFF
--- a/src/decisionengine/framework/modules/logging_configDict.py
+++ b/src/decisionengine/framework/modules/logging_configDict.py
@@ -32,7 +32,7 @@ de_outfile_info = (
 
 structlog_file_index = [2]
 
-timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S")
+timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False)
 
 pre_chain = [
     structlog.stdlib.add_logger_name,


### PR DESCRIPTION
This fixes a mismatch in UTC vs. local that occurs for the log files.