### PR TITLE
Fix unit tests

### DIFF
--- a/src/decisionengine/framework/tests/test_start_with_bad_channels.py
+++ b/src/decisionengine/framework/tests/test_start_with_bad_channels.py
@@ -38,7 +38,7 @@ def _consumes_not_subset(test_str):
 
 def _expected_circularity(test_str):
     return re.search(
-        r"Circular dependencies exist among these items: {'a_uses_b':{'b_uses_a'}, 'b_uses_a':{'a_uses_b'}}",
+        r"Circular dependencies exist among these items: {a_uses_b:{'b_uses_a'}, b_uses_a:{'a_uses_b'}}",
         test_str,
         re.DOTALL,
     )

--- a/src/decisionengine/framework/tests/test_start_with_bad_channels.py
+++ b/src/decisionengine/framework/tests/test_start_with_bad_channels.py
@@ -38,6 +38,7 @@ def _consumes_not_subset(test_str):
 
 def _expected_circularity(test_str):
     return re.search(
+        # Future changes in toposort could reinstate the quotes removed (https://gitlab.com/ericvsmith/toposort/-/issues/7)
         r"Circular dependencies exist among these items: {a_uses_b:{'b_uses_a'}, b_uses_a:{'a_uses_b'}}",
         test_str,
         re.DOTALL,


### PR DESCRIPTION
Updated regexp in _expected_circularity
Jsonnet keys are not in quotes.

This behavior change started with toposort 1.10, spefifically due to:
this [commit in toposort](https://gitlab.com/ericvsmith/toposort/-/commit/e67c242ceec5908564837ce6ac2cb661659b0cc8) to `Use f-strings instead of str.format()`
