### PR TITLE
add distinct logging for sources

### DIFF
--- a/src/decisionengine/framework/dataspace/tests/test_Reaper.py
+++ b/src/decisionengine/framework/dataspace/tests/test_Reaper.py
@@ -46,7 +46,7 @@ def reaper(request):
     with contextlib.suppress(Exception):
         if reaper.thread.is_alive() or not reaper.state.should_stop():
             reaper.state.set(State.OFFLINE)
-            reaper.join(timeout=1)
+            reaper.thread.join(timeout=1)
 
     del reaper
     gc.collect()

--- a/src/decisionengine/framework/engine/de_client.py
+++ b/src/decisionengine/framework/engine/de_client.py
@@ -68,6 +68,15 @@ def create_parser():
         help="Possible levels are NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL",
     )
 
+    sources = parser.add_argument_group("Source-specific options")
+    sources.add_argument("--get-source-loglevel", metavar="<source name>", help="print source log level")
+    sources.add_argument(
+        "--set-source-loglevel",
+        nargs=2,
+        metavar=("<source name>", "<log level>"),
+        help="Possible levels are NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL",
+    )
+
     products = parser.add_argument_group("Product-specific options")
     products.add_argument("--print-product", metavar="<product name>")
     products.add_argument("--print-products", action="store_true", help="print products")
@@ -157,6 +166,16 @@ def execute_command_from_args(argsparsed, de_socket):
         return de_socket.print_product(
             argsparsed.print_product, argsparsed.columns, argsparsed.query, argsparsed.types, argsparsed.format
         )
+
+    # Source-specific options
+    if argsparsed.get_source_loglevel:
+        level = argsparsed.get_source_loglevel
+        if level == "UNITTEST":
+            return "NOTSET"
+        else:
+            return de_socket.get_source_log_level(argsparsed.get_source_loglevel)
+    if argsparsed.set_source_loglevel:
+        return de_socket.set_source_log_level(argsparsed.set_source_loglevel[0], argsparsed.set_source_loglevel[1])
 
     # Database-reaper options
     if argsparsed.reaper_stop:

--- a/src/decisionengine/framework/engine/tests/test_SourceWorkers.py
+++ b/src/decisionengine/framework/engine/tests/test_SourceWorkers.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import kombu
+import pytest
+
+import decisionengine.framework.config.policies as policies
+
+from decisionengine.framework.config.ValidConfig import ValidConfig
+from decisionengine.framework.engine.SourceWorkers import SourceWorker
+from decisionengine.framework.taskmanager.tests.fixtures import (  # noqa: F401
+    DATABASES_TO_TEST,
+    dataspace,
+    PG_DE_DB_WITHOUT_SCHEMA,
+    PG_PROG,
+    SQLALCHEMY_PG_WITH_SCHEMA,
+    SQLALCHEMY_TEMPFILE_SQLITE,
+)
+
+_CWD = os.path.dirname(os.path.abspath(__file__))
+_CONFIG_PATH = os.path.join(_CWD, "../../tests/etc/decisionengine")
+_CHANNEL_CONFIG_DIR = os.path.join(_CWD, "config")
+
+_KEY = "test_key"
+_CHANNEL_NAME = "test_channel"
+_SOURCE_NAME = "source1"
+_BROKER_URL = "redis://localhost:6379/14"  # Use 14 to avoid collisions with other tests
+_EXCHANGE = kombu.Exchange("test_topic_exchange", "topic")
+
+
+@pytest.fixture()
+def global_config(dataspace):  # noqa: F811
+    conf = ValidConfig(policies.global_config_file(_CONFIG_PATH))
+    conf["dataspace"] = dataspace.config["dataspace"]
+    yield conf
+
+
+def source_config(channel_name, source_name):
+    ch_config = ValidConfig(os.path.join(_CHANNEL_CONFIG_DIR, channel_name + ".jsonnet"))
+    src_config = ch_config["sources"]
+    return src_config[source_name]
+
+
+def source_worker_for(src_config, global_config):
+    return SourceWorker(_KEY, src_config, global_config["logger"], _CHANNEL_NAME, _EXCHANGE, _BROKER_URL)
+
+
+def test_worker_name(global_config):
+    src_config = source_config(_CHANNEL_NAME, _SOURCE_NAME)
+    worker = source_worker_for(src_config, global_config)
+    assert worker.name == f"SourceWorker-{_KEY}"
+
+
+def test_worker_logger_sized_rotation(global_config):
+    src_config = source_config(_CHANNEL_NAME, _SOURCE_NAME)
+    worker = source_worker_for(src_config, global_config)
+    worker.setup_logger()
+
+    assert "RotatingFileHandler" in str(worker.logger.handlers)
+
+
+def test_worker_logger_timed_rotation(global_config):
+    global_config["logger"]["file_rotate_by"] = "time"
+    src_config = source_config(_CHANNEL_NAME, _SOURCE_NAME)
+    worker = source_worker_for(src_config, global_config)
+    worker.setup_logger()
+
+    assert "TimedRotatingFileHandler" in str(worker.logger.handlers)
+
+
+def test_worker_logger_wrong_rotation_method(global_config):
+    global_config["logger"]["file_rotate_by"] = "test"
+    src_config = source_config(_CHANNEL_NAME, _SOURCE_NAME)
+    worker = source_worker_for(src_config, global_config)
+
+    with pytest.raises(ValueError):
+        worker.setup_logger()

--- a/src/decisionengine/framework/modules/logging_configDict.py
+++ b/src/decisionengine/framework/modules/logging_configDict.py
@@ -17,6 +17,7 @@ DELOGGER_CHANNEL_NAME = "engine"
 # (the channel name as recorded in the logs is by default the name of the config file
 # for the channel OR alternately can be set in the config file using the key "channel_name")
 CHANNELLOGGERNAME = "channel"
+SOURCELOGGERNAME = "source"
 
 # name suffixes and log levels of the output files from the main logger
 # the base name is given by the "log_file" config parameter in the config file
@@ -30,6 +31,7 @@ de_outfile_info = (
     ("_structlog_debug.log", logging.DEBUG, "%(message)s"),
 )
 
+# location in de_outfile_info of structlog info
 structlog_file_index = [2]
 
 timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False)

--- a/src/decisionengine/framework/tests/PublisherNOP.py
+++ b/src/decisionengine/framework/tests/PublisherNOP.py
@@ -12,7 +12,7 @@ class PublisherNOP(Publisher.Publisher):
         super().__init__(config)
 
     def publish(self, data_block):
-        self.bar(data_block)
+        self.bar(data_block)  # pylint: disable=no-member
 
 
 Publisher.describe(PublisherNOP)

--- a/src/decisionengine/framework/tests/TransformNOP.py
+++ b/src/decisionengine/framework/tests/TransformNOP.py
@@ -13,7 +13,7 @@ class TransformNOP(Transform.Transform):
         super().__init__(config)
 
     def transform(self, data_block):
-        df_in = self.foo(data_block)
+        df_in = self.foo(data_block)  # pylint: disable=no-member
         return {"bar": pd.DataFrame(df_in["key2"])}
 
 

--- a/src/decisionengine/framework/tests/etc/decisionengine/decision_engine.jsonnet
+++ b/src/decisionengine/framework/tests/etc/decisionengine/decision_engine.jsonnet
@@ -8,6 +8,7 @@
     file_rotate_by: "size",
     log_level: "DEBUG",
     global_channel_log_level: "DEBUG",
+    global_source_log_level: "DEBUG",
     start_q_logger: "False",
   },
 

--- a/src/decisionengine/framework/tests/test_client_server.py
+++ b/src/decisionengine/framework/tests/test_client_server.py
@@ -41,8 +41,30 @@ def test_client_set_loglevel(deserver):
     # these shouldn't error out even if the channels are dead
     # they should report the channel is dead, if it did die.
     assert "DEBUG" in deserver.de_client_run_cli("--print-engine-loglevel")
+
+    # channel logger tests
     deserver.de_client_run_cli("--set-channel-loglevel", "test_channel", "DEBUG")
+    output = deserver.de_client_run_cli("--set-channel-loglevel", "test_channel", "DEBUG")
+    assert output == "Nothing to do. Current log level is : DEBUG"
     assert "ERROR" in deserver.de_client_run_cli("--set-channel-loglevel", "test_channel", "ERROR")
+    output = deserver.de_client_run_cli("--set-channel-loglevel", "bad_channel", "DEBUG")
+    assert output == "No channel found with the name bad_channel."
+
+    # source logger tests
+    deserver.de_client_run_cli("--set-source-loglevel", "source1", "DEBUG")
+    output = deserver.de_client_run_cli("--set-source-loglevel", "source1", "DEBUG")
+    assert output == "Nothing to do. Current log level is : DEBUG"
+    assert "ERROR" in deserver.de_client_run_cli("--set-source-loglevel", "source1", "ERROR")
+    output = deserver.de_client_run_cli("--set-source-loglevel", "bad_source", "DEBUG")
+    assert output == "No source found with the name bad_source."
+
+
+def test_client_get_loglevel(deserver):
+    output = deserver.de_client_run_cli("--get-channel-loglevel", "bad_channel")
+    assert output == "No channel found with the name bad_channel."
+
+    output = deserver.de_client_run_cli("--get-source-loglevel", "bad_source")
+    assert output == "No source found with the name bad_source."
 
 
 def test_client_print_product(deserver):

--- a/src/decisionengine/framework/tests/test_defaults.py
+++ b/src/decisionengine/framework/tests/test_defaults.py
@@ -26,6 +26,10 @@ def test_defaults(deserver):
     output = deserver.de_client_run_cli("--get-channel-loglevel=UNITTEST")
     assert output == "NOTSET"
 
+    # Verify unknown source has NOTSET
+    output = deserver.de_client_run_cli("--get-source-loglevel=UNITTEST")
+    assert output == "NOTSET"
+
     # Verify global_channel_log_level setting exists
     output = deserver.de_client_run_cli("--show-de-config")
     assert "global_channel_log_level" in output

--- a/src/decisionengine/framework/tests/test_sample_config.py
+++ b/src/decisionengine/framework/tests/test_sample_config.py
@@ -143,12 +143,16 @@ def test_client_logger_level(deserver):
     output = deserver.de_client_run_cli("--get-channel-loglevel", "test_channel")
     assert output in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
+    # Verify can fetch log level for a source
+    output = deserver.de_client_run_cli("--get-source-loglevel", "source1")
+    assert output in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+
     # Verify set log level for a channel
     output = deserver.de_client_run_cli("--set-channel-loglevel", "test_channel", "DEBUG")
     output = deserver.de_client_run_cli("--get-channel-loglevel", "test_channel")
     assert output == "DEBUG"
 
-    # Verify set log level to current level isn't an error
-    output = deserver.de_client_run_cli("--set-channel-loglevel", "test_channel", "DEBUG")
-    output = deserver.de_client_run_cli("--get-channel-loglevel", "test_channel")
+    # Verify set log level for a source
+    output = deserver.de_client_run_cli("--set-source-loglevel", "source1", "DEBUG")
+    output = deserver.de_client_run_cli("--get-source-loglevel", "source1")
     assert output == "DEBUG"


### PR DESCRIPTION
Address issue 650:

Separate log files are now created for each source. Source log info is still added to the decisionengine_structlog_debug.log file, along with all other logging. The name of the logger is "source" (compare with "decisionengine" and "channel"). The "module" items in the log entries are the names of the sources, as given in the config file.

I ran tests using the channels job_classification and resource_request. The following files were created and populated:
decisionengine_debug.log
decisionengine.log
decisionengine_structlog_debug.log
FactoryEntriesSource.log
FactoryGlobalManifests.log
FigureOfMerit.log
GceFigureOfMerit.log
JobCategorizationSourceProxy.log
job_classification.log
JobManifestsSourceProxy.log
jobs_manifests.log
NerscFigureOfMerit.log
resource_request.log
StartdManifestsSource.log

An example log entry from decisionengine_structlog.log is:
{"channel": "job_classification", "event": "Starting source loop for jobs_manifests", "level": "info", "logger": "source", "module": "jobs_manifests", "timestamp": "2022-05-27 18:51:32"}

An example log entry from FactoryEntriesSource.log is:
2022-05-27 18:51:33,259 - source - SourceWorkers - INFO - {"channel": "resource_request", "event": "Starting source loop for FactoryEntriesSource", "level": "info", "logger": "source", "module": "FactoryEntriesSource", "timestamp": "2022-05-27 18:51:33"}
