### PR TITLE
Set max retry timeout for sqlite in unit tests.

### DIFF
--- a/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/utils.py
+++ b/src/decisionengine/framework/dataspace/datasources/sqlalchemy_ds/utils.py
@@ -52,6 +52,7 @@ def add_engine_pidguard(engine):
         if "sqlite" in str(type(dbapi_connection)):
             cursor = dbapi_connection.cursor()
             cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.execute("PRAGMA busy_timeout=5000")  # permit retrys for 5 seconds only
             cursor.close()
         connection_record.info["pid"] = os.getpid()
 


### PR DESCRIPTION
This should eliminate pointless busy loops and let tasks do some limited retries.