### PR TITLE
Make default database init use stronger data protections

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -32,7 +32,7 @@ Install the default postgresql distributed on RHEL9, Postgress 13:
 
 3. Init the database ::
 
-    postgresql-setup --initdb
+    postgresql-setup --initdb -k
 
 4. edit ``/var/lib/pgsql/data/pg_hba.conf`` like the following::
 


### PR DESCRIPTION
This sets up row checksums.  There is a small performance cost, but far greater durability and recovery from disk corruption.