### PR TITLE
Added wrapper to run the decisionengine commands also as root. Fixed installation glitches.

### DIFF
--- a/doc/source/redis.rst
+++ b/doc/source/redis.rst
@@ -22,6 +22,17 @@ Persistant storage is not currently required for our usage.
 
 .. note::  You may need to install ``podman`` from your system repositories; it should ship with a lot of `modern Linux distributions <https://podman.io/getting-started/installation>`_.  The ``podman`` package should be compatible with Docker, in most cases either one can be used without issue.  If ``podman`` is not avaliable for your platform, you can review the Docker Desktop terms and conditions to see if you qualify for free usage.
 
+.. note::  You may need to install ``nf-tables`` and remove ``ip-tables`` since Alma9 kernels support the former and not the letter. If you see an error like::
+   Error: netavark: code: 3, msg: modprobe: FATAL: Module ip_tables not found in directory /lib/modules/5.14.0-503.21.1.el9_5.x86_64
+   iptables v1.8.10 (legacy): can't initialize iptables table `nat': Table does not exist (do you need to insmod?)
+   Perhaps iptables or your kernel needs to be upgraded.
+
+ Then Run the commands::
+
+   dnf rm iptables-legacy
+   dnf install iptables-nft
+
+
 Configuring the DE server
 #########################
 

--- a/package/rpm/decisionengine-install-python.sh
+++ b/package/rpm/decisionengine-install-python.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+DE_GIT_DEFAULT="https://github.com/HEPCloud/decisionengine.git"
+DEM_GIT_DEFAULT="https://github.com/HEPCloud/decisionengine_modules.git"
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+robust_realpath() {
+    if ! realpath "$1" 2>/dev/null; then
+        echo "$(cd "$(dirname "$1")"; pwd -P)/$(basename "$1")"
+    fi
+}
+
+REQUIRED_RPM=decisionengine-modules-deps
+
+# https://packaging.python.org/en/latest/specifications/version-specifiers/
+help_msg() {
+    cat << EOF
+$0 [options] VERSION [RELEASE]
+Install the Decision Engine (Framework and Modules) Python release via pip. Requires the RPM installation.
+--help                 Print this
+--de-repo-git URI      Decision Engine framework Git repository URI (default: $DE_GIT_DEFAULT)
+--dem-repo-git URI     Decision Engine modules Git repository URI (default: $DEM_GIT_DEFAULT). Keywords:
+                       same - relative to the framework repository
+                       default - $DEM_GIT_DEFAULT
+--de-git-ref REF       Decision Engine framework Git repository reference (default: "" - master)
+--dem-git-ref REF      Decision Engine modules Git repository reference (default: same as DE). Keywords:
+                       auto - Get the reference form the RPM installation version and release
+                              Release is considered only for RCs (e.g. 2.0.4-N -> 2.0.4, 2.1.0-0.4.rc4 -> 2.1.0.rc4)
+--de-repo-dir PATH     Decision Engine framework Git repository directory
+--dem-repo-dir PATH    Decision Engine modules Git repository directory (default: relative to DE directory)
+
+--user USER            User to install and run Decision Engine
+--remote               Pip Installation from the DE and DEM Git (GitHub) URIs
+--local                Pip Installation from the local DE and DEM directory
+Not yet implemented
+--python PYTHON        Python interpreter or venv to use for Decision Engine
+--clone                Make a local clone of the repository
+--dev                  Pip development Installation from the local DE and DEM directory
+EOF
+}
+
+parse_opts() {
+    # Parse options. Uses SCRIPT_DIR
+    # Sets VERBOSE, DO_CLONE, DE_GIT, REL_TAG, DE_DIR, DEM_GIT, DEM_DIR
+    VERBOSE=false
+    DE_USER=decisionengine
+    DE_PYTHON=python3
+    DE_GIT="$DE_GIT_DEFAULT"
+    DE_GIT_REF=
+    DE_DIR=
+    DEM_GIT=
+    DEM_GIT_DEFAULT="https://github.com/HEPCloud/decisionengine_modules.git"
+    DEM_GIT_REF=
+    DEM_DIR=
+    DO_CLONE=false
+    INSTALL_TYPE="remote"
+    while [ -n "$1" ];do
+        case "$1" in
+            --de-repo-git)
+                DE_GIT="$2"
+                shift
+                ;;
+            --de-git-ref)
+                DE_GIT_REF="$2"
+                shift
+                ;;
+            --de-repo-dir)
+                DE_DIR="$2"
+                shift
+                ;;
+            --dem-repo-git)
+                if [[ "$2" = default ]];then
+                    DEM_GIT="$DEM_GIT_DEFAULT"
+                else
+                    DEM_GIT="$2"
+                fi
+                shift
+                ;;
+            --dem-git-ref)
+                DEM_GIT_REF="$2"
+                shift
+                ;;
+            --dem-repo-dir)
+                DEM_DIR="$2"
+                shift
+                ;;
+            --user)
+                DE_USER="$2"
+                shift
+                ;;
+            --python)
+                DE_PYTHON="$2"
+                shift
+                ;;
+            --clone)
+                DO_CLONE=true
+                ;;
+            --remote)
+                INSTALL_TYPE="remote"
+                ;;
+            --local)
+                INSTALL_TYPE="local"
+                ;;
+            --dev)
+                INSTALL_TYPE="devel"
+                ;;
+            --help)
+                help
+                exit 0
+                ;;
+            *)
+                echo "Error. Parameter '$1' is not supported."
+                help
+                exit 1
+        esac
+        shift
+    done
+    # Git URL and reference normalization
+    if [[ -z  "$DEM_GIT" || "$DEM_GIT" = same ]]; then
+        DEM_GIT="${DE_GIT%.git}_modules.git"
+    fi
+    [[ -n "$DE_GIT_REF" ]] && DE_GIT_REF="@$DE_GIT_REF" || true
+    [[ -n "$DEM_GIT_REF" ]] && DEM_GIT_REF="@$DEM_GIT_REF" || DEM_GIT_REF="$DE_GIT_REF"
+    # Checks for local directories
+    if [[ "$INSTALL_TYPE" = local || "$INSTALL_TYPE" = devel ]] && ! $DO_CLONE; then
+        # Must have local repositories
+        [[ -n "$DE_DIR" && -d "$DE_DIR" ]] || { echo "Error. Local install without cloning and no valid DE repository ($DE_DIR). Aborting"; exit 1; }
+        [[ -n "$DEM_DIR" ]] || DEM_DIR="$DE_DIR"/../decisionengine_modules
+        [[ -d "$DEM_DIR" ]] || { echo "Error. Local install without cloning and no valid DEM repository ($DEM_DIR). Aborting"; exit 1; }
+    fi
+    # Relative DEM directory if not set and relative path to DE is there
+    if [[ -n "$DE_DIR" && -z "$DEM_DIR" ]]; then
+        [[ -d "$DE_DIR" && -d "$DE_DIR/../decisionengine_modules" ]] && DEM_DIR="$DE_DIR"/../decisionengine_modules || true
+    fi
+}
+
+get_version() {
+    local retv
+    if ! retv=$(rpm -q "$REQUIRED_RPM"); then
+        echo "Required RPMs ($REQUIRED_RPM) are not installed. Aborting"
+	exit 1
+    fi
+    retv=${retv#${REQUIRED_RPM}-}
+    $VERBOSE && echo "Decision Engine version $retv" || true
+    echo ${retv%.*.noarch}
+}
+
+do_install_su() {
+    local cmd
+    cmd="$(declare -f do_install_pre)
+do_install_pre"
+    # Update pip
+    su -s /bin/bash -c "$cmd" -l "$DE_USER"
+    # Install DE+DEM
+    cmd="$(declare -f do_install)
+DE_FROM='$DE_FROM'
+DE_GIT_REF='$DE_GIT_REF'
+DEM_FROM='$DEM_FROM'
+DEM_GIT_REF='$DEM_GIT_REF'
+do_install"
+    su -s /bin/bash -c "$cmd" -l "$DE_USER"
+}
+
+do_install_pre() {
+    # Update pip
+    pip install --upgrade pip
+    pip install --upgrade setuptools wheel setuptools-scm[toml]
+}
+
+do_install() {
+    retv=0
+    # Install the Python modules via pip
+    pip install "git+$DE_FROM$DE_GIT_REF" || retv=1
+    pip install "git+$DEM_FROM$DEM_GIT_REF" || retv=1
+    # Double check that pip added $HOME/.local/bin to the PATH of user decisionengine
+    return $retv
+}
+
+make_dir() {
+    local src_tmpdir=
+    if [[ -z "$DE_DIR" || -z "$DEM_DIR" ]]; then
+        # mktemp for both Linux and Darwin
+        src_tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'detmpdir')
+        [[ -n "$DE_DIR" ]] || DE_DIR="$src_tmpdir"/decisionengine
+        [[ -n "$DEM_DIR" ]] || DEM_DIR="$src_tmpdir"/decisionengine_modules
+    fi
+}
+
+_main() {
+    local de_rpm_version_release de_git_version
+    de_rpm_version_release=$(get_version)
+    # Parse options and adjust parameters
+    parse_opts "$@"
+
+    if [[ "$de_rpm_version_release" = *rc* ]]; then
+        # Extract the RPM release if RC (Python schema is X.Y.ZrcN, no dot)
+        de_git_version="rc${de_rpm_version_release#*rc}"
+    fi
+    # Add the RPM version
+    de_git_version="${de_rpm_version_release%-*}$de_git_version"
+    [[ "$DE_GIT_REF" = "@auto" ]] && DE_GIT_REF="@$de_git_version" || true
+    [[ "$DEM_GIT_REF" = "@auto" ]] && DEM_GIT_REF="@$de_git_version" || true
+
+    DE_DIR=$(robust_realpath "$DE_DIR")
+    DEM_DIR=$(robust_realpath "$DEM_DIR")
+
+    if [[ "$INSTALL_TYPE" = local ]]; then
+        # This requires absolute paths
+        DE_FROM="file://$DE_DIR"
+        DEM_FROM="file://$DEM_DIR"
+        $VERBOSE && echo "Preparing for local install from $DE_FROM, $DEM_FROM" || true
+    elif [[ "$INSTALL_TYPE" = remote ]]; then
+        DE_FROM="$DE_GIT"
+        DEM_FROM="$DEM_GIT"
+        $VERBOSE && echo "Preparing for remote install from $DE_FROM$DE_GIT_REF, $DEM_FROM$DEM_GIT_REF" || true
+    else
+        echo "Error: $INSTALL_TYPE not supported. Aborting"
+        exit 1
+    fi
+
+    if [[ "$DE_USER" = $(whoami) ]]; then
+        do_install_pre
+        do_install
+    else
+        $VERBOSE && echo "Installing as user $DE_USER" || true
+        do_install_su
+    fi
+    if [[ $? -ne 0 ]]; then
+        echo "Error during the installation"
+        exit 1
+    else
+        $VERBOSE && echo "Installation successful" || true
+    fi
+}
+
+# https://stackoverflow.com/questions/29966449/what-is-the-bash-equivalent-to-pythons-if-name-main
+# Alt: [[ "$(caller)" != "0 "* ]] || _main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    _main "$@"
+fi

--- a/package/rpm/decisionengine-wrapper.sh
+++ b/package/rpm/decisionengine-wrapper.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Wrapper to run the decision engine commands without being the decisionengine user
+#   su -s /bin/bash -c '' - decisionengine
+#   export PATH="~/.local/bin:$PATH"
+#   decisionengine --no-webserver
+
+DE_USER=decisionengine
+DE_CMD=$(basename "$0")
+
+if [ "$UID" -eq 0 ]; then
+    # su -s /bin/bash -l $DE_USER -c "export PATH=\"\$HOME/.local/bin:\$PATH\"; echo \$PATH; command -v \"$DE_CMD\"; \"$DE_CMD\" $(for i in "$@"; do echo -n "\"$i\" "; done;); echo \"Test END\""
+    su -s /bin/bash -l -c "export PATH=\"\$HOME/.local/bin:\$PATH\"; \"$DE_CMD\" $(for i in "$@"; do echo -n "\"$i\" "; done;)" $DE_USER
+elif [ "$(whoami)" = "$DE_USER" ]; then
+    export PATH="$HOME/.local/bin:$PATH"
+    "$DE_CMD" "$@"
+else
+    echo "decisionengine commands can be invoked only as $DE_USER or root user"
+    exit 1
+fi

--- a/package/systemd/decisionengine.service
+++ b/package/systemd/decisionengine.service
@@ -1,5 +1,9 @@
+# SPDX-FileCopyrightText: 2017 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
 [Unit]
-Description = Decision EngineService
+Description = HEPCloud Decision Engine Service
+Documentation = "https://hepcloud.github.io/decisionengine/"
 Wants = network-online.target
 After = network.target
 
@@ -12,6 +16,7 @@ PrivateTmp = true
 ExecStart = /usr/bin/decisionengine "$DE_OPTS"
 ExecStop = /usr/bin/echo "Running /usr/bin/de-client --stop" >&2
 ExecStop = /usr/bin/de-client --stop
+# ExecReload=/usr/sbin/decsionengine reload  $MAINPID
 
 [Install]
 WantedBy = multi-user.target


### PR DESCRIPTION
Added `decisionengine-wrapper.sh`, a wrapper to run the decisionengine commands also as root.
Added a script to install the DE and DEM python files via pip. To ease the install process.
Fixed installation and build glitches installation glitches:
- missing requirements
- missing onenode RPM
- RPMs not copied automatically to the YUM repository