### PR TITLE
lock pyupgrade to python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
           - "prettier"
           - "prettier-plugin-toml@0.3.1"
   - repo: "https://github.com/asottile/pyupgrade"
-    rev: v2.31.0
+    rev: e695ecd365119ab4e5463f6e49bea5f4b7ca786b
     hooks:
       - id: pyupgrade
         args:


### PR DESCRIPTION
This should lock pyupgrade at the version we want.