### PR TITLE
Update to pytest 7 with pytest-postgresql 5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,7 @@
 ---
+# SPDX-FileCopyrightText: 2023 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # For more information see
 #  https://pre-commit.com/index.html#install
 #  https://pre-commit.com/index.html#automatically-enabling-pre-commit-on-repositories
@@ -36,7 +39,7 @@ repos:
     hooks:
       - id: black
   - repo: "https://github.com/pre-commit/mirrors-prettier"
-    rev: v2.6.2
+    rev: v2.7.1
     hooks:
       - id: prettier
         exclude_types:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,11 @@ write_to = "src/decisionengine/framework/version.py"
 minversion = "6.0"
 # -n is used by pytest-xdist. "pytest: error: unrecognized arguments: -n" means that the plugin is missing. Install the development dependencies
 # pytest-xdist is not _mandatory_ for the tests to work, but it is recommended
-addopts = "-l -v --durations=30 --durations-min=0.05 --strict-config --strict-markers --showlocals -n 4"
+addopts = "-l -v --durations=30 --durations-min=0.05 --strict-config --strict-markers --showlocals"
 log_level = "debug"
 testpaths = "src/decisionengine"
 required_plugins = ["pytest-timeout>=1.4.2", "pytest-postgresql >= 3.0.0"]
 timeout = 90
-flake8-max-line-length = "120"
-flake8-ignore = "E501 E303 E302 E261 E265 E203 W503 W504"
-flake8-show-source = "True"
-flake8-statistics = "True"
 
 [tool.black]
 line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -30,18 +30,18 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 runtime_require = [
     "cherrypy >= 18.6.0",
     "kombu[redis] >= 5.2.0rc1",
-    "jsonnet >= 0.17.0",
+    "jsonnet >= 0.20.0",
     "prometheus-client >= 0.10.0",
     "psutil >= 5.8.0",
     "tabulate >= 0.8.7",
     "toposort >= 1.6",
-    "sqlalchemy >= 1.4.20",
+    "sqlalchemy >= 1.4.48, < 2.0.0",
     "structlog >= 21.1.0",
     "typing_extensions >= 4.1.1",
     "numpy == 1.19.5; python_version <= '3.6'",
-    "numpy >= 1.19.5; python_version >= '3.7'",
+    "numpy >= 1.19.5, < 2.0.0; python_version >= '3.7'",
     "pandas == 1.1.5; python_version <= '3.6'",
-    "pandas >= 1.1.5; python_version >= '3.7' and platform_python_implementation == 'CPython'",
+    "pandas >= 1.1.5, < 2.0.0; python_version >= '3.7' and platform_python_implementation == 'CPython'",
     "psycopg2-binary >= 2.8.6; platform_python_implementation == 'CPython'",  # noqa: E501
 ]  # noqa: E501
 
@@ -52,16 +52,15 @@ devel_req = [
     "packaging >= 20.4",
     "wheel >= 0.36.2",
     "coverage >= 6.1.2",
-    "pytest >= 6.2.2, < 7.0",  # pytest 7 incompatible with pytest-postgres < 4
+    "pytest >= 7.0.0, < 8.0",
     "pytest-cov >= 2.11.1",
-    "pytest-flake8 >= 1.0.7",
-    "pytest-postgresql >= 3.0.0, < 4.0.0",
+    "pytest-postgresql >= 5.0.0, < 6.0.0",
     "pytest-timeout >= 1.4.2",
     "pytest-xdist[psutil] >= 2.3.0",
-    "flake8 >= 4.0.0, < 5.0.0",  # https://github.com/tholo/pytest-flake8/issues/87
+    "flake8 >= 6.0.0, < 7.0.0",
     "pre-commit >= 2.13.0",
     "pylint >= 2.7.4",
-    "reuse",
+    "reuse >= 1.1.2",
     "importlib_resources >= 5.1.2; python_version <= '3.8'",
     "sphinx >= 3.5.3",
     "sphinx_rtd_theme >= 0.5.1",


### PR DESCRIPTION
I'm getting some local errors with :
```shell
FAILED src/decisionengine/framework/tests/test_start_with_bad_channels.py::test_client_can_get_products_no_channels[SQLALCHEMY_PG_WITH_SCHEMA] - StopIteration
```
and
```shell
caplog     = <_pytest.logging.LogCaptureFixture object at 0x7f627a07cfa0>
consumes_not_subset = "Channel test_missing_product could not be created: The following products are required but not produced:\n['B']"
deserver   = <DETestWorker(DETestWorker, started 140059755935296)>
error_msgs = ["Channel test_bad_publisher could not be created: \nThe following modules are missing '@consumes' declarations:\n\n -... in the configuration:\nCircular dependencies exist among these items: {a_uses_b:{'b_uses_a'}, b_uses_a:{'a_uses_b'}}"]
output     = 'No channels are currently active.'
when       = 'call'
```

But other sqlalchemy bits are passing locally