### PR TITLE
Use logging for XMLRPC client requests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@
 default_language_version:
   # force all unspecified python hooks to run python3
   python: python3
+  node: 17.9.0
 repos:
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
     rev: v4.1.0

--- a/src/decisionengine/framework/engine/de_client.py
+++ b/src/decisionengine/framework/engine/de_client.py
@@ -138,11 +138,7 @@ def execute_command_from_args(argsparsed, de_socket):
     if argsparsed.start_channels:
         return de_socket.start_channels()
     if argsparsed.get_channel_loglevel:
-        level = argsparsed.get_channel_loglevel
-        if level == "UNITTEST":
-            return "NOTSET"
-        else:
-            return de_socket.get_channel_log_level(argsparsed.get_channel_loglevel)
+        return de_socket.get_channel_log_level(argsparsed.get_channel_loglevel)
     if argsparsed.set_channel_loglevel:
         return de_socket.set_channel_log_level(argsparsed.set_channel_loglevel[0], argsparsed.set_channel_loglevel[1])
     if argsparsed.show_config:
@@ -199,10 +195,8 @@ def console_scripts_main(args_to_parse=None):
     Setuptools thinks a return from this function is an error message.
     """
     msg = main(args_to_parse)
-    if "An error occurred while trying to access a DE server" in msg:
+    if msg is not None:
         return msg
-    else:
-        print(msg)
 
 
 if __name__ == "__main__":

--- a/src/decisionengine/framework/engine/de_query_tool.py
+++ b/src/decisionengine/framework/engine/de_query_tool.py
@@ -81,10 +81,8 @@ def console_scripts_main(args_to_parse=None):
     Setuptools thinks a return from this function is an error message.
     """
     msg = main(args_to_parse)
-    if "An error occurred while trying to access a DE server" in msg:
+    if msg is not None:
         return msg
-    else:
-        print(msg)
 
 
 if __name__ == "__main__":

--- a/src/decisionengine/framework/tests/test_client_server.py
+++ b/src/decisionengine/framework/tests/test_client_server.py
@@ -65,13 +65,13 @@ def test_client_print_product(deserver):
 
     # Test against bad values
     with pytest.raises(ValueError, match=r"Requested product should be a string.*"):
-        deserver.de_server.rpc_print_product(123)
+        deserver.de_server.rpc_print_product(None, 123)
     with pytest.raises(ValueError, match=r"Requested product should be a string.*"):
-        deserver.de_server.rpc_print_product(b"123")
+        deserver.de_server.rpc_print_product(None, b"123")
     with pytest.raises(ValueError, match=r"Requested product should be a string.*"):
-        deserver.de_server.rpc_print_product(pytest)
+        deserver.de_server.rpc_print_product(None, pytest)
     with pytest.raises(ValueError, match=r"Requested product should be a string.*"):
-        deserver.de_server.rpc_print_product({"a": "b"})
+        deserver.de_server.rpc_print_product(None, {"a": "b"})
 
     # Test --types
     output = deserver.de_client_run_cli("--print-product", "foo", "--types")

--- a/src/decisionengine/framework/tests/test_defaults.py
+++ b/src/decisionengine/framework/tests/test_defaults.py
@@ -22,9 +22,9 @@ deserver = DEServer(
 
 
 def test_defaults(deserver):
-    # Verify unknown channel has NOTSET
+    # Verify DE does not attempt to get log level for unknown channel.
     output = deserver.de_client_run_cli("--get-channel-loglevel=UNITTEST")
-    assert output == "NOTSET"
+    assert output == "No channel found with the name UNITTEST."
 
     # Verify global_channel_log_level setting exists
     output = deserver.de_client_run_cli("--show-de-config")


### PR DESCRIPTION
The DE server handles XMLRPC requests by returning a string to the client.  This means the client caller waits until the string is returned, which can be lengthy for requests that take a long time to process.

This PR, instead of returning a string, uses logging on the server end so that requests with lengthy processing can be broken into different logged messages.  This hopefully provides a more user-friendly approach.