### PR TITLE
add distinct logging for sources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@
 default_language_version:
   # force all unspecified python hooks to run python3
   python: python3
+  node: 17.9.0
 repos:
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
     rev: v4.1.0

--- a/src/decisionengine/framework/engine/de_client.py
+++ b/src/decisionengine/framework/engine/de_client.py
@@ -68,6 +68,15 @@ def create_parser():
         help="Possible levels are NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL",
     )
 
+    sources = parser.add_argument_group("Source-specific options")
+    sources.add_argument("--get-source-loglevel", metavar="<source name>", help="print source log level")
+    sources.add_argument(
+        "--set-source-loglevel",
+        nargs=2,
+        metavar=("<source name>", "<log level>"),
+        help="Possible levels are NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL",
+    )
+
     products = parser.add_argument_group("Product-specific options")
     products.add_argument("--print-product", metavar="<product name>")
     products.add_argument("--print-products", action="store_true", help="print products")
@@ -157,6 +166,16 @@ def execute_command_from_args(argsparsed, de_socket):
         return de_socket.print_product(
             argsparsed.print_product, argsparsed.columns, argsparsed.query, argsparsed.types, argsparsed.format
         )
+
+    # Source-specific options
+    if argsparsed.get_source_loglevel:
+        level = argsparsed.get_source_loglevel
+        if level == "UNITTEST":
+            return "NOTSET"
+        else:
+            return de_socket.get_source_log_level(argsparsed.get_source_loglevel)
+    if argsparsed.set_source_loglevel:
+        return de_socket.set_source_log_level(argsparsed.set_source_loglevel[0], argsparsed.set_source_loglevel[1])
 
     # Database-reaper options
     if argsparsed.reaper_stop:

--- a/src/decisionengine/framework/modules/logging_configDict.py
+++ b/src/decisionengine/framework/modules/logging_configDict.py
@@ -17,6 +17,7 @@ DELOGGER_CHANNEL_NAME = "engine"
 # (the channel name as recorded in the logs is by default the name of the config file
 # for the channel OR alternately can be set in the config file using the key "channel_name")
 CHANNELLOGGERNAME = "channel"
+SOURCELOGGERNAME = "source"
 
 # name suffixes and log levels of the output files from the main logger
 # the base name is given by the "log_file" config parameter in the config file
@@ -30,6 +31,7 @@ de_outfile_info = (
     ("_structlog_debug.log", logging.DEBUG, "%(message)s"),
 )
 
+# location in de_outfile_info of structlog info
 structlog_file_index = [2]
 
 timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False)


### PR DESCRIPTION
Address issue 650: [](https://github.com/HEPCloud/decisionengine/issues/650)

Separate log files are now created for each source. Source log info is still added to the decisionengine_structlog_debug.log file, along with all other logging. The name of the logger is "source" (compare with "decisionengine" and "channel"). The "module" items in the log entries are the names of the sources, as given in the config file.

I ran tests using the channels job_classification and resource_request. The following files were created and populated:
decisionengine_debug.log
decisionengine.log
decisionengine_structlog_debug.log
FactoryEntriesSource.log
FactoryGlobalManifests.log
FigureOfMerit.log
GceFigureOfMerit.log
JobCategorizationSourceProxy.log
job_classification.log
JobManifestsSourceProxy.log
jobs_manifests.log
NerscFigureOfMerit.log
resource_request.log
StartdManifestsSource.log

An example log entry from decisionengine_structlog.log is:
{"channel": "job_classification", "event": "Starting source loop for jobs_manifests", "level": "info", "logger": "source", "module": "jobs_manifests", "timestamp": "2022-05-27 18:51:32"}

An example log entry from FactoryEntriesSource.log is:
2022-05-27 18:51:33,259 - source - SourceWorkers - INFO - {"channel": "resource_request", "event": "Starting source loop for FactoryEntriesSource", "level": "info", "logger": "source", "module": "FactoryEntriesSource", "timestamp": "2022-05-27 18:51:33"}