### PR TITLE
Create Redis mock for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,9 @@ venv.bak/
 # Decision Engine modules
 /modules/
 
+# VSCode configuration directory
+.vscode/
+
 .DS_Store
 *.swp
 *.swo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ minversion = "6.0"
 # pytest-xdist is not _mandatory_ for the tests to work, but it is recommended
 addopts = "-l -v --durations=30 --durations-min=0.05 --strict-config --strict-markers --showlocals"
 log_level = "debug"
+markers = [
+    "unit: tests that have no external dependencies"
+]
 testpaths = "src/decisionengine"
 required_plugins = ["pytest-timeout>=1.4.2", "pytest-postgresql >= 3.0.0"]
 timeout = 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ minversion = "6.0"
 addopts = "-l -v --durations=30 --durations-min=0.05 --strict-config --strict-markers --showlocals"
 log_level = "debug"
 markers = [
-    "unit: tests that have no external dependencies"
+    "external: tests with external dependencies (e.g. Redis, Condor, etc.)",
+    "redis: tests that require a running Redis server as a dependency"
 ]
 testpaths = "src/decisionengine"
 required_plugins = ["pytest-timeout>=1.4.2", "pytest-postgresql >= 3.0.0"]

--- a/src/decisionengine/framework/engine/tests/conftest.py
+++ b/src/decisionengine/framework/engine/tests/conftest.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import redis
+
+
+def _redis_server_running() -> bool:
+    r = redis.Redis("127.0.0.1", socket_timeout=0.1)
+    try:
+        r.ping()
+        return True
+    except Exception:
+        return False
+
+
+def pytest_runtest_call(item):
+    if item.get_closest_marker("redis") is not None:
+        if not _redis_server_running():
+            pytest.skip("No redis server running at default broker url")

--- a/src/decisionengine/framework/engine/tests/test_verify_redis_server.py
+++ b/src/decisionengine/framework/engine/tests/test_verify_redis_server.py
@@ -2,10 +2,35 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import redis
 
 from decisionengine.framework.engine.DecisionEngine import _verify_redis_server, _verify_redis_url
 
 
+def _redis_server_running() -> bool:
+    r = redis.Redis("127.0.0.1", socket_timeout=0.1)
+    try:
+        r.ping()
+        return True
+    except Exception:
+        return False
+
+
+skip_if_no_redis = pytest.mark.skipif(
+    not _redis_server_running(), reason="No redis server running at default broker url"
+)
+
+
+@pytest.fixture
+def fake_redis_server(monkeypatch):
+    class mockRedis:
+        def ping(self):
+            return True
+
+    monkeypatch.setattr(redis.Redis, "from_url", lambda x: mockRedis())
+
+
+@pytest.mark.unit
 def test_verify_bad_url():
     bad_url = "Garbage"
     expected = (
@@ -16,6 +41,7 @@ def test_verify_bad_url():
         _verify_redis_url(bad_url)
 
 
+@pytest.mark.unit
 def test_verify_bad_broker():
     amqp_backend = "amqp://localhost:6379/0"
     expected = "Unsupported data-broker backend 'amqp'; only 'redis' is currently supported."
@@ -23,15 +49,23 @@ def test_verify_bad_broker():
         _verify_redis_url(amqp_backend)
 
 
+@pytest.mark.unit
 def test_verify_redis_url():
     _verify_redis_url("redis://localhost:6379/0")
     _verify_redis_url("redis://127.0.0.1:6379/0")
 
 
-def test_verify_redis_server():
+@skip_if_no_redis
+def test_verify_redis_server_int():
     _verify_redis_server("redis://localhost:6379/0")
 
 
+@pytest.mark.unit
+def test_verify_redis_server(fake_redis_server):
+    _verify_redis_server("redis://localhost:6379/0")
+
+
+@pytest.mark.unit
 def test_verify_bad_redis_server():
     url = "redis://localhost:1234/5"
     expected = f"A server with broker URL {url} is not responding."

--- a/src/decisionengine/framework/engine/tests/test_verify_redis_server.py
+++ b/src/decisionengine/framework/engine/tests/test_verify_redis_server.py
@@ -30,7 +30,6 @@ def fake_redis_server(monkeypatch):
     monkeypatch.setattr(redis.Redis, "from_url", lambda x: mockRedis())
 
 
-@pytest.mark.unit
 def test_verify_bad_url():
     bad_url = "Garbage"
     expected = (
@@ -41,7 +40,6 @@ def test_verify_bad_url():
         _verify_redis_url(bad_url)
 
 
-@pytest.mark.unit
 def test_verify_bad_broker():
     amqp_backend = "amqp://localhost:6379/0"
     expected = "Unsupported data-broker backend 'amqp'; only 'redis' is currently supported."
@@ -49,7 +47,6 @@ def test_verify_bad_broker():
         _verify_redis_url(amqp_backend)
 
 
-@pytest.mark.unit
 def test_verify_redis_url():
     _verify_redis_url("redis://localhost:6379/0")
     _verify_redis_url("redis://127.0.0.1:6379/0")
@@ -60,12 +57,10 @@ def test_verify_redis_server_int():
     _verify_redis_server("redis://localhost:6379/0")
 
 
-@pytest.mark.unit
 def test_verify_redis_server(fake_redis_server):
     _verify_redis_server("redis://localhost:6379/0")
 
 
-@pytest.mark.unit
 def test_verify_bad_redis_server():
     url = "redis://localhost:1234/5"
     expected = f"A server with broker URL {url} is not responding."

--- a/src/decisionengine/framework/engine/tests/test_verify_redis_server.py
+++ b/src/decisionengine/framework/engine/tests/test_verify_redis_server.py
@@ -7,20 +7,6 @@ import redis
 from decisionengine.framework.engine.DecisionEngine import _verify_redis_server, _verify_redis_url
 
 
-def _redis_server_running() -> bool:
-    r = redis.Redis("127.0.0.1", socket_timeout=0.1)
-    try:
-        r.ping()
-        return True
-    except Exception:
-        return False
-
-
-skip_if_no_redis = pytest.mark.skipif(
-    not _redis_server_running(), reason="No redis server running at default broker url"
-)
-
-
 @pytest.fixture
 def fake_redis_server(monkeypatch):
     class mockRedis:
@@ -52,7 +38,8 @@ def test_verify_redis_url():
     _verify_redis_url("redis://127.0.0.1:6379/0")
 
 
-@skip_if_no_redis
+@pytest.mark.external
+@pytest.mark.redis
 def test_verify_redis_server_int():
     _verify_redis_server("redis://localhost:6379/0")
 


### PR DESCRIPTION
This PR has two changes:

1.  Establishes a new pytest mark, `unit`, to be used for unit tests
2. Changes in `src/decisionengine/framework/engine/tests/test_verify_redis_server.py` as a model for other test files
   a. Mark the appropriate tests as unit tests; 
   b.  Where possible, mock out external dependencies (like the `redis.Redis.ping()` method returning `True` or throwing an exception, so more tests are true unit tests.
   c.  For the one integration test in this file, run it only if a redis server is actually running.  Otherwise skip it.