### PR TITLE
For flake8 skip build folder

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 [flake8]
   max-line-length = 120
+  # Do not test build folder
+  extend-exclude = ./build
   # Errors and warnings to ignore
   extend-ignore =
      # line too long (90 > 79 characters)


### PR DESCRIPTION
This PR is to exclude "build" folder to be tested by flake8, this folder is created while running the test.
On Jenkins we caught the following report:
```
./build/lib/decisionengine/framework/version.py:5:5: F401 'typing.Tuple' imported but unused
    from typing import Tuple
    ^
1     F401 'typing.Tuple' imported but unused
```

Though this happens while using `setuptools-scm 8.0.3`, with `8.0.4` the generated `version.py` is compliant with flake8.
