### PR TITLE
Update Dockerfile and entrypoint to be able to build RPMs and wheels on Jenkins

### DIFF
--- a/.Jenkins/workflows/Jenkinsfile_EL9
+++ b/.Jenkins/workflows/Jenkinsfile_EL9
@@ -218,17 +218,12 @@ pipeline {
                             cd decisionengine_modules
                             echo "checkout ${BRANCH} branch"
                             git checkout ${BRANCH}
-                            echo GITHUB_PR_NUMBER: ${GITHUB_PR_NUMBER} - GITHUB_PR_STATE: ${GITHUB_PR_STATE}
-                            if [[ -n ${GITHUB_PR_NUMBER} && ${GITHUB_PR_STATE} == OPEN ]]; then
-                                git fetch origin pull/${GITHUB_PR_NUMBER}/merge:merge${GITHUB_PR_NUMBER}
-                                git checkout merge${GITHUB_PR_NUMBER}
-                            fi
                             cd ..
                         '''
                         echo "prepare podman image ${DEbuildStageDockerImage}"
                         sh "podman build --pull --tag ${DEbuildStageDockerImage} --build-arg BASEIMAGE=docker.io/hepcloud/decision-engine-ci-el9:${BRANCH} --build-arg UID=\$(id -u) --build-arg GID=\$(id -g) -f decisionengine/package/ci/EL9/Dockerfile decisionengine/package/ci/EL9/"
                         echo "Run ${STAGE_NAME} tests"
-                        sh "podman run --privileged --userns keep-id:uid=\$(id -u),gid=\$(id -g) --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE} --entrypoint /bin/bash ${DEbuildStageDockerImage} \"decisionengine/package/release/make-release.sh\" \"-v\" \"-e\" \"${BRANCH}\""
+                        sh "podman run --privileged --userns keep-id:uid=\$(id -u),gid=\$(id -g) --rm --env PYTEST_TIMEOUT=${PYTEST_TIMEOUT} -v ${WORKSPACE}:${WORKSPACE} -w ${WORKSPACE}/decisionengine ${DEbuildStageDockerImage} \"make-release\" \"make-release.log\""
                     }
                     post {
                         always {

--- a/package/container/EL9/framework/Dockerfile
+++ b/package/container/EL9/framework/Dockerfile
@@ -47,20 +47,20 @@ RUN dnf -y install --enablerepo crb \
 RUN dnf install -y redis \
  && dnf -y clean all
 
-# Ensure pip/setuptools are up to date
-#  rpm-build requires libraries in /usr
-RUN python3 -m pip install --upgrade --prefix=/usr pip ; \
-    python3 -m pip install --upgrade --prefix=/usr setuptools wheel setuptools-scm[toml] build
+# Prepare a venv and ensure we have up to date pip/setuptools/build modules
+RUN su - adm -s /bin/bash -c "python3 -m venv /var/tmp/de_venv ; \
+    source /var/tmp/de_venv/bin/activate ; \
+    python3 -m pip install --upgrade pip ; \
+    python3 -m pip install --upgrade setuptools wheel setuptools-scm[toml] build"
 
-# Install decisionengine requirements (runtime and testing)
-#  do as one layer to simplify merges
-#  rpm-build requires libraries in /usr
-RUN su - adm -s /bin/bash -c "git clone https://github.com/HEPCloud/decisionengine.git /tmp/decisionengine.git"; \
+# Install decisionengine requirements (runtime and testing) in the venv
+RUN su - adm -s /bin/bash -c "source /var/tmp/de_venv/bin/activate ; \
+    git clone https://github.com/HEPCloud/decisionengine.git /tmp/decisionengine.git ; \
     cd /tmp/decisionengine.git ; \
-    su adm -s /bin/bash -c "cd /tmp/decisionengine.git ; python3 setup.py bdist_wheel" ; \
-    python3 -m pip install --prefix=/usr dist/*.whl ; \
-    python3 -m pip install --prefix=/usr decisionengine[develop] ; \
+    python3 setup.py bdist_wheel ; \
+    python3 -m pip install dist/*.whl ; \
+    python3 -m pip install decisionengine[develop] ; \
     python3 -m pip uninstall -y decisionengine ; \
-    rm -rf /tmp/decisionengine.git
+    rm -rf /tmp/decisionengine.git"
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
In this PR we use python venv to install DE requirements in the framework container.
Then in the entrypoint script used by the CI container we use virtualenvwrapper to chain the DE venv from the framework container with the venv from entrypoint script to be able to install/update DE python dependencies.
The entrypoint script has been updated to allow it to run make-release script to build RPMs and wheels on Jenkins.