### PR TITLE
Set /metrics Content-type header to text/plain

### DIFF
--- a/src/decisionengine/framework/engine/DecisionEngine.py
+++ b/src/decisionengine/framework/engine/DecisionEngine.py
@@ -1332,6 +1332,7 @@ class DecisionEngine(socketserver.ThreadingMixIn, xmlrpc.server.SimpleXMLRPCServ
 
     @cherrypy.expose
     def metrics(self):
+        cherrypy.response.headers["Content-Type"] = "text/plain"
         try:
             return display_metrics()
         except Exception as e:  # pragma: no cover


### PR DESCRIPTION
Closes #711 

This PR sets the `Content-Type` header for the DE metrics endpoint at `de_server_host:8000/metrics` to `text/plain`. 

Before:
```
$ wget -S localhost:8000/metrics
...
HTTP request sent, awaiting response...
  HTTP/1.1 200 OK
  Content-Type: text/html;charset=utf-8
  Server: CherryPy/18.9.0
...
```

After:
```
$ wget -S localhost:8000/metrics
...
HTTP request sent, awaiting response...
  HTTP/1.1 200 OK
  Content-Type: text/plain;charset=utf-8
  Server: CherryPy/18.9.0
...
```