### PR TITLE
Enable some tests only on DE 1.7 branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,7 @@ jobs:
           make rst html latexpdf
 
   rpmbuild_el7:
+    if: ${{ github.ref == 'refs/heads/1.7' }}
     name: Build an EL7 rpm
     runs-on: ubuntu-latest
     needs: pytest

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   run_flake8:
+    if: ${{ github.ref == 'refs/heads/1.7' }}
     name: Run pytest-flake8 against code tree
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -15,6 +15,7 @@ on:
       - 1.7
 jobs:
   pytest_el7:
+    if: ${{ github.ref == 'refs/heads/1.7' }}
     runs-on: ubuntu-latest
     name: A job to test the decision engine framework on EL7
     timeout-minutes: 30


### PR DESCRIPTION
Enable tests that run on EL7 only for DE branch 1.7, those are
rpmbuild_el7 in ci.yaml
pytest_el7 in pytest.yaml

Also enable run_flake8 only on DE branch 1.7 as this relays on pytest-flake8 module that doesn't work with flake8 >= 5.0: 
https://github.com/tholo/pytest-flake8/issues/87