### PR TITLE
explicitly select a container with all our required python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,12 +21,13 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version:
           - "3.6"
-          - "3.10"
+          - "3.9"
+          - "3.11"
 
     name: Python ${{ matrix.python-version }} unit tests
     steps:


### PR DESCRIPTION
This should resolve the issue with the runners not having the right python versions.

Our production pythons are: 3.6 and 3.9.

Testing against 3.11 should give us some forward looking advice.