### PR TITLE
Add a 'ping' method

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -170,6 +170,9 @@ class DecisionEngine(socketserver.ThreadingMixIn, xmlrpc.server.SimpleXMLRPCServ
     def _dataframe_to_csv(self, df):
         return f"{df.to_csv()}\n"
 
+    def rpc_ping(self):
+        return "pong"
+
     def rpc_block_while(self, state_str, timeout=None):
         allowed_state = None
         try:

--- a/src/decisionengine/framework/engine/de_client.py
+++ b/src/decisionengine/framework/engine/de_client.py
@@ -17,6 +17,7 @@ def create_parser():
     )
 
     server = parser.add_argument_group("Decision Engine server options")
+    server.add_argument("--ping", action="store_true", help="perform a minimal connection")
     server.add_argument("--stop", action="store_true", help="stop server")
     server.add_argument("--status", action="store_true", help="print server status")
     server.add_argument("--show-de-config", action="store_true", help="print server configuration")
@@ -86,6 +87,8 @@ def execute_command_from_args(argsparsed, de_socket):
     """argsparsed should be from create_parser in this file"""
 
     # Server-specific options
+    if argsparsed.ping:
+        return de_socket.ping()
     if argsparsed.status:
         return de_socket.status()
     if argsparsed.show_de_config:

--- a/src/decisionengine/framework/tests/test_empty_config.py
+++ b/src/decisionengine/framework/tests/test_empty_config.py
@@ -29,6 +29,8 @@ deserver = DEServer(
 @pytest.mark.usefixtures("deserver")
 def test_client_can_start_one_channel_added_after_startup(deserver):
     """Verify client can start a single channel"""
+    output = deserver.de_client_run_cli("--ping")
+    assert "pong" in output
     output = deserver.de_client_run_cli("--status")
     assert "No channels are currently active." in output
     output = deserver.de_client_run_cli("--show-channel-config", "test_channel")


### PR DESCRIPTION
When checking the startup issues, it is helpful to have a check that
doesn't depend on the state of any internal objects.