### PR TITLE
Logger tests are a bit unstable at high parallelization.

### DIFF
--- a/src/decisionengine/framework/config/tests/de/minimal.jsonnet
+++ b/src/decisionengine/framework/config/tests/de/minimal.jsonnet
@@ -1,6 +1,6 @@
 {
   logger: {
-    log_file: "/tmp/de_config_tests/decision_engine_log",
+    log_file: "",
     max_file_size: 200 * 1000000,
     max_backup_count: 6,
     log_level: "DEBUG",

--- a/src/decisionengine/framework/config/tests/test_config.py
+++ b/src/decisionengine/framework/config/tests/test_config.py
@@ -3,7 +3,6 @@
 
 import os
 import re
-import shutil
 
 import pytest
 
@@ -39,8 +38,9 @@ def load():
 
     yield _call
 
-    # clean up the log directory if it gets created
-    shutil.rmtree("/tmp/de_config_tests", ignore_errors=True)
+    # Cleanup code on this is tricky as the unit tests either share
+    # a static directory to store their logfiles across multiple
+    # fixtures or use random tempfile names.
 
 
 # --------------------------------------------------------------------

--- a/src/decisionengine/framework/modules/de_logger.py
+++ b/src/decisionengine/framework/modules/de_logger.py
@@ -8,6 +8,7 @@ import logging
 import logging.config
 import logging.handlers
 import os
+import tempfile
 
 import structlog
 
@@ -50,9 +51,14 @@ def configure_logging(
     :arg  max_backup_count: start rotaion after this number is reached
     :rtype: None
     """
+    if log_file_name in (None, ""):
+        # we explicitly asked for no name, but a filename
+        # is actually required for this to work.
+        log_file_name = tempfile.NamedTemporaryFile().name
+
     dirname = os.path.dirname(log_file_name)
-    if dirname and not os.path.exists(dirname):
-        os.makedirs(dirname)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
 
     delogger.setLevel(getattr(logging, log_level.upper()))
     if delogger.handlers:


### PR DESCRIPTION
This should help avoid races between them