### PR TITLE
Add Countdown class to address global timeout problem

### DIFF
--- a/src/decisionengine/framework/util/countdown.py
+++ b/src/decisionengine/framework/util/countdown.py
@@ -5,7 +5,8 @@ import time
 
 
 class Countdown:
-    """Countdown is a context manager that keeps track of elapsed time.
+    """
+    Countdown is a context manager that keeps track of elapsed time.
 
     It is designed to be used for cases where a sequence of operations
     should not take longer than a specified period of time.  This is done
@@ -29,6 +30,13 @@ class Countdown:
     """
 
     def __init__(self, wait_up_to):
+        """
+        :type wait_up_to: float or None
+        :param wait_up_to: Countdown start time in seconds.  If None
+                           is specified, no countdown occurs and the ~time_left
+                           variable remains `None` (useful when needing to
+                           call a blocking join on a process/thread).
+        """
         self.time_left = wait_up_to
         self._elapsed_time = None
 

--- a/src/decisionengine/framework/util/countdown.py
+++ b/src/decisionengine/framework/util/countdown.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+
+class Countdown:
+    """Countdown is a context manager that keeps track of elapsed time.
+
+    It is designed to be used for cases where a sequence of operations
+    should not take longer than a specified period of time.  This is done
+    by occasionally querying the 'time_left' attribute (e.g.):
+
+        countdown = Countdown(wait_up_to=10)
+        for p in processes:
+            with countdown:
+                rc = p.join(countdown.time_left)
+                if rc is None:
+                    p.terminate()
+
+    In the above example, the time it takes to shutdown all processes
+    should not exceed 10 seconds.  Upon entering the countdown
+    context, a timer starts.  Once that context is exited, the timer
+    stops and the elapsed time is subtracted from the initial
+    'wait_up_to' value.  If it takes 10 seconds for the first process
+    to join, then the 'time_left' value will be 0 when joining all
+    subsequent processes.  In this way, the entire sequence of
+    operations is constrained to occur in roughly 10 seconds.
+    """
+
+    def __init__(self, wait_up_to):
+        self.time_left = wait_up_to
+        self._elapsed_time = None
+
+    def __enter__(self):
+        if self.time_left is not None:
+            self._elapsed_time = time.monotonic()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self.time_left is None:
+            return
+
+        self._elapsed_time = time.monotonic() - self._elapsed_time
+        self.time_left = max(0, self.time_left - self._elapsed_time)

--- a/src/decisionengine/framework/util/tests/test_countdown.py
+++ b/src/decisionengine/framework/util/tests/test_countdown.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+from decisionengine.framework.util.countdown import Countdown
+
+
+def test_timeout_of_none():
+    countdown = Countdown(wait_up_to=None)
+    assert countdown.time_left is None
+    for i in range(10):
+        with countdown:
+            time.sleep(0.1)
+    assert countdown.time_left is None
+
+
+def test_timeout():
+    countdown = Countdown(wait_up_to=2)
+    with countdown:
+        time.sleep(2)
+    assert countdown.time_left == 0.0


### PR DESCRIPTION
The DE can be configured to shutdown hard after a specified time period has elapsed (default is 10 seconds).  Unfortunately, this timeout was applied for *each* channel and source process, resulting in a wait of '(# channels) * 10 + (# sources) * 10'  seconds.

This commit introduces a Countdown class which keeps track of the elapsed time, enabling a global timeout (10 seconds, by default) that is close to what the operator would expect.