### PR TITLE
pin jsonnet 0.17.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 runtime_require = [
     "cherrypy >= 18.6.0",
     "kombu[redis] >= 5.1.0",
-    "jsonnet >= 0.17.0",
+    "jsonnet == 0.17.0",
     "prometheus-client >= 0.10.0",
     "tabulate >= 0.8.7",
     "toposort >= 1.6",


### PR DESCRIPTION
jsonnet 0.18.0 has been released on Dec 2021.
This version fails to build with GCC 4
```
  In file included from third_party/rapidyaml/rapidyaml/ext/c4core/src/c4/config.hpp:35:0,
                   from third_party/rapidyaml/rapidyaml/ext/c4core/src/c4/substr.hpp:10,
                   from third_party/rapidyaml/rapidyaml/ext/c4core/src/c4/std/string.hpp:6,
                   from third_party/rapidyaml/rapidyaml/src/c4/yml/std/string.hpp:7,
                   from third_party/rapidyaml/rapidyaml/src/./c4/yml/std/std.hpp:4,
                   from third_party/rapidyaml/rapidyaml/src/ryml_std.hpp:4,
                   from core/vm.cpp:29:
  third_party/rapidyaml/rapidyaml/ext/c4core/src/c4/compiler.hpp:90:13: error: #error "GCC < 5 is not supported"
   #           error "GCC < 5 is not supported"
               ^
```
So far we didn't had the need to rebuild the DE Docker image, so this wasn't an issue until now.
I put this on hold because I thought at some point the jsonnet wheel file would be made available, but it looks like also 
jsonnet 0.17.0 has always been built when it is used:

```
Collecting jsonnet==0.17.0
  Downloading jsonnet-0.17.0.tar.gz (259 kB)
[...]
Building wheels for collected packages: jsonnet
  Building wheel for jsonnet (setup.py): started
  Building wheel for jsonnet (setup.py): finished with status 'done'
  Created wheel for jsonnet: filename=jsonnet-0.17.0-cp36-cp36m-linux_x86_64.whl size=2858707 sha256=b932ae072b6126697257fd3134508456bbc197a4014d271a17c3b66de8929edc
  Stored in directory: /root/.cache/pip/wheels/7e/ad/c9/995f065cc9d62d8a6e39ed458050b2c085429afc651e62bf73
Successfully built jsonnet
```
so I think we need to pin jsonnet to 0.17.0