### PR TITLE
Fix systemctl stop time delay

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ runtime_require = [
     "kombu[redis] >= 5.1.0",
     "jsonnet == 0.17.0",
     "prometheus-client >= 0.10.0",
+    "psutil >= 5.8.0",
     "tabulate >= 0.8.7",
     "toposort >= 1.6",
     "sqlalchemy >= 1.4.20",

--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -677,14 +677,14 @@ class DecisionEngine(socketserver.ThreadingMixIn, xmlrpc.server.SimpleXMLRPCServ
         use default webserver port.
         """
         _socket_host = "0.0.0.0"
-        if self.global_config.get("webserver") and isinstance(self.global_config.get("webserver"), dict):
-            _port = self.global_config["webserver"].get("port", DEFAULT_WEBSERVER_PORT)
+        webserver_config = self.global_config.get("webserver")
+        if isinstance(webserver_config, dict):
+            _port = webserver_config.get("port", DEFAULT_WEBSERVER_PORT)
         else:  # pragma: no cover
             # unit tests use a random port
             _port = DEFAULT_WEBSERVER_PORT
 
-        with contextlib.suppress(Exception):
-            self.logger.debug(f"Trying to start metrics server on {_socket_host}:{_port}")
+        self.logger.debug(f"Trying to start metrics server on {_socket_host}:{_port}")
 
         cherrypy.config.update(
             {"server.socket_port": _port, "server.socket_host": _socket_host, "server.shutdown_timeout": 1}
@@ -694,8 +694,7 @@ class DecisionEngine(socketserver.ThreadingMixIn, xmlrpc.server.SimpleXMLRPCServ
         # we know for sure the cherrypy logger is working, so use that too
         cherrypy.log(f"Trying to start metrics server on {_socket_host}:{_port}")
         cherrypy.engine.start()
-        with contextlib.suppress(Exception):
-            self.logger.debug("Started CherryPy server")
+        self.logger.debug("Started CherryPy server")
 
     @cherrypy.expose
     def metrics(self):

--- a/src/decisionengine/framework/engine/SourceWorkers.py
+++ b/src/decisionengine/framework/engine/SourceWorkers.py
@@ -82,6 +82,7 @@ class SourceWorker(multiprocessing.Process):
         """
         Get the data from source
         """
+        self.state.set(State.ACTIVE)
         self.logger.info(f"Starting source loop for {self.key}")
         SOURCE_ACQUIRE_GAUGE.labels(self.key)
         with producers[self.connection].acquire(block=True) as producer:
@@ -177,10 +178,6 @@ class SourceWorkers:
                 self._use_count[key] = {channel_name}
 
         return workers
-
-    def unique(self, source_name):
-        with self._lock:
-            return len(self._use_count[source_name]) == 1
 
     def detach(self, channel_name, source_names):
         with self._lock:

--- a/src/decisionengine/framework/engine/tests/fixtures.py
+++ b/src/decisionengine/framework/engine/tests/fixtures.py
@@ -143,6 +143,7 @@ def DEServer(
     host=DE_HOST,
     port=None,
     make_conf_dirs_if_missing=False,
+    block_until_startup_complete=True,
 ):
     """A DE Server using a private database"""
 
@@ -207,14 +208,17 @@ def DEServer(
             logger.debug("Starting DE Fixture")
             server_proc.start()
 
-            # Ensure the channels have started
-            logger.debug(f"DE Fixture: Wait on startup state: is_set={server_proc.de_server.startup_complete.is_set()}")
-            server_proc.de_server.startup_complete.wait()
-            server_proc.stdout_at_setup = capsys.readouterr().out
+            if block_until_startup_complete:
+                # Ensure the channels have started
+                logger.debug(
+                    f"DE Fixture: Wait on startup state: is_set={server_proc.de_server.startup_complete.is_set()}"
+                )
+                server_proc.de_server.startup_complete.wait()
+                server_proc.stdout_at_setup = capsys.readouterr().out
 
-            logger.debug(
-                f"DE Fixture: Done waiting for startup state: is_set={server_proc.de_server.startup_complete.is_set()}"
-            )
+                logger.debug(
+                    f"DE Fixture: Done waiting for startup state: is_set={server_proc.de_server.startup_complete.is_set()}"
+                )
 
             if not server_proc.is_alive():
                 raise RuntimeError("Could not start PrivateDEServer fixture")

--- a/src/decisionengine/framework/tests/test_status_during_startup.py
+++ b/src/decisionengine/framework/tests/test_status_during_startup.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=redefined-outer-name
+
+import os
+import re
+
+from decisionengine.framework.tests.fixtures import (  # noqa: F401
+    DEServer,
+    PG_DE_DB_WITHOUT_SCHEMA,
+    PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_TEMPFILE_SQLITE,
+    TEST_CONFIG_PATH,
+)
+
+_channel_config_dir = os.path.join(TEST_CONFIG_PATH, "test-combined-channels")  # noqa: F405
+deserver_no_wait = DEServer(
+    conf_path=TEST_CONFIG_PATH, channel_conf_path=_channel_config_dir, block_until_startup_complete=False
+)
+
+
+def test_status_during_startup(deserver_no_wait):
+    output = deserver_no_wait.de_client_run_cli("--status")
+    ref_pattern_none = r"""No sources or channels are currently active.
+
+reaper: state = IDLE"""
+
+    ref_pattern_launched = r"""
+source: source1, queue id = source1.*, state = (BOOT|ACTIVE|STEADY)
+
+channel: test_combined_channels, id = .*, state = (BOOT|ACTIVE|STEADY)
+
+reaper: state = IDLE"""
+    assert re.search(ref_pattern_none, output, re.DOTALL) or re.search(ref_pattern_launched, output, re.DOTALL)


### PR DESCRIPTION
This PR solves #626 and it is a first step toward fixing issue #639.The reason for the blocking is that all channels were brought online *before* the server's `serve_forever()` call was made.  This PR calls `serve_forever()` much earlier and starts the channels using a separate thread.  This solves one issue but it the `de-client --status` call still hangs even after `serve_forever()` has been called.