### PR TITLE
fix source logging in v1.7

### DIFF
--- a/src/decisionengine/framework/modules/Source.py
+++ b/src/decisionengine/framework/modules/Source.py
@@ -2,6 +2,9 @@ __all__ = ['Parameter', 'Source', 'describe', 'produces', 'supports_config']
 
 import pprint
 import sys
+import structlog
+
+import decisionengine.framework.modules.logging_configDict as logconf
 
 from decisionengine.framework.config.ValidConfig import ValidConfig
 from decisionengine.framework.modules.Module import Module, produces
@@ -14,6 +17,7 @@ class Source(Module):
 
     def __init__(self, set_of_parameters):
         super().__init__(set_of_parameters)
+        self.logger = structlog.getLogger(logconf.SOURCELOGGERNAME)
 
     # acquire: The action function for a source. Will
     # retrieve data from external sources and issue a

--- a/src/decisionengine/framework/modules/logging_configDict.py
+++ b/src/decisionengine/framework/modules/logging_configDict.py
@@ -14,6 +14,7 @@ DELOGGER_CHANNEL_NAME = "engine"
 # (the channel name as recorded in the logs is by default the name of the config file
 # for the channel OR alternately can be set in the config file using the key "channel_name")
 CHANNELLOGGERNAME = "channel"
+SOURCELOGGERNAME = "source"
 
 # name suffixes and log levels of the output files from the main logger
 # the base name is given by the "log_file" config parameter in the config file
@@ -27,9 +28,11 @@ de_outfile_info = (
     ("_structlog_debug.log", logging.DEBUG, "%(message)s"),
 )
 
+# location in de_outfile_info of structlog info
 structlog_file_index = [2]
 
-timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S")
+# timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S")
+timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False)
 
 pre_chain = [
     structlog.stdlib.add_logger_name,


### PR DESCRIPTION
fix source logging by defining logger in Sources after PR670 plus missing adjustments (e.g. adding SOURCELOGGERNAME definition)