### PR TITLE
cherrypy metrics server blocking startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ write_to = "src/decisionengine/framework/version.py"
 [tool.pytest.ini_options]
 minversion = "6.0"
 # -n is used by pytest-xdist. "pytest: error: unrecognized arguments: -n" means that the plugin is missing. Install the development dependencies
-addopts = "-l -v --durations=30 --durations-min=0.05 --strict-config --strict-markers --showlocals -n 2"
+# pytest-xdist is not _mandatory_ for the tests to work, but it is recommended
+addopts = "-l -v --durations=30 --durations-min=0.05 --strict-config --strict-markers --showlocals -n 4"
 log_level = "debug"
 testpaths = "src/decisionengine"
 required_plugins = ["pytest-timeout>=1.4.2", "pytest-postgresql >= 3.0.0"]

--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -69,7 +69,7 @@ class DETestWorker(threading.Thread):
         self.global_config["shutdown_timeout"] = 1
         self.global_config["server_address"] = self.server_address
         self.global_config["dataspace"]["datasource"] = datasource
-        self.global_config["no_webserver"] = True
+        self.global_config["no_webserver"] = False
         self.global_config["webserver"] = {}
         self.global_config["webserver"]["port"] = get_random_port()
 

--- a/src/decisionengine/framework/util/sockets.py
+++ b/src/decisionengine/framework/util/sockets.py
@@ -13,6 +13,7 @@ logger = logger.bind(module=__name__.split(".")[-1], channel=DELOGGER_CHANNEL_NA
 
 def get_random_port():
     try:
+        logger.debug("looking for random port in get_random_port")
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("127.0.0.1", 0))
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
This should fix the startup blocking issue with cherrypy and add it to the testing framework.

It about doubles the testing time on my system, so I added some more workers to pytest-xdist to try and offset the cost.