### PR TITLE
Fix over-logging of "Taking channel offline" message

### DIFF
--- a/src/decisionengine/framework/engine/SourceWorkers.py
+++ b/src/decisionengine/framework/engine/SourceWorkers.py
@@ -186,8 +186,11 @@ class SourceWorkers:
         with self._lock:
             for source_name in source_names:
                 self._use_count[source_name].discard(channel_name)
-                if len(self._use_count[source_name]) == 0:
-                    self._logger.debug(f"Taking channel {channel_name} offline")
+                if len(self._use_count[source_name]) != 0:
+                    continue
+
+                if self._workers[source_name].state.probably_running():
+                    self._logger.debug(f"Taking source {source_name} offline")
                     self._workers[source_name].take_offline()
 
     def prune(self, channel_name, source_names):


### PR DESCRIPTION
In the event that a source was taken offline due to an error, a message was logged every 0.5 seconds that the "channel" was being taken offline.  This PR fixes the problem, emitting the message only when the source is taken offline.  Incidentally, the logged message has been corrected to "Taking source ... offline", not the channel.