### PR TITLE
Fix pre-commit node version to 17.9.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@
 default_language_version:
   # force all unspecified python hooks to run python3
   python: python3
+  node: 17.9.0
 repos:
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
     rev: v4.1.0


### PR DESCRIPTION
This is the last version of node known to support SL7.