### PR TITLE
Update Python 3.6-compatible pre-commit hooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,11 +31,11 @@ repos:
     hooks:
       - id: isort
   - repo: "https://github.com/psf/black"
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: "https://github.com/pre-commit/mirrors-prettier"
-    rev: v2.5.1
+    rev: v2.6.2
     hooks:
       - id: prettier
         exclude_types:


### PR DESCRIPTION
The pre-commit auto-updater updates hooks that are not Python 3.6-compatible.  This PR manually updates some of the hooks that are still compatible with Python 3.6.