### PR TITLE
Isolate Redis DBs during unit tests

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -752,6 +752,10 @@ def _start_de_server(server):
             server.get_logger().error(msg)
 
         raise __e
+    finally:
+        r = redis.Redis.from_url(server.broker_url)
+        with contextlib.suppress(Exception):
+            r.flushdb()
 
 
 def main(args=None):


### PR DESCRIPTION
The DE server configuration for unit tests uses an exchange with the name `hep_topic_exchange`, and it uses the same Redis URL for each test.  This is a problem whenever independent unit tests use the same routing keys, resulting in Kombu message collisions.

This PR attempts to mitigate this problem by assigning different Redis databases per DE server fixture.  If `pytest-xdist` is setup, the xdist worker number will be used as the database number.  Otherwise, a number between 0 and 15 (inclusive) will be randomly picked as the database number--Redis supports 16 databases by default.

*N.B.* This PR is based off of PRs #620 and #623.