### PR TITLE
Flush Redis DB after DE server stops

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -752,6 +752,10 @@ def _start_de_server(server):
             server.get_logger().error(msg)
 
         raise __e
+    finally:
+        r = redis.Redis.from_url(server.broker_url)
+        with contextlib.suppress(Exception):
+            r.flushdb()
 
 
 def main(args=None):


### PR DESCRIPTION
This ensures that the Redis DB is properly cleaned up after the DE server shuts down, which is appropriate as we're not using Redis for persistent storage.

*N.B.* This is based off of PR #620.