### PR TITLE
changes to fix source logging

### DIFF
--- a/src/decisionengine/framework/engine/SourceWorkers.py
+++ b/src/decisionengine/framework/engine/SourceWorkers.py
@@ -50,18 +50,19 @@ class SourceWorker(multiprocessing.Process):
         :arg config: configuration dictionary describing the worker
         """
         super().__init__(name=f"SourceWorker-{key}")
-        self.module_instance = _create_module_instance(config, Source, channel_name)
         self.config = config
         self.logger_config = logger_config
         self.channel_name = channel_name
         self.module = self.config["module"]
         self.key = key
-        self.class_name = self.module_instance.__class__.__name__
         SOURCE_ACQUIRE_GAUGE.labels(self.key)
 
         self.loglevel = multiprocessing.Value("i", logging.WARNING)
         self.logger = structlog.getLogger(logconf.SOURCELOGGERNAME)
         self.logger.setLevel(logging.DEBUG)
+
+        self.module_instance = _create_module_instance(config, Source, channel_name)
+        self.class_name = self.module_instance.__class__.__name__
 
         logger = structlog.getLogger(logconf.LOGGERNAME)
         logger = logger.bind(module=__name__.split(".")[-1], source=self.key)

--- a/src/decisionengine/framework/modules/Source.py
+++ b/src/decisionengine/framework/modules/Source.py
@@ -4,6 +4,10 @@
 import pprint
 import sys
 
+import structlog
+
+import decisionengine.framework.modules.logging_configDict as logconf
+
 from decisionengine.framework.config.ValidConfig import ValidConfig
 from decisionengine.framework.modules import describe as _describe
 from decisionengine.framework.modules.describe import Parameter, supports_config
@@ -17,6 +21,8 @@ class Source(Module):
 
     def __init__(self, set_of_parameters):
         super().__init__(set_of_parameters)
+
+        self.logger = structlog.getLogger(logconf.SOURCELOGGERNAME)
 
     # acquire: The action function for a source. Will
     # retrieve data from external sources and issue a


### PR DESCRIPTION
Individual Source loggers were failing because of the addition of ChannelWorkers as different multiprocessing processes.

Each of the SourceWorker objects is a multiprocessing.Process that has its own logger based on the SOURCELOGGERNAME. Each SourceWorker also has a dict of Sources, each of which has its own logger which **was** based on the CHANNELLOGGERNAME, which is actually in another multiprocessing.Process. Any logging done by the Sources was thus not getting recorded.

I changed the design so that now the Sources get their logger from the SourceWorker; the logger is passed through as a parameter in the Source initialization.
